### PR TITLE
feat: modular deploy scripts with lib.sh, rollback support, and dry-run mode

### DIFF
--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# deploy/lib.sh -- Shared shell library for runner-dashboard deploy scripts.
+# Source with: source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# Do NOT execute directly.
+
+# Terminal colours
+GREEN='\033[0;32m'; CYAN='\033[0;36m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}[ OK ]${NC} $*"; }
+info() { echo -e "${CYAN}[INFO]${NC} $*"; }
+fail() { echo -e "${RED}[FAIL]${NC} $*" >&2; exit 1; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+
+# Guard helpers
+require_dir()  { [[ -d "$1" ]] || fail "Required directory not found: $1"; }
+require_file() { [[ -f "$1" ]] || fail "Required file not found: $1"; }
+require_cmd()  { command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"; }
+
+# pip install with --break-system-packages when supported
+pip_install() {
+    local -a pkgs=("$@")
+    local -a cmd=(pip3 install --quiet "${pkgs[@]}")
+    if pip3 install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
+        cmd=(pip3 install --break-system-packages --quiet "${pkgs[@]}")
+    fi
+    "${cmd[@]}"
+}
+
+# Sync directory (rsync preferred, rm/cp fallback)
+sync_dir() {
+    local src="$1" dest="$2"
+    if command -v rsync >/dev/null 2>&1; then
+        rsync -a --delete "$src/" "$dest/"
+        return
+    fi
+    warn "rsync not found; using rm/cp fallback for ${dest}"
+    rm -rf "$dest"; mkdir -p "$dest"; cp -a "$src/." "$dest/"
+}
+
+# Backup helper: creates a timestamped copy, prints backup path to stdout.
+backup_dir() {
+    local src="$1"
+    local ts; ts=$(date +%Y%m%d_%H%M%S)
+    local backup="${src}.bak.${ts}"
+    if [[ -d "$src" ]]; then
+        cp -a "$src" "$backup"
+        echo "$backup"
+    fi
+}
+
+# Dry-run support. Set DRY_RUN=true to enable.
+# Usage: dry_run "description" || { actual_command; }
+DRY_RUN="${DRY_RUN:-false}"
+dry_run() {
+    [[ "$DRY_RUN" == "true" ]] || return 1
+    warn "[DRY-RUN] Skipping: $*"
+    return 0
+}

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# deploy/rollback.sh -- Roll back the dashboard to a previous backup snapshot.
+#
+# Usage:
+#   bash rollback.sh --list                   # List available backups
+#   bash rollback.sh                          # Roll back to most recent backup
+#   bash rollback.sh --to /path/to/backup     # Roll back to specific backup
+#   bash rollback.sh --dry-run                # Preview rollback without executing
+#
+set -euo pipefail
+# shellcheck source=deploy/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DEPLOY_DIR="${DEPLOY_DIR:-$HOME/actions-runners/dashboard}"
+SERVICE="runner-dashboard"
+LIST_ONLY=false
+BACKUP_PATH=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --list)       LIST_ONLY=true; shift ;;
+        --to)         BACKUP_PATH="$2"; shift 2 ;;
+        --deploy-dir) DEPLOY_DIR="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        *) warn "Unknown option: $1"; shift ;;
+    esac
+done
+
+require_dir "$DEPLOY_DIR"
+
+if [[ "$LIST_ONLY" == "true" ]]; then
+    info "Available backups:"
+    ls -d "${DEPLOY_DIR}.bak."* 2>/dev/null | sort -r | head -20 \
+        || warn "No backups found for $DEPLOY_DIR"
+    exit 0
+fi
+
+if [[ -z "$BACKUP_PATH" ]]; then
+    BACKUP_PATH=$(ls -d "${DEPLOY_DIR}.bak."* 2>/dev/null | sort -r | head -1 || true)
+    [[ -n "$BACKUP_PATH" ]] || fail "No backup found. Run update-deployed.sh first."
+    info "Auto-selected: $BACKUP_PATH"
+fi
+
+require_dir "$BACKUP_PATH"
+
+info "Rolling back $DEPLOY_DIR to $BACKUP_PATH ..."
+if ! dry_run "sync_dir $BACKUP_PATH $DEPLOY_DIR"; then
+    sync_dir "$BACKUP_PATH" "$DEPLOY_DIR"
+    ok "Files restored"
+fi
+
+info "Restarting $SERVICE ..."
+if ! dry_run "sudo systemctl restart $SERVICE"; then
+    sudo systemctl restart "$SERVICE"
+    sleep 2
+    if sudo systemctl is-active --quiet "$SERVICE"; then
+        ok "Service is running after rollback"
+    else
+        fail "Service failed to start after rollback"
+    fi
+fi
+ok "Rollback complete."

