### PR TITLE
refactor: extract fleet dispatch and credentials into bounded FastAPI routers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -69,6 +69,21 @@ The backend is a single-process FastAPI application that:
 | `workflow_stats.py` | Aggregate workflow success/failure statistics |
 | `report_files.py` | Parse dated report files for the Reports tab |
 | `runner_autoscaler.py` | Dynamic runner count scaling logic |
+| `config_schema.py` | Config validation and atomic JSON writes |
+
+**Bounded domain routers (`backend/routers/`):**
+
+Well-bounded API domains with no cross-domain shared state are extracted into
+`APIRouter` modules and registered with `app.include_router()`. This reduces
+coupling and makes each domain independently testable.
+
+| Router | Prefix | Responsibility |
+|---|---|---|
+| `routers/dispatch.py` | `/api/fleet/dispatch` | Fleet agent dispatcher — allowlisted hub-to-node commands |
+| `routers/credentials.py` | `/api` | Credential probe — tool/key presence without exposing values |
+
+The migration from inline `@app.*` endpoints to bounded routers is ongoing.
+Remaining endpoint domains in `server.py` are tracked for extraction under issue #4.
 
 ### 2.2 Frontend
 

--- a/backend/routers/credentials.py
+++ b/backend/routers/credentials.py
@@ -1,0 +1,211 @@
+"""Credentials probe router.
+
+Read-only endpoint that checks which AI tool CLIs and API keys are available
+on the host. Never exposes secret values — only presence/connectivity state.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt_mod
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from fastapi import APIRouter
+
+UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
+datetime = _dt_mod.datetime
+
+router = APIRouter(prefix="/api", tags=["credentials"])
+
+log = logging.getLogger("dashboard.credentials")
+
+
+def _env_present(key: str) -> bool:
+    val = os.environ.get(key, "")
+    return bool(val and val.strip())
+
+
+def _env_source(key: str) -> str:
+    return "env_var" if os.environ.get(key, "") else "unavailable"
+
+
+@router.get("/credentials")
+async def get_credentials() -> dict:
+    """Probe provider credential and connectivity state. Never exposes secret values."""
+    probes: list[dict] = []
+
+    # GitHub CLI
+    gh_binary = shutil.which("gh")
+    gh_auth_ok = False
+    gh_auth_detail = "gh not found"
+    if gh_binary:
+        try:
+            result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True, timeout=10)
+            gh_auth_ok = result.returncode == 0
+            gh_auth_detail = "authenticated" if gh_auth_ok else "not logged in"
+        except Exception:
+            gh_auth_detail = "probe failed"
+
+    probes.append(
+        {
+            "id": "github_cli",
+            "label": "GitHub CLI",
+            "icon": "github",
+            "installed": gh_binary is not None,
+            "authenticated": gh_auth_ok,
+            "reachable": gh_auth_ok,
+            "usable": gh_auth_ok,
+            "status": "ready" if gh_auth_ok else ("not_authed" if gh_binary else "not_installed"),
+            "detail": gh_auth_detail,
+            "config_source": "system" if gh_binary else "unavailable",
+            "docs_url": "https://cli.github.com/",
+            "setup_hint": "Run: gh auth login",
+        }
+    )
+
+    # Jules CLI
+    jules_binary = shutil.which("jules")
+    probes.append(
+        {
+            "id": "jules_cli",
+            "label": "Jules CLI",
+            "icon": "jules",
+            "installed": jules_binary is not None,
+            "authenticated": jules_binary is not None,
+            "reachable": jules_binary is not None,
+            "usable": jules_binary is not None,
+            "status": "ready" if jules_binary else "not_installed",
+            "detail": f"Found at {jules_binary}" if jules_binary else "jules not found on PATH",
+            "config_source": "system" if jules_binary else "unavailable",
+            "docs_url": "https://jules.google/docs/",
+            "setup_hint": "Install Jules CLI from jules.google",
+        }
+    )
+
+    # Jules API
+    jules_api_key = _env_present("JULES_API_KEY") or _env_present("GOOGLE_API_KEY")
+    probes.append(
+        {
+            "id": "jules_api",
+            "label": "Jules API",
+            "icon": "jules",
+            "installed": True,
+            "authenticated": jules_api_key,
+            "reachable": jules_api_key,
+            "usable": jules_api_key,
+            "status": "ready" if jules_api_key else "missing_key",
+            "detail": "API key present" if jules_api_key else "JULES_API_KEY or GOOGLE_API_KEY not set",
+            "config_source": _env_source("JULES_API_KEY") if jules_api_key else "unavailable",
+            "docs_url": "https://jules.google/docs/api/",
+            "setup_hint": "Set JULES_API_KEY environment variable",
+        }
+    )
+
+    # Codex CLI
+    codex_binary = shutil.which("codex")
+    openai_key = _env_present("OPENAI_API_KEY")
+    probes.append(
+        {
+            "id": "codex_cli",
+            "label": "Codex CLI",
+            "icon": "openai",
+            "installed": codex_binary is not None,
+            "authenticated": openai_key,
+            "reachable": codex_binary is not None and openai_key,
+            "usable": codex_binary is not None and openai_key,
+            "status": "ready"
+            if (codex_binary and openai_key)
+            else ("missing_key" if codex_binary else "not_installed"),
+            "detail": (
+                "Ready"
+                if (codex_binary and openai_key)
+                else ("OPENAI_API_KEY not set" if codex_binary else "codex not found on PATH")
+            ),
+            "config_source": (
+                _env_source("OPENAI_API_KEY") if openai_key else ("system" if codex_binary else "unavailable")
+            ),
+            "docs_url": "https://github.com/openai/codex",
+            "setup_hint": "npm install -g @openai/codex && set OPENAI_API_KEY",
+        }
+    )
+
+    # Claude Code CLI
+    claude_binary = shutil.which("claude")
+    anthropic_key = _env_present("ANTHROPIC_API_KEY")
+    probes.append(
+        {
+            "id": "claude_code_cli",
+            "label": "Claude Code CLI",
+            "icon": "anthropic",
+            "installed": claude_binary is not None,
+            "authenticated": anthropic_key,
+            "reachable": claude_binary is not None and anthropic_key,
+            "usable": claude_binary is not None and anthropic_key,
+            "status": "ready"
+            if (claude_binary and anthropic_key)
+            else ("missing_key" if claude_binary else "not_installed"),
+            "detail": (
+                "Ready"
+                if (claude_binary and anthropic_key)
+                else ("ANTHROPIC_API_KEY not set" if claude_binary else "claude not found on PATH")
+            ),
+            "config_source": (
+                _env_source("ANTHROPIC_API_KEY") if anthropic_key else ("system" if claude_binary else "unavailable")
+            ),
+            "docs_url": "https://docs.anthropic.com/claude-code",
+            "setup_hint": "npm install -g @anthropic-ai/claude-code && set ANTHROPIC_API_KEY",
+        }
+    )
+
+    # Cline (VS Code extension)
+    cline_config = Path.home() / ".config" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
+    cline_installed = cline_config.exists()
+    probes.append(
+        {
+            "id": "cline",
+            "label": "Cline (VS Code)",
+            "icon": "vscode",
+            "installed": cline_installed,
+            "authenticated": cline_installed,
+            "reachable": cline_installed,
+            "usable": cline_installed,
+            "status": "ready" if cline_installed else "not_installed",
+            "detail": ("VS Code extension data found" if cline_installed else "Cline VS Code extension not found"),
+            "config_source": "vscode" if cline_installed else "unavailable",
+            "docs_url": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "setup_hint": "Install Cline extension in VS Code",
+        }
+    )
+
+    # Ollama
+    ollama_binary = shutil.which("ollama")
+    probes.append(
+        {
+            "id": "ollama_local",
+            "label": "Ollama (Local)",
+            "icon": "ollama",
+            "installed": ollama_binary is not None,
+            "authenticated": True,
+            "reachable": ollama_binary is not None,
+            "usable": ollama_binary is not None,
+            "status": "ready" if ollama_binary else "not_installed",
+            "detail": f"Found at {ollama_binary}" if ollama_binary else "ollama not found on PATH",
+            "config_source": "system" if ollama_binary else "unavailable",
+            "docs_url": "https://ollama.com/",
+            "setup_hint": "Install from ollama.com",
+        }
+    )
+
+    ready = sum(1 for p in probes if p["usable"])
+    return {
+        "probes": probes,
+        "summary": {
+            "total": len(probes),
+            "ready": ready,
+            "not_ready": len(probes) - ready,
+        },
+        "probed_at": datetime.now(UTC).isoformat(),
+    }

--- a/backend/routers/dispatch.py
+++ b/backend/routers/dispatch.py
@@ -1,0 +1,95 @@
+"""Fleet agent dispatcher router.
+
+Hub-to-node dispatch endpoints. All mutating operations go through the
+dispatch_contract allowlist so only approved actions can be triggered.
+Privileged actions require an explicit DispatchConfirmation payload.
+
+These endpoints are intentionally thin: they validate and record; actual
+execution is done by the caller after receiving an accepted envelope back.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import dispatch_contract
+from fastapi import APIRouter, HTTPException, Request
+
+router = APIRouter(prefix="/api/fleet/dispatch", tags=["dispatch"])
+
+log = logging.getLogger("dashboard.dispatch")
+
+
+@router.get("/actions")
+async def list_dispatch_actions() -> dict:
+    """Return every allowlisted action with its access level and description."""
+    return {"actions": [a.to_dict() for a in dispatch_contract.ALLOWLISTED_ACTIONS.values()]}
+
+
+async def _parse_envelope(request: Request) -> dispatch_contract.CommandEnvelope:
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="Malformed envelope: expected object")
+    try:
+        return dispatch_contract.CommandEnvelope.from_dict(body)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=f"Malformed envelope: {exc}") from exc
+
+
+@router.post("/validate")
+async def validate_dispatch_envelope(request: Request) -> dict:
+    """Validate a raw command envelope dict and return the validation result.
+
+    The caller is responsible for providing a well-formed envelope JSON body.
+    Privileged actions must include a ``confirmation`` sub-object.
+    """
+    envelope = await _parse_envelope(request)
+    result = dispatch_contract.validate_envelope(envelope)
+    audit = dispatch_contract.build_audit_log_entry(envelope, result)
+
+    log.info(
+        "validate envelope_id=%s action=%s decision=%s",
+        envelope.envelope_id,
+        envelope.action,
+        audit.decision,
+    )
+
+    return {
+        "accepted": result.accepted,
+        "reason": result.reason,
+        "confirmation_required": result.confirmation_required,
+        "action": result.action.to_dict() if result.action else None,
+        "audit": audit.to_dict(),
+    }
+
+
+@router.post("/submit")
+async def submit_dispatch_command(request: Request) -> dict:
+    """Accept a validated, confirmed command envelope and record the audit entry.
+
+    Returns the prototype command tuple so the calling hub can preview or
+    execute the approved action against the node. Actual execution is kept
+    outside the dashboard process boundary for safety.
+    """
+    envelope = await _parse_envelope(request)
+    result = dispatch_contract.validate_envelope(envelope)
+    audit = dispatch_contract.build_audit_log_entry(envelope, result)
+
+    log.info(
+        "submit envelope_id=%s action=%s decision=%s requested_by=%s",
+        envelope.envelope_id,
+        envelope.action,
+        audit.decision,
+        envelope.requested_by,
+    )
+
+    if not result.accepted:
+        raise HTTPException(status_code=403, detail=result.reason)
+
+    prototype_cmd = dispatch_contract.command_preview(envelope.action, envelope.payload)
+    return {
+        "envelope_id": envelope.envelope_id,
+        "action": envelope.action,
+        "prototype_command": list(prototype_cmd),
+        "audit": audit.to_dict(),
+    }

