### PR TITLE
test: behavior-oriented tests for contracts, remediation, and frontend integrity

### DIFF
--- a/backend/dispatch_contract.py
+++ b/backend/dispatch_contract.py
@@ -358,8 +358,9 @@ def validate_envelope(envelope: CommandEnvelope) -> DispatchValidationResult:
             confirmation_required=True,
         )
 
-    assert confirmation is not None  # narrowed by guard above
-    if action.access is DispatchAccess.PRIVILEGED and not confirmation.approved_by.strip():
+    # The guard above returns early only for PRIVILEGED+None; READ_ONLY actions
+    # may reach this point with confirmation=None, so gate checks on access level.
+    if action.access is DispatchAccess.PRIVILEGED and (confirmation is None or not confirmation.approved_by.strip()):
         return DispatchValidationResult(
             accepted=False,
             reason="confirmation must record approved_by",
@@ -367,7 +368,7 @@ def validate_envelope(envelope: CommandEnvelope) -> DispatchValidationResult:
             confirmation_required=True,
         )
 
-    if action.access is DispatchAccess.PRIVILEGED and not confirmation.approved_at.strip():
+    if action.access is DispatchAccess.PRIVILEGED and (confirmation is None or not confirmation.approved_at.strip()):
         return DispatchValidationResult(
             accepted=False,
             reason="confirmation must record approved_at",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ uvicorn[standard]>=0.27.0
 psutil>=5.9.0
 httpx>=0.27.0
 PyYAML>=6.0.1
+pytest>=8.0
+pytest-asyncio>=0.23


### PR DESCRIPTION
## Summary

- Add `tests/` with pytest suite covering dispatch contracts, remote execution contract, agent remediation, and frontend static integrity
- Fix a bug in `dispatch_contract.validate_envelope` where a bare `assert confirmation is not None` fired for READ_ONLY actions (which legitimately have no confirmation); replaced with access-level-gated guards
- Add `pytest>=8.0` and `pytest-asyncio>=0.23` to `requirements.txt`
- Add Section 8 "Testing" to `SPEC.md` documenting the test suite and how to run it

### Tests written

| File | What it covers |
|---|---|
| `tests/test_dispatch_contract.py` | `DispatchConfirmation.from_dict`, `CommandEnvelope` round-trip, `validate_envelope` for READ_ONLY/PRIVILEGED/empty-approval/unknown-action cases |
| `tests/test_remote_execution_contract.py` | `_host_is_private` for localhost/private/public IPs, `_url_is_private`, unknown-target rejection |
| `tests/test_agent_remediation.py` | `FailureContext.from_dict`, `classify_workflow_type` for "CI Standard" → test and "ruff lint check" → lint, policy defaults |
| `tests/test_frontend_integrity.py` | 18 required tab/component function markers, `HeavyTestsTab` absence, icon helper symbols; `RunnerPlanTab` and DOMPurify proximity marked `xfail` with clear reasons |

All 43 tests pass; 2 are `xfail` (expected failures tracking future work).

## Test plan

- [x] `pytest tests/ -q` passes locally (43 passed, 2 xfailed)
- [x] `ruff check tests/` — clean
- [x] `ruff format tests/ --check` — all files already formatted
- [x] Dispatch contract bugfix verified: READ_ONLY envelopes without confirmation are now correctly accepted

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)