--- a/deploy/update-deployed.sh
+++ b/deploy/update-deployed.sh
@@ -12,23 +12,17 @@
 #
 # Or add a shell alias for convenience:
 #   alias update-dashboard='bash /mnt/c/Users/diete/Repositories/Repository_Management/runner-dashboard/deploy/update-deployed.sh'
+#
+# Options:
+#   --repo <path>        Override the REPO path
+#   --deploy-dir <path>  Override the deploy directory
+#   --artifact <file>    Deploy from a pre-built artifact tarball
+#   --dry-run            Preview without executing destructive steps
 # ==============================================================================
 
 set -euo pipefail
-
-GREEN='\033[0;32m'; CYAN='\033[0;36m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
-ok()   { echo -e "${GREEN}[ OK ]${NC} $*"; }
-info() { echo -e "${CYAN}[INFO]${NC} $*"; }
-fail() { echo -e "${RED}[FAIL]${NC} $*"; exit 1; }
-warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-
-pip_install_backend_deps() {
-    local -a cmd=(pip3 install --quiet fastapi uvicorn psutil httpx PyYAML)
-    if pip3 install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
-        cmd=(pip3 install --break-system-packages --quiet fastapi uvicorn psutil httpx PyYAML)
-    fi
-    "${cmd[@]}"
-}
+# shellcheck source=deploy/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 REPO="${REPO:-/mnt/c/Users/diete/Repositories/Repository_Management}"
 DEPLOY_DIR="${DEPLOY_DIR:-$HOME/actions-runners/dashboard}"
@@ -40,6 +34,7 @@ while [[ $# -gt 0 ]]; do
         --repo) REPO="$2"; shift 2 ;;
         --deploy-dir) DEPLOY_DIR="$2"; shift 2 ;;
         --artifact) ARTIFACT_SOURCE="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=true; shift ;;
         *) shift ;;
     esac
 done
@@ -49,131 +44,140 @@ if [[ -z "$ARTIFACT_SOURCE" ]]; then
     [[ -d "$REPO/runner-dashboard" ]] || fail "Repo not found at $REPO — check the path."
 fi
 
-sync_dir() {
-    local src="$1"
-    local dest="$2"
-    if command -v rsync >/dev/null 2>&1; then
-        rsync -a --delete "$src/" "$dest/"
-        return
-    fi
-    warn "rsync not found; using rm/cp fallback for ${dest}"
-    rm -rf "$dest"
-    mkdir -p "$dest"
-    cp -a "$src/." "$dest/"
-}
-
 info "Installing/updating backend dependencies..."
-pip_install_backend_deps
+pip_install fastapi uvicorn psutil httpx PyYAML
 ok "backend dependencies installed"
+
+if ! dry_run "backup $DEPLOY_DIR"; then
+    info "Creating backup snapshot..."
+    _BACKUP=$(backup_dir "$DEPLOY_DIR")
+    [[ -n "$_BACKUP" ]] && ok "Backup: $_BACKUP"
+fi
 
 if [[ -n "$ARTIFACT_SOURCE" ]]; then
     info "Installing dashboard artifact..."