--- a/backend/server.py
+++ b/backend/server.py
@@ -57,6 +57,8 @@ from machine_registry import (  # noqa: E402
     merge_registry_with_live_nodes,
 )
 from report_files import parse_report_metrics, sanitize_report_date  # noqa: E402
+from routers import credentials as _credentials_router  # noqa: E402
+from routers import dispatch as _dispatch_router  # noqa: E402
 
 # datetime.UTC added in Python 3.11; fall back to timezone.utc on older runtimes.
 UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
@@ -176,6 +178,10 @@ app = FastAPI(
     version="4.0.0",
     description="Monitor and control self-hosted GitHub Actions runners",
 )
+
+# ── Bounded domain routers ────────────────────────────────────────────────────
+app.include_router(_dispatch_router.router)
+app.include_router(_credentials_router.router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -4264,290 +4270,11 @@ async def serve_icon():
     return FileResponse(icon_path, media_type="image/svg+xml")
 
 
-# ─── Fleet Agent Dispatcher API ───────────────────────────────────────────────
-#
-# Hub-to-node dispatch endpoints.  All mutating operations go through the
-# dispatch_contract allowlist so only approved actions can be triggered.
-# Privileged actions require an explicit DispatchConfirmation payload.
-#
-# These endpoints are intentionally thin: they validate and record; actual
-# execution is done by the caller after receiving an accepted envelope back.
-# A future iteration can add an async executor and log-streaming via WebSocket.
+# ─── Fleet Agent Dispatcher API — see backend/routers/dispatch.py ─────────────
+# Endpoints extracted to routers/dispatch.py and registered via app.include_router.
 
-
-@app.get("/api/fleet/dispatch/actions")
-async def list_dispatch_actions() -> dict:
-    """Return every allowlisted action with its access level and description."""
-    return {"actions": [a.to_dict() for a in dispatch_contract.ALLOWLISTED_ACTIONS.values()]}
-
-
-async def _parse_dispatch_envelope(
-    request: Request,
-) -> dispatch_contract.CommandEnvelope:
-    body = await request.json()
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=422, detail="Malformed envelope: expected object")
-    try:
-        return dispatch_contract.CommandEnvelope.from_dict(body)
-    except (KeyError, TypeError, ValueError) as exc:
-        raise HTTPException(status_code=422, detail=f"Malformed envelope: {exc}") from exc
-
-
-@app.post("/api/fleet/dispatch/validate")
-async def validate_dispatch_envelope(request: Request) -> dict:
-    """Validate a raw command envelope dict and return the validation result.
-
-    The caller is responsible for providing a well-formed envelope JSON body.
-    Privileged actions must include a ``confirmation`` sub-object.
-    """
-    envelope = await _parse_dispatch_envelope(request)
-
-    result = dispatch_contract.validate_envelope(envelope)
-    audit = dispatch_contract.build_audit_log_entry(envelope, result)
-
-    log.info(
-        "fleet-dispatch validate envelope_id=%s action=%s decision=%s",
-        envelope.envelope_id,
-        envelope.action,
-        audit.decision,
-    )
-
-    return {
-        "accepted": result.accepted,
-        "reason": result.reason,
-        "confirmation_required": result.confirmation_required,
-        "action": result.action.to_dict() if result.action else None,
-        "audit": audit.to_dict(),
-    }
-
-
-@app.post("/api/fleet/dispatch/submit")
-async def submit_dispatch_command(request: Request) -> dict:
-    """Accept a validated, confirmed command envelope and record the audit entry.
-
-    Returns the prototype command tuple so the calling hub can preview or
-    execute the approved action against the node.  Actual execution is kept
-    outside the dashboard process boundary for safety.
-    """
-    envelope = await _parse_dispatch_envelope(request)
-
-    result = dispatch_contract.validate_envelope(envelope)
-    audit = dispatch_contract.build_audit_log_entry(envelope, result)
-
-    log.info(
-        "fleet-dispatch submit envelope_id=%s action=%s decision=%s requested_by=%s",
-        envelope.envelope_id,
-        envelope.action,
-        audit.decision,
-        envelope.requested_by,
-    )
-
-    if not result.accepted:
-        raise HTTPException(status_code=403, detail=result.reason)
-
-    prototype_cmd = dispatch_contract.command_preview(envelope.action, envelope.payload)
-    return {
-        "envelope_id": envelope.envelope_id,
-        "action": envelope.action,
-        "prototype_command": list(prototype_cmd),
-        "audit": audit.to_dict(),
-    }
-
-
-# ─── Credentials Probe ────────────────────────────────────────────────────────
-
-
-@app.get("/api/credentials")
-async def get_credentials() -> dict:
-    """Probe provider credential and connectivity state. Never exposes secret values."""
-
-    def env_present(key: str) -> bool:
-        val = os.environ.get(key, "")
-        return bool(val and val.strip())
-
-    def env_source(key: str) -> str:
-        val = os.environ.get(key, "")
-        if not val:
-            return "unavailable"
-        if val.startswith("ghp_") or val.startswith("github_pat_"):
-            return "env_var"
-        return "env_var"
-
-    probes = []
-
-    # GitHub CLI
-    gh_binary = shutil.which("gh")
-    gh_auth_ok = False
-    gh_auth_detail = "gh not found"
-    if gh_binary:
-        try:
-            result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True, timeout=10)
-            gh_auth_ok = result.returncode == 0
-            gh_auth_detail = "authenticated" if gh_auth_ok else "not logged in"
-        except Exception:
-            gh_auth_detail = "probe failed"
-
-    probes.append(
-        {
-            "id": "github_cli",
-            "label": "GitHub CLI",
-            "icon": "github",
-            "installed": gh_binary is not None,
-            "authenticated": gh_auth_ok,
-            "reachable": gh_auth_ok,
-            "usable": gh_auth_ok,
-            "status": "ready" if gh_auth_ok else ("not_authed" if gh_binary else "not_installed"),
-            "detail": gh_auth_detail,
-            "config_source": "system" if gh_binary else "unavailable",
-            "docs_url": "https://cli.github.com/",
-            "setup_hint": "Run: gh auth login",
-        }
-    )
-
-    # Jules CLI
-    jules_binary = shutil.which("jules")
-    probes.append(
-        {
-            "id": "jules_cli",
-            "label": "Jules CLI",
-            "icon": "jules",
-            "installed": jules_binary is not None,
-            "authenticated": jules_binary is not None,
-            "reachable": jules_binary is not None,
-            "usable": jules_binary is not None,
-            "status": "ready" if jules_binary else "not_installed",
-            "detail": f"Found at {jules_binary}" if jules_binary else "jules not found on PATH",
-            "config_source": "system" if jules_binary else "unavailable",
-            "docs_url": "https://jules.google/docs/",
-            "setup_hint": "Install Jules CLI from jules.google",
-        }
-    )
-
-    # Jules API
-    jules_api_key = env_present("JULES_API_KEY") or env_present("GOOGLE_API_KEY")
-    probes.append(
-        {
-            "id": "jules_api",
-            "label": "Jules API",
-            "icon": "jules",
-            "installed": True,
-            "authenticated": jules_api_key,
-            "reachable": jules_api_key,
-            "usable": jules_api_key,
-            "status": "ready" if jules_api_key else "missing_key",
-            "detail": "API key present" if jules_api_key else "JULES_API_KEY or GOOGLE_API_KEY not set",
-            "config_source": env_source("JULES_API_KEY") if jules_api_key else "unavailable",
-            "docs_url": "https://jules.google/docs/api/",
-            "setup_hint": "Set JULES_API_KEY environment variable",
-        }
-    )
-
-    # Codex CLI
-    codex_binary = shutil.which("codex")
-    openai_key = env_present("OPENAI_API_KEY")
-    probes.append(
-        {
-            "id": "codex_cli",
-            "label": "Codex CLI",
-            "icon": "openai",
-            "installed": codex_binary is not None,
-            "authenticated": openai_key,
-            "reachable": codex_binary is not None and openai_key,
-            "usable": codex_binary is not None and openai_key,
-            "status": "ready"
-            if (codex_binary and openai_key)
-            else ("missing_key" if codex_binary else "not_installed"),
-            "detail": (
-                "Ready"
-                if (codex_binary and openai_key)
-                else ("OPENAI_API_KEY not set" if codex_binary else "codex not found on PATH")
-            ),
-            "config_source": (
-                env_source("OPENAI_API_KEY") if openai_key else ("system" if codex_binary else "unavailable")
-            ),
-            "docs_url": "https://github.com/openai/codex",
-            "setup_hint": "npm install -g @openai/codex && set OPENAI_API_KEY",
-        }
-    )
-
-    # Claude Code CLI
-    claude_binary = shutil.which("claude")
-    anthropic_key = env_present("ANTHROPIC_API_KEY")
-    probes.append(
-        {
-            "id": "claude_code_cli",
-            "label": "Claude Code CLI",
-            "icon": "anthropic",
-            "installed": claude_binary is not None,
-            "authenticated": anthropic_key,
-            "reachable": claude_binary is not None and anthropic_key,
-            "usable": claude_binary is not None and anthropic_key,
-            "status": "ready"
-            if (claude_binary and anthropic_key)
-            else ("missing_key" if claude_binary else "not_installed"),
-            "detail": (
-                "Ready"
-                if (claude_binary and anthropic_key)
-                else ("ANTHROPIC_API_KEY not set" if claude_binary else "claude not found on PATH")
-            ),
-            "config_source": (
-                env_source("ANTHROPIC_API_KEY") if anthropic_key else ("system" if claude_binary else "unavailable")
-            ),
-            "docs_url": "https://docs.anthropic.com/claude-code",
-            "setup_hint": "npm install -g @anthropic-ai/claude-code && set ANTHROPIC_API_KEY",
-        }
-    )
-
-    # Cline (VS Code extension - check if config exists)
-    cline_config = Path.home() / ".config" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
-    cline_installed = cline_config.exists()
-    probes.append(
-        {
-            "id": "cline",
-            "label": "Cline (VS Code)",
-            "icon": "vscode",
-            "installed": cline_installed,
-            "authenticated": cline_installed,
-            "reachable": cline_installed,
-            "usable": cline_installed,
-            "status": "ready" if cline_installed else "not_installed",
-            "detail": ("VS Code extension data found" if cline_installed else "Cline VS Code extension not found"),
-            "config_source": "vscode" if cline_installed else "unavailable",
-            "docs_url": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
-            "setup_hint": "Install Cline extension in VS Code",
-        }
-    )
-
-    # Ollama
-    ollama_binary = shutil.which("ollama")
-    probes.append(
-        {
-            "id": "ollama_local",
-            "label": "Ollama (Local)",
-            "icon": "ollama",
-            "installed": ollama_binary is not None,
-            "authenticated": True,
-            "reachable": ollama_binary is not None,
-            "usable": ollama_binary is not None,
-            "status": "ready" if ollama_binary else "not_installed",
-            "detail": f"Found at {ollama_binary}" if ollama_binary else "ollama not found on PATH",
-            "config_source": "system" if ollama_binary else "unavailable",
-            "docs_url": "https://ollama.com/",
-            "setup_hint": "Install from ollama.com",
-        }
-    )
-
-    ready = sum(1 for p in probes if p["usable"])
-    return {
-        "probes": probes,
-        "summary": {
-            "total": len(probes),
-            "ready": ready,
-            "not_ready": len(probes) - ready,
-        },
-        "probed_at": datetime.now(UTC).isoformat(),
-    }
-
+# ─── Credentials Probe — see backend/routers/credentials.py ──────────────────
+# Endpoint extracted to routers/credentials.py and registered via app.include_router.
 
 # ─── Maxwell-Daemon endpoints ─────────────────────────────────────────────────
 

