### PR TITLE
[codex] fix dashboard rerun and deploy hardening

### DIFF
--- a/.github/workflows/Agent-Redundant-PR-Closer.yml
+++ b/.github/workflows/Agent-Redundant-PR-Closer.yml
@@ -58,8 +58,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Check Jules app credentials
+        id: app-creds
+        env:
+          JULES_APP_ID: ${{ secrets.JULES_APP_ID }}
+          JULES_APP_PRIVATE_KEY: ${{ secrets.JULES_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "$JULES_APP_ID" ] && [ -n "$JULES_APP_PRIVATE_KEY" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::JULES_APP_ID/JULES_APP_PRIVATE_KEY are not configured; skipping redundant PR closer."
+          fi
+
       - name: Generate Jules app token
         id: app-token
+        if: steps.app-creds.outputs.configured == 'true'
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.JULES_APP_ID }}
@@ -67,6 +81,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout Repository_Management (for scripts)
+        if: steps.app-creds.outputs.configured == 'true'
         uses: actions/checkout@v4
         with:
           repository: D-sorganization/Repository_Management
@@ -75,11 +90,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Python
+        if: steps.app-creds.outputs.configured == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Close redundant agent PRs
+        if: steps.app-creds.outputs.configured == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -122,4 +139,5 @@ jobs:
             echo "- **Trigger:** ${{ github.event_name }}"
             echo "- **Dry run:** ${{ inputs.dry_run || 'false' }}"
             echo "- **Agent filter:** ${{ inputs.agent_filter || 'all non-user' }}"
+            echo "- **App credentials configured:** ${{ steps.app-creds.outputs.configured || 'false' }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/SPEC.md
+++ b/SPEC.md
@@ -547,7 +547,7 @@ adjusts the active runner count based on the policy defined in
 
 - Terminal colours and `ok`/`info`/`warn`/`fail` log helpers
 - Guard assertions: `require_dir`, `require_file`, `require_cmd`
-- `pip_install <pkg...>` — pip3 with `--break-system-packages` when supported
+- `pip_install <pkg...>` — Python 3.11-preferring pip with `--break-system-packages` when supported
 - `sync_dir <src> <dest>` — rsync with rm/cp fallback
 - `backup_dir <path>` — timestamped `cp -a` backup
 - `dry_run "<description>"` — no-op gate when `DRY_RUN=true`