-    "$(dirname "$0")/install-dashboard-artifact.sh" \
-        --artifact "$ARTIFACT_SOURCE" \
-        --deploy-dir "$DEPLOY_DIR"
+    if ! dry_run "install-dashboard-artifact.sh --artifact $ARTIFACT_SOURCE --deploy-dir $DEPLOY_DIR"; then
+        "$(dirname "$0")/install-dashboard-artifact.sh" \
+            --artifact "$ARTIFACT_SOURCE" \
+            --deploy-dir "$DEPLOY_DIR"
+    fi
 else
     info "Copying backend..."
-    sync_dir "$REPO/runner-dashboard/backend" "$DEPLOY_DIR/backend"
-    ok  "backend deployed"
+    if ! dry_run "sync_dir $REPO/runner-dashboard/backend $DEPLOY_DIR/backend"; then
+        sync_dir "$REPO/runner-dashboard/backend" "$DEPLOY_DIR/backend"
+        ok  "backend deployed"
+    fi
 
     info "Copying deploy scripts..."
-    cp "$REPO/runner-dashboard/deploy/refresh-token.sh"   "$DEPLOY_DIR/refresh-token.sh"
-    chmod +x "$DEPLOY_DIR/refresh-token.sh"
-    ok  "refresh-token.sh deployed"
+    if ! dry_run "cp refresh-token.sh -> $DEPLOY_DIR/refresh-token.sh"; then
+        cp "$REPO/runner-dashboard/deploy/refresh-token.sh"   "$DEPLOY_DIR/refresh-token.sh"
+        chmod +x "$DEPLOY_DIR/refresh-token.sh"
+        ok  "refresh-token.sh deployed"
+    fi
 
     info "Copying frontend..."
-    sync_dir "$REPO/runner-dashboard/frontend" "$DEPLOY_DIR/frontend"
-    ok  "frontend deployed"
+    if ! dry_run "sync_dir $REPO/runner-dashboard/frontend $DEPLOY_DIR/frontend"; then
+        sync_dir "$REPO/runner-dashboard/frontend" "$DEPLOY_DIR/frontend"
+        ok  "frontend deployed"
+    fi
 
     info "Copying local app manifest..."
-    cp "$REPO/runner-dashboard/local_apps.json"           "$DEPLOY_DIR/local_apps.json"
-    ok  "local_apps.json deployed"
+    if ! dry_run "cp local_apps.json -> $DEPLOY_DIR/local_apps.json"; then
+        cp "$REPO/runner-dashboard/local_apps.json"           "$DEPLOY_DIR/local_apps.json"
+        ok  "local_apps.json deployed"
+    fi
 
     info "Writing deployment metadata..."
-    "$(dirname "$0")/write-deployment-metadata.sh" "$DEPLOY_DIR" "$REPO"
-    ok "deployment metadata written from source checkout"
+    if ! dry_run "write-deployment-metadata.sh $DEPLOY_DIR $REPO"; then
+        "$(dirname "$0")/write-deployment-metadata.sh" "$DEPLOY_DIR" "$REPO"
+        ok "deployment metadata written from source checkout"
+    fi
 fi
 
 info "Restarting $SERVICE..."
-sudo systemctl restart "$SERVICE"
-
-# Brief wait then check status
-sleep 2
-if sudo systemctl is-active --quiet "$SERVICE"; then
-    ok "Service is running"
-    echo ""
-    echo "  Dashboard: http://localhost:8321"
-    echo "  Health:    http://localhost:8321/api/health"
-    echo "  Runs:      http://localhost:8321/api/runs"
-    echo "  Queue:     http://localhost:8321/api/queue"
-else
-    echo ""
-    sudo systemctl status "$SERVICE" --no-pager
-    fail "Service failed to start — check logs above"
+if ! dry_run "sudo systemctl restart $SERVICE"; then
+    sudo systemctl restart "$SERVICE"
 fi
 