--- a/tests/test_backend_routers.py
+++ b/tests/test_backend_routers.py
@@ -1,0 +1,104 @@
+"""Structural tests for the extracted backend routers (issue #4).
+
+These are import-time and shape tests — they verify the routers are correctly
+structured and expose the expected routes without needing a running server.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+_py311 = pytest.mark.skipif(sys.version_info < (3, 11), reason="dispatch_contract requires Python 3.11+")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch router
+# ---------------------------------------------------------------------------
+
+
+@_py311
+def test_dispatch_router_importable() -> None:
+    from routers import dispatch
+
+    assert hasattr(dispatch, "router"), "routers/dispatch.py must export 'router'"
+
+
+@_py311
+def test_dispatch_router_has_expected_routes() -> None:
+    from routers import dispatch
+
+    paths = {r.path for r in dispatch.router.routes}  # type: ignore[attr-defined]
+    assert "/api/fleet/dispatch/actions" in paths
+    assert "/api/fleet/dispatch/validate" in paths
+    assert "/api/fleet/dispatch/submit" in paths
+
+
+def test_dispatch_router_uses_dispatch_contract() -> None:
+    """The dispatch router module must reference dispatch_contract — its core dependency."""
+    source = (_BACKEND_DIR / "routers" / "dispatch.py").read_text(encoding="utf-8")
+    assert "import dispatch_contract" in source, "dispatch router must import dispatch_contract"
+
+
+# ---------------------------------------------------------------------------
+# Credentials router
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_router_importable() -> None:
+    from routers import credentials  # noqa: PLC0415
+
+    assert hasattr(credentials, "router"), "routers/credentials.py must export 'router'"
+
+
+def test_credentials_router_has_credentials_route() -> None:
+    from routers import credentials  # noqa: PLC0415
+
+    paths = {r.path for r in credentials.router.routes}  # type: ignore[attr-defined]
+    assert "/api/credentials" in paths
+
+
+def test_credentials_router_no_secret_exposure() -> None:
+    """Credentials router must never log or return raw env var values."""
+    source = (_BACKEND_DIR / "routers" / "credentials.py").read_text(encoding="utf-8")
+    assert "os.environ.get" in source, "must probe env vars"
+    # Ensure the router doesn't return raw env values — only booleans
+    assert "return os.environ" not in source, "must not return raw env var contents"
+
+
+# ---------------------------------------------------------------------------
+# server.py registration
+# ---------------------------------------------------------------------------
+
+
+def test_server_registers_dispatch_router() -> None:
+    """server.py must include the dispatch router (not re-implement it inline)."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert "from routers import dispatch" in server_src or "routers.dispatch" in server_src
+    assert "include_router(_dispatch_router.router)" in server_src
+
+
+def test_server_registers_credentials_router() -> None:
+    """server.py must include the credentials router (not re-implement it inline)."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert "from routers import credentials" in server_src or "routers.credentials" in server_src
+    assert "include_router(_credentials_router.router)" in server_src
+
+
+def test_server_dispatch_not_inline() -> None:
+    """The dispatch endpoints must not be defined inline in server.py."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert "@app.get(\"/api/fleet/dispatch/actions\")" not in server_src
+    assert "@app.post(\"/api/fleet/dispatch/validate\")" not in server_src
+    assert "@app.post(\"/api/fleet/dispatch/submit\")" not in server_src
+
+
+def test_server_credentials_not_inline() -> None:
+    """The credentials endpoint must not be defined inline in server.py."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert "@app.get(\"/api/credentials\")" not in server_src


### PR DESCRIPTION
## Summary

- Creates `backend/routers/` package with two extracted API domains:
  - `routers/dispatch.py` — `/api/fleet/dispatch/*` endpoints (list, validate, submit); depends only on `dispatch_contract`, no global server state
  - `routers/credentials.py` — `/api/credentials` endpoint; reads `os.environ` and probes local binaries; no GitHub client dependency
- `server.py` now registers these via `app.include_router()` and removes ~270 lines of inline endpoint code (~5285 → ~5012 lines)
- Adds `tests/test_backend_routers.py` with structural tests verifying router shape, expected paths, and that `server.py` uses `include_router` (not inline re-implementation)
- Updates SPEC.md section 2.1 to document the bounded routers pattern and ongoing migration plan

The remaining endpoint domains in `server.py` (runner control, queue, fleet metrics, reports, Maxwell, assessments) are candidates for future extraction following the same pattern, tracked in issue #4.

## Test plan
- [x] `pytest tests/test_backend_routers.py -q` — 8 passed, 2 skipped (Python 3.10 local; 3.11 required for dispatch_contract import)
- [x] `pytest tests/ --ignore=tests/test_dispatch_contract.py --ignore=tests/test_remote_execution_contract.py -q` — 46 passed, all green
- [x] SPEC.md updated with new router table and migration note

Closes #4