--- a/deploy/configure-agent-remediation.sh
+++ b/deploy/configure-agent-remediation.sh
@@ -78,6 +78,7 @@ set_env_var() {
     local value="$2"
     local tmp
     tmp="$(mktemp)"
+    trap 'rm -f "${tmp}"' RETURN
     python3 - "${ENV_FILE}" "${key}" "${value}" >"${tmp}" <<'PY'
 from pathlib import Path
 import sys
@@ -96,6 +97,7 @@ sys.stdout.write("\n".join(filtered) + "\n")
 PY
     cat "${tmp}" > "${ENV_FILE}"
     rm -f "${tmp}"
+    trap - RETURN
 }
 
 require_npm() {

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -3,6 +3,8 @@
 # Source with: source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 # Do NOT execute directly.
 
+set -euo pipefail
+
 # Terminal colours
 GREEN='\033[0;32m'; CYAN='\033[0;36m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
 ok()   { echo -e "${GREEN}[ OK ]${NC} $*"; }
@@ -18,9 +20,14 @@ require_cmd()  { command -v "$1" >/dev/null 2>&1 || fail "Required command not f
 # pip install with --break-system-packages when supported
 pip_install() {
     local -a pkgs=("$@")
-    local -a cmd=(pip3 install --quiet "${pkgs[@]}")
-    if pip3 install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
-        cmd=(pip3 install --break-system-packages --quiet "${pkgs[@]}")
+    local python_bin="${RUNNER_DASHBOARD_PYTHON:-}"
+    if [[ -z "$python_bin" ]]; then
+        python_bin="$(command -v python3.11 || command -v python3)"
+    fi
+
+    local -a cmd=("$python_bin" -m pip install --quiet "${pkgs[@]}")
+    if "$python_bin" -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
+        cmd=("$python_bin" -m pip install --break-system-packages --quiet "${pkgs[@]}")
     fi
     "${cmd[@]}"
 }

--- a/deploy/refresh-token.sh
+++ b/deploy/refresh-token.sh
@@ -23,7 +23,7 @@ TOKEN=$(gh auth token 2>/dev/null || echo "")
 # Older gh (<2.40) prints its usage/error to stdout, so `2>/dev/null` doesn't
 # silence it. Treat anything that doesn't look like a GitHub token
 # (gho_/ghp_/ghu_/ghs_/ghr_) as empty so the fallback kicks in.
-if [[ ! "${TOKEN}" =~ ^(gho_|ghp_|ghu_|ghs_|ghr_|github_pat_) ]]; then
+if [[ ! "${TOKEN}" =~ ^(gho_|ghp_|ghu_|ghs_|ghr_|github_pat_)[A-Za-z0-9_]{30,}$ ]]; then
     TOKEN=""
 fi
 
@@ -36,6 +36,10 @@ if not hosts.exists(): sys.exit(0)
 m = re.search(r'oauth_token:\s*(\S+)', hosts.read_text())
 print(m.group(1) if m else '', end='')
 " 2>/dev/null || echo "")
+fi
+
+if [[ ! "${TOKEN}" =~ ^(gho_|ghp_|ghu_|ghs_|ghr_|github_pat_)[A-Za-z0-9_]{30,}$ ]]; then
+    TOKEN=""
 fi
 
 if [[ -z "${TOKEN}" ]]; then

--- a/deploy/runner-dashboard.service
+++ b/deploy/runner-dashboard.service
@@ -8,7 +8,7 @@ Type=simple
 User=dieterolson
 WorkingDirectory=/home/dieterolson/actions-runners/dashboard
 ExecStartPre=/home/dieterolson/actions-runners/dashboard/refresh-token.sh
-ExecStart=/usr/bin/python3 /home/dieterolson/actions-runners/dashboard/backend/server.py
+ExecStart=/usr/bin/python3.11 /home/dieterolson/actions-runners/dashboard/backend/server.py
 Restart=always
 RestartSec=5
 Environment=GITHUB_ORG=D-sorganization

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -57,6 +57,7 @@ FLEET_NODES_VAL=""
 HUB_URL_VAL=""
 ARTIFACT_SOURCE=""
 SCHEDULE_CONFIG_VAL="${RUNNER_SCHEDULE_CONFIG:-$HOME/.config/runner-dashboard/runner-schedule.json}"
+PYTHON_BIN="${RUNNER_DASHBOARD_PYTHON:-$(command -v python3.11 || command -v python3)}"
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
@@ -88,12 +89,17 @@ echo "Display:      ${DISPLAY_NAME_VAL}"
 echo "Role:         ${MACHINE_ROLE}"
 echo "Runners:      ${NUM_RUNNERS}"
 echo "Schedule:     ${SCHEDULE_CONFIG_VAL}"
+echo "Python:       ${PYTHON_BIN}"
 [[ -n "$FLEET_NODES_VAL" ]] && echo "Fleet nodes:  ${FLEET_NODES_VAL}"
 echo ""
 
 # ── Step 1: Install Python deps ──────────────────────────────────────────────
 header "Step 1/5: Python Dependencies"
-pip3 install --break-system-packages --quiet fastapi uvicorn psutil httpx PyYAML
+PIP_ARGS=(install --quiet fastapi uvicorn psutil httpx PyYAML)
+if "${PYTHON_BIN}" -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
+    PIP_ARGS=(install --break-system-packages --quiet fastapi uvicorn psutil httpx PyYAML)
+fi
+"${PYTHON_BIN}" -m pip "${PIP_ARGS[@]}"
 ok "fastapi, uvicorn, psutil, httpx, PyYAML installed"
 
 # ── Step 2: Deploy dashboard files ───────────────────────────────────────────
@@ -149,6 +155,9 @@ if not hosts.exists(): sys.exit(0)
 m = re.search(r'oauth_token:\s*(\S+)', hosts.read_text())
 print(m.group(1) if m else '', end='')
 " 2>/dev/null || true)
+fi
+if [[ ! "${AUTO_TOKEN}" =~ ^(gho_|ghp_|ghu_|ghs_|ghr_|github_pat_)[A-Za-z0-9_]{30,}$ ]]; then
+    AUTO_TOKEN=""
 fi
 if [[ -n "${AUTO_TOKEN}" ]]; then
     sed -i '/^GH_TOKEN=/d' "${SECRETS_FILE}"
@@ -221,7 +230,7 @@ Type=simple
 User=${USER}
 WorkingDirectory=${DEPLOY_DIR}
 ExecStartPre=${DEPLOY_DIR}/refresh-token.sh
-ExecStart=/usr/bin/python3 ${DEPLOY_DIR}/backend/server.py
+ExecStart=${PYTHON_BIN} ${DEPLOY_DIR}/backend/server.py
 Restart=always
 RestartSec=5
 Environment=GITHUB_ORG=D-sorganization

--- a/deploy/update-deployed.sh
+++ b/deploy/update-deployed.sh
@@ -50,8 +50,9 @@ ok "backend dependencies installed"
 
 if ! dry_run "backup $DEPLOY_DIR"; then
     info "Creating backup snapshot..."
-    _BACKUP=$(backup_dir "$DEPLOY_DIR")
-    [[ -n "$_BACKUP" ]] && ok "Backup: $_BACKUP"
+    _BACKUP=$(backup_dir "$DEPLOY_DIR") || fail "Backup failed; aborting update"
+    [[ -n "$_BACKUP" ]] || fail "Backup returned empty path; aborting update"
+    ok "Backup: $_BACKUP"
 fi
 
 if [[ -n "$ARTIFACT_SOURCE" ]]; then

--- a/deploy/write-deployment-metadata.sh
+++ b/deploy/write-deployment-metadata.sh
@@ -39,7 +39,7 @@ GIT_DIRTY=$([ -z "$(git -C "$SOURCE_DIR" status --porcelain)" ] && echo "false" 
 DEPLOYED_AT=$(date -Iseconds)
 HOSTNAME=$(hostname)
 ARTIFACT_SCHEMA="${RUNNER_DASHBOARD_ARTIFACT_SCHEMA:-runner-dashboard-artifact-v1}"
-PYTHON_REQUIRES="${RUNNER_DASHBOARD_PYTHON_REQUIRES:->=3.10}"
+PYTHON_REQUIRES="${RUNNER_DASHBOARD_PYTHON_REQUIRES:->=3.11}"
 SERVICE_NAME="${RUNNER_DASHBOARD_SERVICE_NAME:-runner-dashboard.service}"
 
 # Create metadata file

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -533,6 +533,34 @@
         font-size: 12px;
         border-bottom: 1px solid var(--border);
       }
+      .data-table th.sortable {
+        cursor: pointer;
+        user-select: none;
+        white-space: nowrap;
+      }
+      .data-table th.sortable:hover {
+        color: var(--text-primary);
+        background: rgba(88, 166, 255, 0.08);
+      }
+      .sort-heading {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .sort-indicator {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 14px;
+        height: 14px;
+        border-radius: 4px;
+        color: var(--text-muted);
+        font-size: 10px;
+      }
+      th.sortable.active .sort-indicator {
+        color: var(--accent-blue);
+        background: rgba(88, 166, 255, 0.12);
+      }
       .data-table td {
         padding: 8px 12px;
         border-bottom: 1px solid var(--border);
@@ -1210,7 +1238,32 @@
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.5/dist/purify.min.js"></script>
     <script>
+      window.__dashboardRenderFailed = function (message) {
+        var root = document.getElementById("root");
+        if (!root || root.childElementCount > 0) return;
+        root.innerHTML =
+          '<div style="min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px;background:#0f1117;color:#e6edf3;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">' +
+          '<div style="max-width:560px;border:1px solid #30363d;border-radius:8px;background:#161b22;padding:20px;box-shadow:0 12px 40px rgba(0,0,0,.24)">' +
+          '<h1 style="font-size:18px;margin:0 0 8px">Dashboard failed to render</h1>' +
+          '<p style="margin:0 0 12px;color:#8b949e;line-height:1.5">The backend is reachable, but the browser could not start the frontend. Hard-refresh this page, then check whether the CDN scripts are blocked.</p>' +
+          '<code style="display:block;white-space:pre-wrap;color:#f85149;font-size:12px">' +
+          String(message || "Unknown frontend error").replace(/[<>&]/g, function (c) {
+            return { "<": "&lt;", ">": "&gt;", "&": "&amp;" }[c];
+          }) +
+          "</code></div></div>";
+      };
+      window.addEventListener("error", function (event) {
+        window.__dashboardRenderFailed(event.message);
+      });
+    </script>
+    <script>
       "use strict";
+      if (typeof React === "undefined" || typeof ReactDOM === "undefined") {
+        window.__dashboardRenderFailed(
+          "React or ReactDOM did not load. Check network access to cdnjs.cloudflare.com.",
+        );
+        throw new Error("Dashboard dependencies failed to load");
+      }
       var h = React.createElement;
 
       // Configure marked with safe options (issue #7)
@@ -1639,6 +1692,91 @@
         return pa.number - pb.number;
       }
 
+      function sortStateNext(current, key) {
+        if (current && current.key === key) {
+          return { key: key, dir: current.dir === "asc" ? "desc" : "asc" };
+        }
+        return { key: key, dir: "asc" };
+      }
+
+      function normalizeSortValue(value) {
+        if (value == null) return "";
+        if (typeof value === "number") return value;
+        if (typeof value === "boolean") return value ? 1 : 0;
+        var text = String(value);
+        var asDate = Date.parse(text);
+        if (
+          !Number.isNaN(asDate) &&
+          /\d{4}-\d{2}-\d{2}|T\d{2}:/.test(text)
+        ) {
+          return asDate;
+        }
+        var numeric = Number(text.replace(/[^0-9.-]/g, ""));
+        if (text.trim() && !Number.isNaN(numeric) && /[0-9]/.test(text)) {
+          return numeric;
+        }
+        return text.toLowerCase();
+      }
+
+      function sortRows(rows, sort, accessors) {
+        if (!sort || !sort.key || !accessors || !accessors[sort.key]) {
+          return rows.slice();
+        }
+        var dir = sort.dir === "desc" ? -1 : 1;
+        return rows
+          .map(function (row, index) {
+            return { row: row, index: index };
+          })
+          .sort(function (a, b) {
+            var av = normalizeSortValue(accessors[sort.key](a.row));
+            var bv = normalizeSortValue(accessors[sort.key](b.row));
+            if (av < bv) return -1 * dir;
+            if (av > bv) return 1 * dir;
+            return a.index - b.index;
+          })
+          .map(function (entry) {
+            return entry.row;
+          });
+      }
+
+      function SortTh(p) {
+        var active = p.sort && p.sort.key === p.sortKey;
+        var dir = active ? p.sort.dir : "";
+        var props = Object.assign({}, p.thProps || {}, {
+          className:
+            ((p.thProps && p.thProps.className) || "") +
+            " sortable" +
+            (active ? " active" : ""),
+          role: "button",
+          tabIndex: 0,
+          "aria-sort": active
+            ? dir === "desc"
+              ? "descending"
+              : "ascending"
+            : "none",
+          title: "Sort by " + p.label,
+          onClick: function () {
+            p.setSort(sortStateNext(p.sort, p.sortKey));
+          },
+          onKeyDown: function (e) {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              p.setSort(sortStateNext(p.sort, p.sortKey));
+            }
+          },
+        });
+        return h(
+          "th",
+          props,
+          h(
+            "span",
+            { className: "sort-heading" },
+            p.label,
+            h("span", { className: "sort-indicator" }, active ? (dir === "desc" ? "↓" : "↑") : "↕"),
+          ),
+        );
+      }
+
       function shortSha(sha) {
         return sha ? String(sha).slice(0, 7) : "unknown";
       }
@@ -1741,6 +1879,12 @@
         var expandedState = React.useState({});
         var expanded = expandedState[0],
           setExpanded = expandedState[1];
+        var machineSortState = React.useState({ key: "machine", dir: "asc" });
+        var machineSort = machineSortState[0],
+          setMachineSort = machineSortState[1];
+        var runnerTableSortState = React.useState({ key: "number", dir: "asc" });
+        var runnerTableSort = runnerTableSortState[0],
+          setRunnerTableSort = runnerTableSortState[1];
         var on = runners.filter(function (r) {
           return r.status === "online";
         }).length;
@@ -1798,6 +1942,51 @@
           });
           if (!known) machineNodes.push(n);
         });