-# Check GitHub API connectivity first (most common failure point)
-info "Checking GitHub API connectivity..."
-HEALTH_JSON=$(curl -s --max-time 8 http://localhost:8321/api/health 2>/dev/null || echo "{}")
-GH_STATUS=$(echo "$HEALTH_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('github_api','unknown'))" 2>/dev/null || echo "unknown")
-RUNNERS=$(echo "$HEALTH_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('runners_registered',0))" 2>/dev/null || echo "0")
-
-if [[ "$GH_STATUS" == "connected" ]]; then
-    ok "GitHub API: connected | runners registered: $RUNNERS"
-else
-    # Distinguish rate-limit exhaustion from a missing/bad token
-    SECRETS_FILE="${HOME}/.config/runner-dashboard/env"
-    STORED_TOKEN=$(grep '^GH_TOKEN=' "${SECRETS_FILE}" 2>/dev/null | cut -d= -f2-)
-    RL_REMAINING="unknown"
-    if [[ -n "$STORED_TOKEN" ]]; then
-        RL_REMAINING=$(curl -s --max-time 5 \
-            -H "Authorization: token ${STORED_TOKEN}" \
-            https://api.github.com/rate_limit \
-            | python3 -c "import sys,json,datetime; d=json.load(sys.stdin)['rate']; \
-              reset=datetime.datetime.fromtimestamp(d['reset']); \
-              print(f\"{d['remaining']}/{d['limit']} resets {reset.strftime('%H:%M:%S')}\")" \
-            2>/dev/null || echo "unknown")
-    fi
-
-    if [[ "$RL_REMAINING" == "0/"* ]]; then
-        RESET_TIME=$(echo "$RL_REMAINING" | grep -o 'resets [0-9:]*' || echo "")
-        echo -e "${YELLOW}[WARN]${NC} GitHub API rate limit exhausted (${RL_REMAINING})"
+# Brief wait then check status — skipped in dry-run mode
+if [[ "$DRY_RUN" != "true" ]]; then
+    sleep 2
+    if sudo systemctl is-active --quiet "$SERVICE"; then
+        ok "Service is running"
         echo ""
-        echo "  The token is valid but the 5000 req/hr limit is used up."
-        echo "  Dashboard will reconnect automatically when the window resets."
-        echo "  ${RESET_TIME} — check with:"
-        echo "    curl -s http://localhost:8321/api/health | python3 -m json.tool"
-        echo ""
+        echo "  Dashboard: http://localhost:8321"
+        echo "  Health:    http://localhost:8321/api/health"
+        echo "  Runs:      http://localhost:8321/api/runs"
+        echo "  Queue:     http://localhost:8321/api/queue"
     else
-        echo -e "${RED}[WARN]${NC} GitHub API is NOT connected (status: $GH_STATUS)"
         echo ""
-        if [[ -z "$STORED_TOKEN" ]]; then
-            echo "  No GH_TOKEN found in ${SECRETS_FILE}."
-        else
-            echo "  GH_TOKEN present but API returned an error (rate limit remaining: ${RL_REMAINING})."
-        fi
-        echo "  Run these commands in WSL2 (as ${USER}, not root) to fix:"
-        echo ""
-        echo "    TOKEN=\$(gh auth token 2>/dev/null)"
-        echo "    sed -i '/^GH_TOKEN=/d' ~/.config/runner-dashboard/env"
-        echo "    printf 'GH_TOKEN=%s\\n' \"\$TOKEN\" >> ~/.config/runner-dashboard/env"
-        echo "    sudo systemctl restart runner-dashboard"
-        echo ""
-        echo "  If gh auth token returns empty, re-authenticate:"
-        echo "    gh auth login"
-        echo "    gh auth refresh -s admin:org"
-        echo ""
+        sudo systemctl status "$SERVICE" --no-pager
+        fail "Service failed to start — check logs above"
     fi
-fi
 
-# Smoke-test the runs endpoint
-info "Smoke-testing /api/runs..."
-RUNS=$(curl -s --max-time 10 http://localhost:8321/api/runs 2>/dev/null \
-       | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('workflow_runs',[])))" 2>/dev/null || echo "0")
-if [[ "$GH_STATUS" == "connected" ]]; then
-    ok "Endpoint returned $RUNS workflow runs"
-else
-    echo -e "${CYAN}[INFO]${NC} Runs endpoint returned $RUNS (expected 0 — API not connected yet)"
+    # Check GitHub API connectivity first (most common failure point)
+    info "Checking GitHub API connectivity..."
+    HEALTH_JSON=$(curl -s --max-time 8 http://localhost:8321/api/health 2>/dev/null || echo "{}")
+    GH_STATUS=$(echo "$HEALTH_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('github_api','unknown'))" 2>/dev/null || echo "unknown")
+    RUNNERS=$(echo "$HEALTH_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('runners_registered',0))" 2>/dev/null || echo "0")
+
+    if [[ "$GH_STATUS" == "connected" ]]; then
+        ok "GitHub API: connected | runners registered: $RUNNERS"
+    else
+        # Distinguish rate-limit exhaustion from a missing/bad token
+        SECRETS_FILE="${HOME}/.config/runner-dashboard/env"
+        STORED_TOKEN=$(grep '^GH_TOKEN=' "${SECRETS_FILE}" 2>/dev/null | cut -d= -f2-)
+        RL_REMAINING="unknown"
+        if [[ -n "$STORED_TOKEN" ]]; then
+            RL_REMAINING=$(curl -s --max-time 5 \
+                -H "Authorization: token ${STORED_TOKEN}" \
+                https://api.github.com/rate_limit \
+                | python3 -c "import sys,json,datetime; d=json.load(sys.stdin)['rate']; \
+                  reset=datetime.datetime.fromtimestamp(d['reset']); \
+                  print(f\"{d['remaining']}/{d['limit']} resets {reset.strftime('%H:%M:%S')}\")" \
+                2>/dev/null || echo "unknown")
+        fi
+
+        if [[ "$RL_REMAINING" == "0/"* ]]; then
+            RESET_TIME=$(echo "$RL_REMAINING" | grep -o 'resets [0-9:]*' || echo "")
+            warn "GitHub API rate limit exhausted (${RL_REMAINING})"
+            echo ""
+            echo "  The token is valid but the 5000 req/hr limit is used up."
+            echo "  Dashboard will reconnect automatically when the window resets."
+            echo "  ${RESET_TIME} -- check with:"
+            echo "    curl -s http://localhost:8321/api/health | python3 -m json.tool"
+            echo ""
+        else
+            warn "GitHub API is NOT connected (status: $GH_STATUS)"
+            echo ""
+            if [[ -z "$STORED_TOKEN" ]]; then
+                echo "  No GH_TOKEN found in ${SECRETS_FILE}."
+            else
+                echo "  GH_TOKEN present but API returned an error (rate limit remaining: ${RL_REMAINING})."
+            fi
+            echo "  Run these commands in WSL2 (as ${USER}, not root) to fix:"
+            echo ""
+            echo "    TOKEN=\$(gh auth token 2>/dev/null)"
+            echo "    sed -i '/^GH_TOKEN=/d' ~/.config/runner-dashboard/env"
+            echo "    printf 'GH_TOKEN=%s\\n' \"\$TOKEN\" >> ~/.config/runner-dashboard/env"
+            echo "    sudo systemctl restart runner-dashboard"
+            echo ""
+            echo "  If gh auth token returns empty, re-authenticate:"
+            echo "    gh auth login"
+            echo "    gh auth refresh -s admin:org"
+            echo ""
+        fi
+    fi
+
+    # Smoke-test the runs endpoint
+    info "Smoke-testing /api/runs..."
+    RUNS=$(curl -s --max-time 10 http://localhost:8321/api/runs 2>/dev/null \
+           | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('workflow_runs',[])))" 2>/dev/null || echo "0")
+    if [[ "$GH_STATUS" == "connected" ]]; then
+        ok "Endpoint returned $RUNS workflow runs"
+    else
+        info "Runs endpoint returned $RUNS (expected 0 -- API not connected yet)"
+    fi
 fi
 
 echo ""

--- a/docs/deployment-model.md
+++ b/docs/deployment-model.md
@@ -1,0 +1,344 @@
+# Deployment Model -- Runner Dashboard
+
+This guide covers the full operational lifecycle of the Runner Dashboard: initial
+setup, routine updates, dry-run preview, rollback, secrets management, token
+refresh, health verification, artifact-based deployment, and multi-machine fleet
+operation.
+
+---
+
+## Overview
+
+The Runner Dashboard is a FastAPI backend + React SPA frontend that runs as a
+**systemd service** (`runner-dashboard.service`) on each fleet machine. It
+exposes a web UI on port 8321 and proxies the GitHub API for runner and workflow
+management.
+
+The service is long-lived: you update it in-place using the deploy scripts rather
+than restarting the machine.
+
+---
+
+## File Layout
+
+After a successful setup, the deployed dashboard lives at:
+
+```
+~/actions-runners/dashboard/
+|-- backend/          # Python FastAPI application (server.py, modules)
+|-- frontend/         # Static SPA (index.html)
+|-- config/           # Runtime configuration (agent_remediation.json, etc.)
+|-- local_apps.json   # Local process health registry
+|-- deployment.json   # Version and deployment metadata
+`-- refresh-token.sh  # GitHub token refresh helper
+```
+
+Secrets are stored separately from the deploy tree:
+
+```
+~/.config/runner-dashboard/env   # GH_TOKEN, GITHUB_ORG, etc. -- loaded by systemd
+```
+
+---
+
+## Bootstrap (First Time)
+
+Run `setup.sh` once per machine. Provide the machine-specific flags:
+
+```bash
+# ControlTower -- 8 runners, hub role
+bash deploy/setup.sh --runners 8 --machine-name ControlTower --role hub
+
+# OG-Laptop -- 4 runners, node role (default)
+bash deploy/setup.sh --runners 4 --machine-name OG-Laptop
+
+# Brick-Windows -- 1 runner, GPU node
+bash deploy/setup.sh --runners 1 --machine-name Brick-Windows
+
+# DeskComputer -- schedule-controlled runner count
+bash deploy/setup.sh --runners 8 --machine-name DeskComputer --runner-aliases desktop
+```
+
+`setup.sh` will:
+1. Install Python dependencies.
+2. Copy the dashboard to `~/actions-runners/dashboard/`.
+3. Write the systemd unit file and enable the service.
+4. Configure sudoers so the runner user can control runner services.
+
+After all machines are running, add the fleet node list to the hub:
+
+```bash
+bash deploy/setup.sh --runners 8 --machine-name ControlTower --role hub \
+  --fleet-nodes "Brick-Windows:http://100.x.x.x:8321,OG-Laptop:http://100.x.x.x:8321"
+```
+
+---
+
+## Routine Update
+
+After any change to `backend/`, `frontend/`, or `local_apps.json`, push the
+update to the deployed instance:
+
+```bash
+bash deploy/update-deployed.sh
+```
+
+The script will:
+1. Install/update Python dependencies via `pip_install` (sourced from `deploy/lib.sh`).
+2. Create a timestamped backup of the current deploy directory (`.bak.YYYYMMDD_HHMMSS`).
+3. Copy updated backend, frontend, deploy helpers, and `local_apps.json`.
+4. Write fresh `deployment.json` metadata.
+5. Restart `runner-dashboard.service`.
+6. Verify the service started and check GitHub API connectivity.
+7. Smoke-test the `/api/runs` endpoint.
+
+### Override the Source Repo Path
+
+If the repo is not at the default Windows path:
+
+```bash
+bash deploy/update-deployed.sh --repo /path/to/runner-dashboard-parent
+```
+
+### Override the Deploy Directory
+
+```bash
+bash deploy/update-deployed.sh --deploy-dir /custom/deploy/path
+```
+
+---
+
+## Dry-Run Mode
+
+Preview every destructive step without executing it:
+
+```bash
+bash deploy/update-deployed.sh --dry-run
+```
+
+Or via environment variable:
+
+```bash
+DRY_RUN=true bash deploy/update-deployed.sh
+```
+
+In dry-run mode:
+- No backup is created.
+- No files are copied or synced.
+- `systemctl restart` is not called.
+- The health check and smoke tests are skipped.
+- Each skipped step is logged as `[WARN] [DRY-RUN] Skipping: <description>`.
+
+---
+
+## Rollback
+
+Each run of `update-deployed.sh` automatically creates a timestamped backup
+of the deploy directory before any files are changed. Use `rollback.sh` to
+restore a previous state.
+
+### List Available Backups
+
+```bash
+bash deploy/rollback.sh --list
+```
+
+Output example:
+
+```
+[INFO] Available backups:
+/home/user/actions-runners/dashboard.bak.20260423_141502
+/home/user/actions-runners/dashboard.bak.20260422_093017
+```
+
+### Roll Back to the Most Recent Backup
+
+```bash
+bash deploy/rollback.sh
+```
+
+The script auto-selects the most recent backup, restores files, and restarts
+the service.
+
+### Roll Back to a Specific Backup
+
+```bash
+bash deploy/rollback.sh --to /home/user/actions-runners/dashboard.bak.20260422_093017
+```
+
+### Dry-Run Rollback
+
+```bash
+bash deploy/rollback.sh --dry-run
+```
+
+---
+
+## Secrets
+
+The systemd service loads environment variables from:
+
+```
+~/.config/runner-dashboard/env
+```
+
+Required variables:
+
+| Variable | Description |
+|---|---|
+| `GH_TOKEN` | GitHub PAT with `admin:org`, `repo`, `workflow` scopes |
+| `GITHUB_ORG` | GitHub organization name (e.g. `D-sorganization`) |
+| `NUM_RUNNERS` | Expected runner count for this machine |
+| `DISPLAY_NAME` | Human-readable machine name shown in the UI |
+
+Do not commit this file -- it is outside the repo tree and loaded only by systemd
+at service start. The file is owned by the runner user with mode `0600`.
+
+---
+
+## Token Refresh
+
+GitHub PATs expire. When the dashboard reports `github_api: disconnected`, refresh
+the token:
+
+```bash
+bash deploy/refresh-token.sh
+```
+
+Or manually:
+
+```bash
+TOKEN=$(gh auth token 2>/dev/null)
+sed -i '/^GH_TOKEN=/d' ~/.config/runner-dashboard/env
+printf 'GH_TOKEN=%s\n' "$TOKEN" >> ~/.config/runner-dashboard/env
+sudo systemctl restart runner-dashboard
+```
+
+If `gh auth token` returns empty, re-authenticate first:
+
+```bash
+gh auth login
+gh auth refresh -s admin:org
+```
+
+---
+
+## Health Check
+
+Verify the service is responding:
+
+```bash
+curl http://localhost:8321/api/health
+```
+
+Expected response when fully connected:
+
+```json
+{"status": "ok", "github_api": "connected", "runners_registered": 8}
+```
+
+Check the detailed system view:
+
+```bash
+curl -s http://localhost:8321/api/health | python3 -m json.tool
+```
+
+---
+
+## Artifact-Based Deployment
+
+For release builds, deploy from a pre-built tarball instead of the source
+checkout:
+
+```bash
+bash deploy/update-deployed.sh --artifact runner-dashboard-v4.0.1.tar.gz
+```
+
+The `--artifact` flag delegates file installation to
+`deploy/install-dashboard-artifact.sh`, which unpacks the tarball into the
+deploy directory. The backup, dependency install, and service restart steps
+still run normally.
+
+Build artifacts are described in `deploy/ARTIFACT_BUILD.md`.
+
+---
+
+## Multi-Machine Fleet
+
+Each fleet machine runs its own dashboard instance independently. There is no
+shared database or central coordinator -- the hub machine (`--role hub`) aggregates
+status from the other nodes via the `/api/fleet/nodes` endpoint using Tailscale
+IPs.
+
+Setup order:
+
+1. Run `setup.sh` on every node machine.
+2. Note each node's Tailscale IP.
+3. Run `setup.sh` on the hub machine with `--role hub --fleet-nodes "..."`.
+
+Updates are deployed per-machine. There is no fleet-wide push mechanism built
+into the deploy scripts; use the Fleet Orchestration tab in the dashboard UI
+for coordinated rolling deploys.
+
+---
+
+## Troubleshooting
+
+### View Live Logs
+
+```bash
+sudo journalctl -u runner-dashboard -f
+```
+
+### View Recent Logs (No Pager)
+
+```bash
+sudo journalctl -u runner-dashboard -n 50 --no-pager
+```
+
+### Check Service Status
+
+```bash
+sudo systemctl status runner-dashboard
+```
+
+### Service Fails to Start After Update
+
+1. Check the journal for the Python traceback.
+2. Verify the env file: `cat ~/.config/runner-dashboard/env`
+3. Roll back: `bash deploy/rollback.sh`
+4. Investigate the change that broke the service, fix, and redeploy.
+
+### GitHub API Rate Limit
+
+The dashboard shows `github_api: rate_limited` when the 5000 req/hr limit is
+exhausted. This clears automatically when the rate-limit window resets. Check
+the reset time:
+
+```bash
+curl -s http://localhost:8321/api/health | python3 -m json.tool
+```
+
+---
+
+## Shared Deploy Library
+
+All deploy scripts source `deploy/lib.sh` for shared utilities:
+
+| Function | Description |
+|---|---|
+| `ok`, `info`, `warn`, `fail` | Coloured log output |
+| `require_dir`, `require_file`, `require_cmd` | Guard assertions |
+| `pip_install <pkg...>` | pip3 install with `--break-system-packages` when supported |
+| `sync_dir <src> <dest>` | rsync with rm/cp fallback |
+| `backup_dir <path>` | Timestamped `cp -a` backup; prints backup path |
+| `dry_run "<description>"` | Returns 0 (skip) when `DRY_RUN=true` |
+
+To add a new deploy script, start with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck source=deploy/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+```