+        var machineAccessors = {
+          machine: function (n) {
+            return n.name;
+          },
+          reachability: function (n) {
+            return n.online ? 1 : 0;
+          },
+          runners: function (n) {
+            return (runnersByMachine[n.name] || []).filter(function (r) {
+              return r.status === "online";
+            }).length;
+          },
+          detail: function (n) {
+            return offlineReasonLabel(n.offline_reason || (n.online ? "" : "unknown"));
+          },
+          resources: function (n) {
+            return ((n.system || {}).cpu || {}).percent_1m_avg || ((n.system || {}).cpu || {}).percent || 0;
+          },
+          lastSeen: function (n) {
+            return n.last_seen || "";
+          },
+        };
+        var sortedMachineNodes = sortRows(
+          machineNodes,
+          machineSort,
+          machineAccessors,
+        );
+        var runnerAccessors = {
+          number: function (r) {
+            return parseRunnerName(r.name).number;
+          },
+          runner: function (r) {
+            return r.name;
+          },
+          state: function (r) {
+            return r.busy ? "busy" : r.status;
+          },
+          labels: function (r) {
+            return (r.labels || [])
+              .map(function (l) {
+                return l.name || l;
+              })
+              .join(", ");
+          },
+        };
         var machineCount = machineNodes.length;
         var machineOnline = machineNodes.filter(function (n) {
           return n.online;
@@ -2018,18 +2207,48 @@
                 h(
                   "tr",
                   null,
-                  h("th", null, "Machine"),
-                  h("th", null, "Reachability"),
-                  h("th", null, "Runners"),
-                  h("th", null, "Offline Detail"),
-                  h("th", null, "Resources"),
-                  h("th", null, "Last Seen"),
+                  h(SortTh, {
+                    label: "Machine",
+                    sortKey: "machine",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Reachability",
+                    sortKey: "reachability",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Runners",
+                    sortKey: "runners",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Offline Detail",
+                    sortKey: "detail",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Resources",
+                    sortKey: "resources",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Last Seen",
+                    sortKey: "lastSeen",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
                 ),
               ),
               h(
                 "tbody",
                 null,
-                machineNodes.map(function (n) {
+                sortedMachineNodes.map(function (n) {
                   var mrs = runnersByMachine[n.name] || [];
                   var onlineRunners = mrs.filter(function (r) {
                     return r.status === "online";
@@ -2206,6 +2425,11 @@
                   },
                 );
                 if (!machineRunners.length) return null;
+                var sortedMachineRunners = sortRows(
+                  machineRunners,
+                  runnerTableSort,
+                  runnerAccessors,
+                );
                 var node = nodesByName[machine.toLowerCase()] || {};
                 var sys = node.system || {};
                 var cpu = sys.cpu || {};
@@ -2295,17 +2519,38 @@
                           h(
                             "tr",
                             null,
-                            h("th", { style: { width: 54 } }, "#"),
-                            h("th", null, "Runner"),
-                            h("th", null, "State"),
-                            h("th", null, "Labels"),
+                            h(SortTh, {
+                              label: "#",
+                              sortKey: "number",
+                              sort: runnerTableSort,
+                              setSort: setRunnerTableSort,
+                              thProps: { style: { width: 54 } },
+                            }),
+                            h(SortTh, {
+                              label: "Runner",
+                              sortKey: "runner",
+                              sort: runnerTableSort,
+                              setSort: setRunnerTableSort,
+                            }),
+                            h(SortTh, {
+                              label: "State",
+                              sortKey: "state",
+                              sort: runnerTableSort,
+                              setSort: setRunnerTableSort,
+                            }),
+                            h(SortTh, {
+                              label: "Labels",
+                              sortKey: "labels",
+                              sort: runnerTableSort,
+                              setSort: setRunnerTableSort,
+                            }),
                             h("th", { style: { width: 90 } }, ""),
                           ),
                         ),
                         h(
                           "tbody",
                           null,
-                          machineRunners.map(function (r) {
+                          sortedMachineRunners.map(function (r) {
                             var parsed = parseRunnerName(r.name);
                             var st = r.busy ? "busy" : r.status;
                             var customLabels = (r.labels || [])
@@ -5091,6 +5336,12 @@
         var crcs = React.useState(null);
         var confirmRun = crcs[0],
           setConfirmRun = crcs[1];
+        var ipSortState = React.useState({ key: "runningFor", dir: "desc" });
+        var ipSort = ipSortState[0],
+          setIpSort = ipSortState[1];
+        var queueSortState = React.useState({ key: "waiting", dir: "desc" });
+        var queueSort = queueSortState[0],
+          setQueueSort = queueSortState[1];
         function elapsed(r) {
           var start = r.run_started_at || r.created_at;
           if (!start) return "-";
@@ -5115,6 +5366,37 @@
               ? "var(--accent-yellow)"
               : "inherit";
         }
+        function runRepo(r) {
+          return (r.repository && r.repository.name) || "";
+        }
+        function runRunner(r) {
+          return r.runner_name || (r.runner && r.runner.name) || "-";
+        }
+        function elapsedSeconds(r) {
+          var start = r.run_started_at || r.created_at;
+          return start
+            ? Math.round((Date.now() - new Date(start).getTime()) / 1000)
+            : 0;
+        }
+        function waitingSeconds(r) {
+          return r.created_at
+            ? Math.round((Date.now() - new Date(r.created_at).getTime()) / 1000)
+            : 0;
+        }
+        var runAccessors = {
+          workflow: function (r) {
+            return r.name;
+          },
+          repo: runRepo,
+          branch: function (r) {
+            return r.head_branch;
+          },
+          runner: runRunner,
+          runningFor: elapsedSeconds,
+          waiting: waitingSeconds,
+        };
+        var sortedIp = sortRows(ip, ipSort, runAccessors);
+        var sortedQu = sortRows(qu, queueSort, runAccessors);
         function runDiagnose() {
           setDiagLoading(true);
           setDiag(null);
@@ -5626,18 +5908,43 @@
                         "tr",
                         null,
                         h("th", null, ""),
-                        h("th", null, "Workflow"),
-                        h("th", null, "Repo"),
-                        h("th", null, "Branch"),
-                        h("th", null, "Runner"),
-                        h("th", null, "Running for"),
+                        h(SortTh, {
+                          label: "Workflow",
+                          sortKey: "workflow",
+                          sort: ipSort,
+                          setSort: setIpSort,
+                        }),
+                        h(SortTh, {
+                          label: "Repo",
+                          sortKey: "repo",
+                          sort: ipSort,
+                          setSort: setIpSort,
+                        }),
+                        h(SortTh, {
+                          label: "Branch",
+                          sortKey: "branch",
+                          sort: ipSort,
+                          setSort: setIpSort,
+                        }),
+                        h(SortTh, {
+                          label: "Runner",
+                          sortKey: "runner",
+                          sort: ipSort,
+                          setSort: setIpSort,
+                        }),
+                        h(SortTh, {
+                          label: "Running for",
+                          sortKey: "runningFor",
+                          sort: ipSort,
+                          setSort: setIpSort,
+                        }),
                         h("th", null, ""),
                       ),
                     ),
                     h(
                       "tbody",
                       null,
-                      ip.map(function (r) {
+                      sortedIp.map(function (r) {
                         var repo = (r.repository && r.repository.name) || "";
                         var key = repo + "/" + r.id;
                         var cstate = cancelling[key];
@@ -5850,17 +6157,37 @@
                           "tr",
                           null,
                           h("th", null, "#"),
-                          h("th", null, "Workflow"),
-                          h("th", null, "Repo"),
-                          h("th", null, "Branch"),
-                          h("th", null, "Waiting"),
+                          h(SortTh, {
+                            label: "Workflow",
+                            sortKey: "workflow",
+                            sort: queueSort,
+                            setSort: setQueueSort,
+                          }),
+                          h(SortTh, {
+                            label: "Repo",
+                            sortKey: "repo",
+                            sort: queueSort,
+                            setSort: setQueueSort,
+                          }),
+                          h(SortTh, {
+                            label: "Branch",
+                            sortKey: "branch",
+                            sort: queueSort,
+                            setSort: setQueueSort,
+                          }),
+                          h(SortTh, {
+                            label: "Waiting",
+                            sortKey: "waiting",
+                            sort: queueSort,
+                            setSort: setQueueSort,
+                          }),
                           h("th", null, ""),
                         ),
                       ),
                       h(
                         "tbody",
                         null,
-                        qu.map(function (r, idx) {
+                        sortedQu.map(function (r, idx) {
                           var repo = (r.repository && r.repository.name) || "";
                           var key = repo + "/" + r.id;
                           var cstate = cancelling[key];
@@ -5980,6 +6307,27 @@
         var net = sys.network || {};
         var gpus = (sys.gpu && sys.gpu.gpus) || [];
         var rprocs = sys.runner_processes || [];
+        var procSortState = React.useState({ key: "runner", dir: "asc" });
+        var procSort = procSortState[0],
+          setProcSort = procSortState[1];
+        var procAccessors = {
+          runner: function (rp) {
+            return rp.runner_num || 0;
+          },
+          status: function (rp) {
+            return rp.status || "";
+          },
+          cpu: function (rp) {
+            return rp.cpu_percent || 0;
+          },
+          memory: function (rp) {
+            return rp.memory_mb || 0;
+          },
+          procs: function (rp) {
+            return rp.process_count || 0;
+          },
+        };
+        var sortedRprocs = sortRows(rprocs, procSort, procAccessors);
         if (!cpu.percent && !mem.percent)
           return h(
             "div",
@@ -6251,17 +6599,42 @@
                     h(
                       "tr",
                       null,
-                      h("th", null, "Runner"),
-                      h("th", null, "Status"),
-                      h("th", null, "CPU %"),
-                      h("th", null, "Memory"),
-                      h("th", null, "Procs"),
+                      h(SortTh, {
+                        label: "Runner",
+                        sortKey: "runner",
+                        sort: procSort,
+                        setSort: setProcSort,
+                      }),
+                      h(SortTh, {
+                        label: "Status",
+                        sortKey: "status",
+                        sort: procSort,
+                        setSort: setProcSort,
+                      }),
+                      h(SortTh, {
+                        label: "CPU %",
+                        sortKey: "cpu",
+                        sort: procSort,
+                        setSort: setProcSort,
+                      }),
+                      h(SortTh, {
+                        label: "Memory",
+                        sortKey: "memory",
+                        sort: procSort,
+                        setSort: setProcSort,
+                      }),
+                      h(SortTh, {
+                        label: "Procs",
+                        sortKey: "procs",
+                        sort: procSort,
+                        setSort: setProcSort,
+                      }),
                     ),
                   ),
                   h(
                     "tbody",
                     null,
-                    rprocs.map(function (rp) {
+                    sortedRprocs.map(function (rp) {
                       return h(
                         "tr",
                         { key: rp.runner_num },
@@ -6307,6 +6680,9 @@
         var fs = React.useState("all");
         var filter = fs[0],
           setFilter = fs[1];
+        var sortState = React.useState({ key: "when", dir: "desc" });
+        var historySort = sortState[0],
+          setHistorySort = sortState[1];
         var filtered = runs.filter(function (r) {
           if (filter === "all") return true;
           if (filter === "success") return r.conclusion === "success";
@@ -6361,6 +6737,31 @@
             );
           return h("span", { style: { color: "var(--text-muted)" } }, "\u2022");
         }
+        var historyAccessors = {
+          status: function (r) {
+            return r.status === "in_progress" ? "running" : r.conclusion || "";
+          },
+          workflow: function (r) {
+            return r.name;
+          },
+          repository: function (r) {
+            return (r.repository || {}).name || "";
+          },
+          branch: function (r) {
+            return r.head_branch;
+          },
+          machine: function (r) {
+            return r.machine_name || "";
+          },
+          duration: function (r) {
+            if (!r.run_started_at || !r.updated_at) return 0;
+            return new Date(r.updated_at) - new Date(r.run_started_at);
+          },
+          when: function (r) {
+            return r.created_at || r.updated_at || "";
+          },
+        };
+        var sortedFiltered = sortRows(filtered, historySort, historyAccessors);
         var counts = {
           all: runs.length,
           success: runs.filter(function (r) {
@@ -6426,19 +6827,55 @@
               h(
                 "tr",
                 null,
-                h("th", { style: { width: 30 } }, ""),
-                h("th", null, "Workflow"),
-                h("th", null, "Repository"),
-                h("th", null, "Branch"),
-                h("th", null, "Machine"),
-                h("th", null, "Duration"),
-                h("th", null, "When"),
+                h(SortTh, {
+                  label: "",
+                  sortKey: "status",
+                  sort: historySort,
+                  setSort: setHistorySort,
+                  thProps: { style: { width: 30 } },
+                }),
+                h(SortTh, {
+                  label: "Workflow",
+                  sortKey: "workflow",
+                  sort: historySort,
+                  setSort: setHistorySort,
+                }),
+                h(SortTh, {
+                  label: "Repository",
+                  sortKey: "repository",
+                  sort: historySort,
+                  setSort: setHistorySort,
+                }),
+                h(SortTh, {
+                  label: "Branch",
+                  sortKey: "branch",
+                  sort: historySort,
+                  setSort: setHistorySort,
+                }),
+                h(SortTh, {
+                  label: "Machine",
+                  sortKey: "machine",
+                  sort: historySort,
+                  setSort: setHistorySort,
+                }),
+                h(SortTh, {
+                  label: "Duration",
+                  sortKey: "duration",
+                  sort: historySort,
+                  setSort: setHistorySort,
+                }),
+                h(SortTh, {
+                  label: "When",
+                  sortKey: "when",
+                  sort: historySort,
+                  setSort: setHistorySort,
+                }),
               ),
             ),
             h(
               "tbody",
               null,
-              filtered.slice(0, 50).map(function (r) {
+              sortedFiltered.slice(0, 50).map(function (r) {
                 var machine = r.machine_name || "-";
                 var mColor = MACHINE_COLORS[machine] || "var(--text-muted)";
                 var repo = (r.repository || {}).name || "?";
@@ -10144,6 +10581,36 @@
         var dpss = React.useState(null);
         var deploySuccess = dpss[0],
           setDeploySuccess = dpss[1];
+        var machineSortState = React.useState({ key: "machine", dir: "asc" });
+        var machineSort = machineSortState[0],
+          setMachineSort = machineSortState[1];
+        var machineAccessors = {
+          machine: function (m) {
+            return m.display_name || m.name;
+          },
+          role: function (m) {
+            return m.role || "node";
+          },
+          status: function (m) {
+            return m.online ? 1 : 0;
+          },
+          runners: function (m) {
+            return m.runner_count || 0;
+          },
+          busy: function (m) {
+            return m.busy_runners || 0;
+          },
+          cpu: function (m) {
+            return m.cpu_percent || 0;
+          },
+          memory: function (m) {
+            return m.memory_percent || 0;
+          },
+          lastPing: function (m) {
+            return m.last_ping || "";
+          },
+        };
+        var sortedMachines = sortRows(machines, machineSort, machineAccessors);
 
         function machineStatusColor(online) {
           return online ? "var(--accent-green)" : "var(--accent-red)";
@@ -10321,14 +10788,54 @@
                 h(
                   "tr",
                   null,
-                  h("th", null, "Machine"),
-                  h("th", null, "Role"),
-                  h("th", null, "Status"),
-                  h("th", null, "Runners"),
-                  h("th", null, "Busy"),
-                  h("th", null, "CPU %"),
-                  h("th", null, "Mem %"),
-                  h("th", null, "Last Ping"),
+                  h(SortTh, {
+                    label: "Machine",
+                    sortKey: "machine",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Role",
+                    sortKey: "role",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Status",
+                    sortKey: "status",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Runners",
+                    sortKey: "runners",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Busy",
+                    sortKey: "busy",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "CPU %",
+                    sortKey: "cpu",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Mem %",
+                    sortKey: "memory",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
+                  h(SortTh, {
+                    label: "Last Ping",
+                    sortKey: "lastPing",
+                    sort: machineSort,
+                    setSort: setMachineSort,
+                  }),
                 ),
               ),
               h(
@@ -10351,7 +10858,7 @@
                         loading ? "Loading machines…" : "No machines found.",
                       ),
                     )
-                  : machines.map(function (m) {
+                  : sortedMachines.map(function (m) {
                       return h(
                         "tr",
                         { key: m.name },

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2726,7 +2726,10 @@
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ repo: repo, run_id: runId }),
           })
-            .then(function (r) { return r.json(); })
+            .then(function (r) {
+              if (!r.ok) throw new Error("rerun failed");
+              return r.json();
+            })
             .then(function () {
               setRerunState(function (prev) {
                 var n = Object.assign({}, prev);

--- a/tests/test_deploy_hardening.py
+++ b/tests/test_deploy_hardening.py
@@ -1,0 +1,34 @@
+"""Static regression checks for deploy hardening."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).parent.parent
+_DEPLOY = _ROOT / "deploy"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_shared_deploy_lib_enables_strict_mode() -> None:
+    content = _read(_DEPLOY / "lib.sh")
+    assert "set -euo pipefail" in content
+
+
+def test_update_deployed_requires_successful_backup() -> None:
+    content = _read(_DEPLOY / "update-deployed.sh")
+    assert 'backup_dir "$DEPLOY_DIR") || fail "Backup failed; aborting update"' in content
+    assert 'fail "Backup returned empty path; aborting update"' in content
+
+
+def test_refresh_token_requires_more_than_prefix() -> None:
+    content = _read(_DEPLOY / "refresh-token.sh")
+    assert "[A-Za-z0-9_]{30,}" in content
+
+
+def test_setup_prefers_python_311_for_runtime_service() -> None:
+    content = _read(_DEPLOY / "setup.sh")
+    assert "command -v python3.11 || command -v python3" in content
+    assert "ExecStart=${PYTHON_BIN} ${DEPLOY_DIR}/backend/server.py" in content

--- a/tests/test_frontend_integrity.py
+++ b/tests/test_frontend_integrity.py
@@ -96,6 +96,17 @@ def test_tests_tab_rerun_checks_response_ok_before_triggered_state() -> None:
     assert 'throw new Error("rerun failed")' in rerun_block
 
 
+def test_runner_facing_tables_use_sortable_headers() -> None:
+    content = _read_index()
+
+    assert "function SortTh" in content
+    assert "function sortRows" in content
+    assert 'sortKey: "runner"' in content
+    assert 'sortKey: "waiting"' in content
+    assert 'sortKey: "machine"' in content
+    assert 'sortKey: "when"' in content
+
+
 # ---------------------------------------------------------------------------
 # dangerouslySetInnerHTML safety check
 # ---------------------------------------------------------------------------

--- a/tests/test_frontend_integrity.py
+++ b/tests/test_frontend_integrity.py
@@ -86,6 +86,16 @@ def test_tests_tab_function_present() -> None:
     assert "function TestsTab" in content
 
 
+def test_tests_tab_rerun_checks_response_ok_before_triggered_state() -> None:
+    content = _read_index()
+    rerun_start = content.index('fetch("/api/tests/rerun"')
+    triggered_state = content.index('n[repo] = "triggered";', rerun_start)
+    rerun_block = content[rerun_start:triggered_state]
+
+    assert "if (!r.ok)" in rerun_block
+    assert 'throw new Error("rerun failed")' in rerun_block
+
+
 # ---------------------------------------------------------------------------
 # dangerouslySetInnerHTML safety check
 # ---------------------------------------------------------------------------
@@ -108,7 +118,8 @@ def test_dangerous_set_inner_html_sanitized() -> None:
         if not (has_sanitize or has_safe_wrapper or has_safe_comment):
             violations.append(lineno + 1)
     assert not violations, (
-        f"dangerouslySetInnerHTML at line(s) {violations} has no DOMPurify.sanitize, renderMarkdown wrapper, or safety comment"
+        f"dangerouslySetInnerHTML at line(s) {violations} has no DOMPurify.sanitize, "
+        "renderMarkdown wrapper, or safety comment"
     )
 
 

--- a/tests/test_keepalive_diagnostics.py
+++ b/tests/test_keepalive_diagnostics.py
@@ -4,14 +4,27 @@ import asyncio
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
 
 import server  # noqa: E402
 
 
+def _patch_server_windows_os(monkeypatch) -> None:
+    real_os = server.os
+
+    class WindowsOs(SimpleNamespace):
+        name = "nt"
+
+        def __getattr__(self, key: str):  # noqa: ANN202
+            return getattr(real_os, key)
+
+    monkeypatch.setattr(server, "os", WindowsOs())
+
+
 def test_windows_wslconfig_path_is_checked_directly(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(server.os, "name", "nt")
+    _patch_server_windows_os(monkeypatch)
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.delenv("HOMEDRIVE", raising=False)
     monkeypatch.delenv("HOMEPATH", raising=False)
@@ -22,7 +35,7 @@ def test_windows_wslconfig_path_is_checked_directly(monkeypatch, tmp_path: Path)
 
 
 def test_systemd_keepalive_probe_is_windows_safe(monkeypatch) -> None:
-    monkeypatch.setattr(server.os, "name", "nt")
+    _patch_server_windows_os(monkeypatch)
 
     result = asyncio.run(server._inspect_systemd_keepalive())
 
@@ -31,7 +44,7 @@ def test_systemd_keepalive_probe_is_windows_safe(monkeypatch) -> None:
 
 
 def test_systemd_timer_check_is_windows_safe(monkeypatch) -> None:
-    monkeypatch.setattr(server.os, "name", "nt")
+    _patch_server_windows_os(monkeypatch)
 
     assert server._unit_active_sync("runner-scheduler.timer") is False
 


### PR DESCRIPTION
## Summary

- Treat non-OK `/api/tests/rerun` responses as frontend failures instead of marking reruns as triggered.
- Harden deploy scripts with strict mode, fatal backup failures, tighter GitHub token validation, temp-file cleanup, and Python 3.11 runtime alignment.
- Fix the Windows diagnostics test harness so Linux pytest runs are not poisoned by a global `os.name = "nt"` mutation.

## Why

The rerun UI could show success after backend rejection, and today's deployment exposed a real runtime mismatch: current dashboard code requires Python 3.11, while the installed service was still launching Python 3.10. The deploy script changes make that class of failure less likely and make partial deployments easier to avoid.

## Validation

- `pytest tests -q` -> `76 passed, 1 xfailed`
- `ruff check backend tests`
- `bash -n deploy/lib.sh deploy/update-deployed.sh deploy/refresh-token.sh deploy/configure-agent-remediation.sh deploy/setup.sh deploy/write-deployment-metadata.sh`
- `git diff --check`

Closes #57.
Addresses part of #41.