### PR DESCRIPTION
## Summary

- **`deploy/lib.sh`** — new shared shell library providing colours, `ok`/`info`/`warn`/`fail` helpers, `require_dir`/`require_file`/`require_cmd` guards, `pip_install` (auto `--break-system-packages`), `sync_dir` (rsync + fallback), `backup_dir` (timestamped `cp -a`), and `dry_run` gate
- **`deploy/update-deployed.sh`** — refactored to source `lib.sh`, add `--dry-run` flag, and create an automatic timestamped backup before every deploy; removed ~26 lines of duplicated colour/function definitions
- **`deploy/rollback.sh`** — new script to list backups (`--list`), roll back to the most recent or a specific backup (`--to`), with `--dry-run` support
- **`docs/deployment-model.md`** — new operator guide covering bootstrap, update, dry-run, rollback, secrets, token refresh, health check, artifact deploy, and multi-machine fleet
- **`SPEC.md`** — Section 6 expanded with Rollback (6.4), updated systemd section (6.5), and Shared Deploy Library (6.7)

Closes #8

## Lines removed from `update-deployed.sh`

| Removed block | Lines |
|---|---|
| Colour variables (`GREEN`/`CYAN`/`RED`/`YELLOW`/`NC`) | 1 |
| `ok`/`info`/`fail`/`warn` function definitions | 4 |
| `pip_install_backend_deps` function | 8 |
| `sync_dir` function | 10 |
| Raw `echo -e` colour calls replaced with helper calls | 3 |
| **Total removed** | **~26 lines** |

## Test plan

- [ ] `bash -n deploy/lib.sh` passes (syntax check)
- [ ] `bash -n deploy/update-deployed.sh` passes (syntax check)
- [ ] `bash -n deploy/rollback.sh` passes (syntax check)
- [ ] `bash deploy/update-deployed.sh --dry-run` prints DRY-RUN lines without touching files or services
- [ ] `bash deploy/rollback.sh --list` lists `.bak.*` directories
- [ ] `bash deploy/rollback.sh --dry-run` prints DRY-RUN lines without touching files
- [ ] CI spec-check passes (SPEC.md updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)