### PR TITLE
chore(issues): introduce label-based taxonomy and agent dispatch contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,102 @@
+name: Bug
+description: Defect in existing behavior.
+title: "[BUG] "
+labels: ["type:bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What is broken
+      description: Current behavior, expected behavior, and a clear repro.
+      placeholder: |
+        **Current:** ...
+        **Expected:** ...
+        **Repro:**
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, stack traces, file:line citations.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: complexity
+    attributes:
+      label: Complexity (agent skill tier required)
+      options:
+        - trivial
+        - routine
+        - complex
+        - deep
+        - research
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - "xs (< 1 hour)"
+        - "s (< 4 hours)"
+        - "m (< 1 day)"
+        - "l (1–3 days)"
+        - "xl (> 3 days)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: judgement
+    attributes:
+      label: Judgement
+      description: Most bugs are `objective`. Flag `design` if the fix implies a behavior change.
+      options:
+        - objective
+        - preference
+        - design
+        - contested
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: flags
+    attributes:
+      label: Flags
+      options:
+        - label: "Quick win"
+          required: false
+        - label: "Panel review requested"
+          required: false
+
+  - type: input
+    id: domains
+    attributes:
+      label: Skill domains
+      placeholder: "backend"
+    validations:
+      required: true
+
+  - type: textarea
+    id: dispatch_metadata
+    attributes:
+      label: "dispatch-metadata (do not edit — agents read this)"
+      value: |
+        <!-- dispatch-metadata:v1
+        type: bug
+        complexity:
+        effort:
+        judgement: objective
+        quick_win: false
+        panel_review: false
+        domains: []
+        wave:
+        depends_on: []
+        blocks: []
+        -->
+      render: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue taxonomy reference
+    url: https://github.com/d-sorganization/runner-dashboard/blob/main/docs/issue-taxonomy.md
+    about: How issues are labeled and how agents pick work from them.
+  - name: Migration plan
+    url: https://github.com/d-sorganization/runner-dashboard/blob/main/docs/issue-migration-plan.md
+    about: Current migration status and what's coming.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,75 @@
+name: Epic
+description: Parent tracking issue. Work happens on sub-issues.
+title: "[EPIC] "
+labels: ["type:epic", "tracking"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for multi-issue initiatives. Children are linked as
+        sub-issues (not markdown checklists). Do **not** set `complexity` or
+        `effort` on an epic — those belong on the children.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+    validations:
+      required: true
+
+  - type: textarea
+    id: utility
+    attributes:
+      label: Why this matters (utility evaluation)
+      description: Concrete problems this epic solves. What we get, what we don't.
+    validations:
+      required: true
+
+  - type: textarea
+    id: design_sketch
+    attributes:
+      label: Design sketch
+      description: Non-binding. Enough for reviewers to agree on direction.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria for the epic
+      description: What "done" looks like at the epic level.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: children
+    attributes:
+      label: Proposed children (to file as sub-issues)
+      description: Freeform list. Each becomes a real sub-issue once the epic is accepted.
+    validations:
+      required: false
+
+  - type: input
+    id: domains
+    attributes:
+      label: Skill domains (roll-up)
+      placeholder: "backend, frontend, security"
+    validations:
+      required: true
+
+  - type: textarea
+    id: dispatch_metadata
+    attributes:
+      label: "dispatch-metadata (do not edit)"
+      value: |
+        <!-- dispatch-metadata:v1
+        type: epic
+        judgement: design
+        panel_review: false
+        domains: []
+        wave:
+        -->
+      render: markdown

--- a/.github/ISSUE_TEMPLATE/research.yml
+++ b/.github/ISSUE_TEMPLATE/research.yml
@@ -1,0 +1,72 @@
+name: Research / spike
+description: Investigation where the answer is unknown. Produces a decision, not a PR.
+title: "[RESEARCH] "
+labels: ["type:research", "complexity:research"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: The specific thing we are trying to answer.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why we need an answer
+      description: What downstream work this unblocks.
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverable
+    attributes:
+      label: Deliverable
+      description: What shape the answer takes. Usually a short doc or a comment on this issue.
+      placeholder: "A recommendation with tradeoffs, posted as a comment on this issue."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - "xs (< 1 hour)"
+        - "s (< 4 hours)"
+        - "m (< 1 day)"
+        - "l (1–3 days)"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: flags
+    attributes:
+      label: Flags
+      options:
+        - label: "Panel review (multi-agent opinions requested)"
+          required: false
+
+  - type: input
+    id: domains
+    attributes:
+      label: Skill domains
+      placeholder: "backend, security"
+    validations:
+      required: true
+
+  - type: textarea
+    id: dispatch_metadata
+    attributes:
+      label: "dispatch-metadata (do not edit)"
+      value: |
+        <!-- dispatch-metadata:v1
+        type: research
+        complexity: research
+        effort:
+        judgement: design
+        panel_review: false
+        domains: []
+        -->
+      render: markdown

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,132 @@
+name: Task
+description: Ordinary unit of work. Use this for most feature/fix issues.
+title: "[TASK] "
+labels: ["type:task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill in every required field. These map directly to labels and the
+        `dispatch-metadata` block at the top of the issue, which controls
+        which agents may pick up the work. See
+        [the taxonomy doc](../blob/main/docs/issue-taxonomy.md) for what
+        each field means.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What are we doing, and why.
+      placeholder: One or two paragraphs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How we know this is done.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: complexity
+    attributes:
+      label: Complexity (agent skill tier required)
+      description: |
+        `trivial` = single-file mechanical. `routine` = well-scoped, multi-file.
+        `complex` = cross-cutting, architectural awareness. `deep` = deep
+        codebase knowledge / novel design. `research` = answer unknown.
+      options:
+        - trivial
+        - routine
+        - complex
+        - deep
+        - research
+    validations:
+      required: true
+
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort (size of the work)
+      description: Independent of complexity.
+      options:
+        - "xs (< 1 hour)"
+        - "s (< 4 hours)"
+        - "m (< 1 day)"
+        - "l (1–3 days)"
+        - "xl (> 3 days)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: judgement
+    attributes:
+      label: Judgement (how much opinion is involved)
+      description: |
+        `objective` = most agents would agree on the fix. `preference` = style
+        matters but diffs are small. `design` = architectural decision —
+        panel-review before implementation. `contested` = active disagreement.
+      options:
+        - objective
+        - preference
+        - design
+        - contested
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: flags
+    attributes:
+      label: Flags
+      options:
+        - label: "Quick win (low effort, high value)"
+          required: false
+        - label: "Panel review requested before implementation"
+          required: false
+
+  - type: input
+    id: domains
+    attributes:
+      label: Skill domains
+      description: Comma-separated. E.g. `backend, security`. See taxonomy doc for the vocabulary.
+      placeholder: "backend, security"
+    validations:
+      required: true
+
+  - type: input
+    id: wave
+    attributes:
+      label: Wave (optional)
+      description: 1–5, or blank.
+      placeholder: "2"
+
+  - type: input
+    id: depends_on
+    attributes:
+      label: Depends on (optional)
+      description: Issue references, comma-separated. E.g. `#16, #17`.
+      placeholder: "#16"
+
+  - type: textarea
+    id: dispatch_metadata
+    attributes:
+      label: "dispatch-metadata (do not edit — agents read this)"
+      value: |
+        <!-- dispatch-metadata:v1
+        type: task
+        complexity:
+        effort:
+        judgement:
+        quick_win: false
+        panel_review: false
+        domains: []
+        wave:
+        depends_on: []
+        blocks: []
+        -->
+      render: markdown

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,116 @@
+# Label manifest for runner-dashboard.
+#
+# Source of truth for all labels. Apply with the `Labels Sync` workflow
+# (.github/workflows/labels-sync.yml). Existing labels not listed here are
+# left alone.
+#
+# See docs/issue-taxonomy.md for semantics.
+
+# ---------------------------------------------------------------------------
+# Type — what kind of issue this is.
+# ---------------------------------------------------------------------------
+- name: "type:epic"
+  color: "3E4B9E"
+  description: "Parent tracking issue. Children linked as sub-issues."
+- name: "type:task"
+  color: "5B7FFF"
+  description: "Ordinary unit of work."
+- name: "type:bug"
+  color: "D73A4A"
+  description: "Defect in existing behavior."
+- name: "type:security"
+  color: "B60205"
+  description: "Security finding."
+- name: "type:research"
+  color: "8B5CF6"
+  description: "Investigation or spike — answer unknown."
+- name: "type:docs"
+  color: "0E8A16"
+  description: "Documentation-only change."
+- name: "type:chore"
+  color: "C5DEF5"
+  description: "Housekeeping: deps, CI, lint, formatting."
+
+# ---------------------------------------------------------------------------
+# Complexity — the skill tier required of the agent.
+# ---------------------------------------------------------------------------
+- name: "complexity:trivial"
+  color: "C2E0C6"
+  description: "Single-file mechanical change. No judgement, no architectural awareness."
+- name: "complexity:routine"
+  color: "A2D8A2"
+  description: "Well-scoped, multi-file within one subsystem."
+- name: "complexity:complex"
+  color: "FEF2C0"
+  description: "Cross-cutting, architectural awareness needed."
+- name: "complexity:deep"
+  color: "F9A825"
+  description: "Deep codebase knowledge or novel design."
+- name: "complexity:research"
+  color: "BA68C8"
+  description: "Answer unknown; investigate and write up options first."
+
+# ---------------------------------------------------------------------------
+# Effort — size of the work, independent of complexity.
+# ---------------------------------------------------------------------------
+- name: "effort:xs"
+  color: "E6F4EA"
+  description: "< 1 hour. Typically single-PR."
+- name: "effort:s"
+  color: "CEE7D1"
+  description: "< 4 hours."
+- name: "effort:m"
+  color: "FFF2B7"
+  description: "< 1 day."
+- name: "effort:l"
+  color: "FAD1A1"
+  description: "1–3 days."
+- name: "effort:xl"
+  color: "F1948A"
+  description: "> 3 days. Should be an epic with children."
+
+# ---------------------------------------------------------------------------
+# Flags — booleans that surface specific lanes.
+# ---------------------------------------------------------------------------
+- name: "quick-win"
+  color: "2EA043"
+  description: "Low effort, high value. Safe pool for fast agents and new contributors."
+
+- name: "panel-review"
+  color: "9333EA"
+  description: "Agent panel is reviewing / should review. Do not implement from this issue."
+
+# ---------------------------------------------------------------------------
+# Judgement — dispatch gating.
+# ---------------------------------------------------------------------------
+- name: "judgement:objective"
+  color: "0366D6"
+  description: "Competent agents would agree on the correct implementation."
+- name: "judgement:preference"
+  color: "5BC0DE"
+  description: "Multiple valid approaches; style/ergonomics matter but diffs are small."
+- name: "judgement:design"
+  color: "F0AD4E"
+  description: "Architectural decision. Do not dispatch implementation until decided."
+- name: "judgement:contested"
+  color: "D9534F"
+  description: "Active disagreement. Hold — panel review required."
+
+# ---------------------------------------------------------------------------
+# Wave — execution-order buckets, used by tracking issues.
+# ---------------------------------------------------------------------------
+- name: "wave:1"
+  color: "EDEDED"
+  description: "Execution wave 1 (highest-priority remediation)."
+- name: "wave:2"
+  color: "EDEDED"
+  description: "Execution wave 2."
+- name: "wave:3"
+  color: "EDEDED"
+  description: "Execution wave 3."
+- name: "wave:4"
+  color: "EDEDED"
+  description: "Execution wave 4."
+- name: "wave:5"
+  color: "EDEDED"
+  description: "Execution wave 5 (normal cadence polish)."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -97,6 +97,24 @@
   description: "Active disagreement. Hold — panel review required."
 
 # ---------------------------------------------------------------------------
+# Rollout — label-triggered execution of migration workflows. Apply one of
+# these labels to an epic to run the corresponding workflow end-to-end.
+# See docs/issue-migration-plan.md "Label-triggered rollout" section.
+# ---------------------------------------------------------------------------
+- name: "rollout:taxonomy"
+  color: "6F42C1"
+  description: "Applying this label to the taxonomy migration epic fires the Taxonomy Rollout workflow (creates labels, previews backfill, applies if confirmed)."
+- name: "rollout:taxonomy-apply"
+  color: "22863A"
+  description: "Authorizes the Taxonomy Rollout to execute the backfill for real (not just dry-run). Apply only after reviewing the preview comment."
+- name: "rollout:in-progress"
+  color: "FBCA04"
+  description: "Automation has started executing a rollout on this issue. Do not apply manually — managed by the workflow."
+- name: "rollout:done"
+  color: "2EA043"
+  description: "A rollout workflow completed successfully against this issue. Managed by the workflow."
+
+# ---------------------------------------------------------------------------
 # Wave — execution-order buckets, used by tracking issues.
 # ---------------------------------------------------------------------------
 - name: "wave:1"

--- a/.github/scripts/issue-backfill.js
+++ b/.github/scripts/issue-backfill.js
@@ -1,0 +1,164 @@
+// Shared issue-taxonomy-backfill logic. Invoked by
+// issue-taxonomy-backfill.yml and taxonomy-rollout.yml via
+// actions/github-script.
+//
+// Two independent operations:
+//   - applyLabels(): adds the taxonomy labels listed in the manifest
+//   - applyHierarchy(): adds native sub-issue edges via GraphQL
+//
+// Both idempotent. When collectPreview is set, each operation returns an
+// array of human-readable preview lines so the caller can post a single
+// diff comment to the migration epic.
+
+const fs = require("fs");
+const yaml = require("js-yaml");
+
+const MANIFEST_PATH_DEFAULT = "docs/issue-taxonomy-backfill.yml";
+
+function loadManifest(manifestPath) {
+  const path = manifestPath || MANIFEST_PATH_DEFAULT;
+  const manifest = yaml.load(fs.readFileSync(path, "utf8"));
+  if (manifest.version !== 1) {
+    throw new Error(`Unsupported manifest version: ${manifest.version}`);
+  }
+  return manifest;
+}
+
+async function applyLabels({ github, context, core, dryRun, manifestPath, collectPreview }) {
+  const manifest = loadManifest(manifestPath);
+  const { owner, repo } = context.repo;
+  const preview = [];
+  let added = 0, already = 0, missing = 0;
+
+  for (const entry of manifest.issues) {
+    const n = entry.number;
+    const adds = entry.add || [];
+    if (adds.length === 0) continue;
+
+    let cur;
+    try {
+      const { data } = await github.rest.issues.get({
+        owner, repo, issue_number: n,
+      });
+      cur = data;
+    } catch (e) {
+      core.warning(`#${n}: ${e.message}`);
+      missing++;
+      continue;
+    }
+    if (cur.state !== "open") {
+      core.info(`#${n}: skipping (state=${cur.state})`);
+      continue;
+    }
+
+    const existing = new Set(cur.labels.map((l) => l.name || l));
+    const toAdd = adds.filter((l) => !existing.has(l));
+    if (toAdd.length === 0) {
+      already++;
+      continue;
+    }
+
+    const line = `#${n}: ${dryRun ? "WOULD ADD" : "ADD"} ${toAdd.join(", ")}`;
+    core.info(line);
+    if (collectPreview) preview.push(line);
+
+    if (!dryRun) {
+      try {
+        await github.rest.issues.addLabels({
+          owner, repo, issue_number: n, labels: toAdd,
+        });
+        added++;
+      } catch (e) {
+        core.warning(`#${n}: addLabels failed (${e.message}). Did Labels Sync run?`);
+        missing++;
+      }
+    } else {
+      added++;
+    }
+  }
+
+  core.notice(`labels: added=${added} already=${already} missing=${missing} dry_run=${dryRun}`);
+  return { added, already, missing, preview };
+}
+
+async function resolveIssueNodeId(github, owner, repo, num) {
+  const q = `
+    query($owner:String!, $repo:String!, $n:Int!) {
+      repository(owner:$owner, name:$repo) { issue(number:$n) { id } }
+    }
+  `;
+  const res = await github.graphql(q, { owner, repo, n: num });
+  return res.repository.issue && res.repository.issue.id;
+}
+
+async function applyHierarchy({ github, context, core, dryRun, manifestPath, collectPreview }) {
+  const manifest = loadManifest(manifestPath);
+  const { owner, repo } = context.repo;
+  const preview = [];
+  let added = 0, already = 0, skipped = 0;
+
+  for (const [parentStr, spec] of Object.entries(manifest.parents || {})) {
+    const parentNum = Number(parentStr);
+    const parentId = await resolveIssueNodeId(github, owner, repo, parentNum);
+    if (!parentId) {
+      core.warning(`parent #${parentNum} not found; skipping`);
+      continue;
+    }
+
+    // Existing sub-issues on this parent.
+    const existingQ = `
+      query($id:ID!) {
+        node(id:$id) { ... on Issue { subIssues(first:100) { nodes { number } } } }
+      }
+    `;
+    let existingNums = new Set();
+    try {
+      const existingRes = await github.graphql(existingQ, { id: parentId });
+      existingNums = new Set(
+        (existingRes.node && existingRes.node.subIssues &&
+          existingRes.node.subIssues.nodes || []).map((x) => x.number),
+      );
+    } catch (e) {
+      core.warning(`subIssues query on #${parentNum} failed: ${e.message}`);
+    }
+
+    for (const childNum of spec.children || []) {
+      if (existingNums.has(childNum)) {
+        already++;
+        continue;
+      }
+      const childId = await resolveIssueNodeId(github, owner, repo, childNum);
+      if (!childId) {
+        core.warning(`child #${childNum} not found; skipping`);
+        skipped++;
+        continue;
+      }
+
+      const line = `#${parentNum} -> #${childNum}: ${dryRun ? "WOULD LINK" : "LINK"}`;
+      core.info(line);
+      if (collectPreview) preview.push(line);
+
+      if (!dryRun) {
+        const mut = `
+          mutation($parentId:ID!, $childId:ID!) {
+            addSubIssue(input:{issueId:$parentId, subIssueId:$childId}) { issue { number } }
+          }
+        `;
+        try {
+          await github.graphql(mut, { parentId, childId });
+          added++;
+        } catch (e) {
+          core.warning(`link #${parentNum} -> #${childNum} failed: ${e.message}`);
+          skipped++;
+        }
+      } else {
+        added++;
+      }
+    }
+  }
+
+  core.notice(`hierarchy: added=${added} already=${already} skipped=${skipped} dry_run=${dryRun}`);
+  return { added, already, skipped, preview };
+}
+
+module.exports = { applyLabels, applyHierarchy, loadManifest };

--- a/.github/scripts/labels-sync.js
+++ b/.github/scripts/labels-sync.js
@@ -1,0 +1,67 @@
+// Shared label-sync logic. Invoked by labels-sync.yml and
+// taxonomy-rollout.yml via actions/github-script.
+//
+// Reconciles .github/labels.yml with the repo's labels:
+//   - creates labels listed in the manifest that don't exist yet
+//   - updates color/description when they drift
+//   - leaves unrelated existing labels alone
+//
+// Returns counters for the invoking workflow to log.
+
+const fs = require("fs");
+const yaml = require("js-yaml");
+
+async function sync({ github, context, core, dryRun, manifestPath }) {
+  const path = manifestPath || ".github/labels.yml";
+  const manifest = yaml.load(fs.readFileSync(path, "utf8"));
+  const { owner, repo } = context.repo;
+
+  const existing = new Map();
+  for await (const res of github.paginate.iterator(
+    github.rest.issues.listLabelsForRepo,
+    { owner, repo, per_page: 100 },
+  )) {
+    for (const l of res.data) existing.set(l.name, l);
+  }
+
+  let created = 0, updated = 0, skipped = 0;
+
+  for (const entry of manifest) {
+    const cur = existing.get(entry.name);
+    if (!cur) {
+      core.info(`CREATE ${entry.name}`);
+      if (!dryRun) {
+        await github.rest.issues.createLabel({
+          owner, repo,
+          name: entry.name,
+          color: entry.color,
+          description: entry.description || "",
+        });
+      }
+      created++;
+    } else if (
+      cur.color.toLowerCase() !== entry.color.toLowerCase() ||
+      (cur.description || "") !== (entry.description || "")
+    ) {
+      core.info(`UPDATE ${entry.name}`);
+      if (!dryRun) {
+        await github.rest.issues.updateLabel({
+          owner, repo,
+          name: entry.name,
+          color: entry.color,
+          description: entry.description || "",
+        });
+      }
+      updated++;
+    } else {
+      skipped++;
+    }
+  }
+
+  core.notice(
+    `labels-sync: created=${created} updated=${updated} skipped=${skipped} dry_run=${dryRun}`,
+  );
+  return { created, updated, skipped };
+}
+
+module.exports = { sync };

--- a/.github/scripts/panel-review.js
+++ b/.github/scripts/panel-review.js
@@ -1,0 +1,181 @@
+// Panel review helper, called from .github/workflows/agent-panel-review.yml.
+//
+// Responsibilities:
+//
+//   1. postBrief(issue)
+//      Posts a single "dispatch brief" comment on an issue labeled
+//      `panel-review`. The brief tells panelists what to weigh in on and
+//      the comment format to use. Idempotent: if a brief already exists
+//      on the issue, it is not re-posted.
+//
+//   2. sweep({ specificIssueNumber, mode })
+//      Iterates all open issues labeled `panel-review` (or just the one
+//      in specificIssueNumber) and:
+//        - posts a brief if one is missing (mode = brief or both)
+//        - tallies panel-opinion comments and posts a summary when enough
+//          opinions exist (mode = summarize or both)
+//
+// The workflow does not invoke panelists. Panelists are agent workflows
+// that subscribe to issue comments or labels and respond on their own
+// cadence. This script only curates the conversation.
+
+const BRIEF_MARKER = "<!-- panel-review:brief:v1 -->";
+const SUMMARY_MARKER = "<!-- panel-review:summary:v1 -->";
+const OPINION_MARKER_RE = /<!--\s*panel-opinion:v1\s+([^>]+?)\s*-->/;
+const MIN_OPINIONS_FOR_SUMMARY = 2;
+
+async function postBrief({ github, context, core, issue }) {
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(
+    github.rest.issues.listComments,
+    { owner, repo, issue_number: issue.number, per_page: 100 },
+  );
+
+  if (comments.some((c) => c.body && c.body.includes(BRIEF_MARKER))) {
+    core.info(`Brief already exists on #${issue.number}`);
+    return;
+  }
+
+  const brief = [
+    BRIEF_MARKER,
+    "## Panel review requested",
+    "",
+    "This issue is flagged `panel-review`. Multiple agents are invited to",
+    "weigh in **before** anyone opens a PR. Implementation is blocked until",
+    "a human removes the `panel-review` label and sets a non-`design` /",
+    "non-`contested` judgement label.",
+    "",
+    "### How to respond",
+    "",
+    "Post **one** comment in this format:",
+    "",
+    "````",
+    "<!-- panel-opinion:v1 agent=<tier> stance=support|oppose|modify -->",
+    "## Opinion",
+    "…",
+    "## Suggested approach",
+    "…",
+    "## Risks",
+    "…",
+    "````",
+    "",
+    "`tier` is the agent's skill tier (`tier-1`, `tier-2`, `tier-3`, or",
+    "`research`). `stance` is one of `support`, `oppose`, `modify`.",
+    "",
+    "See [docs/issue-taxonomy.md](../blob/main/docs/issue-taxonomy.md#panel-review)",
+    "for the full contract.",
+  ].join("\n");
+
+  await github.rest.issues.createComment({
+    owner, repo, issue_number: issue.number, body: brief,
+  });
+  core.info(`Posted brief on #${issue.number}`);
+}
+
+function parseOpinion(body) {
+  if (!body) return null;
+  const m = body.match(OPINION_MARKER_RE);
+  if (!m) return null;
+  const attrs = {};
+  for (const pair of m[1].split(/\s+/)) {
+    const eq = pair.indexOf("=");
+    if (eq > 0) attrs[pair.slice(0, eq)] = pair.slice(eq + 1);
+  }
+  return attrs;
+}
+
+async function summarize({ github, context, core, issue }) {
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(
+    github.rest.issues.listComments,
+    { owner, repo, issue_number: issue.number, per_page: 100 },
+  );
+
+  const opinions = [];
+  for (const c of comments) {
+    const parsed = parseOpinion(c.body);
+    if (parsed) opinions.push({ parsed, author: c.user && c.user.login });
+  }
+
+  if (opinions.length < MIN_OPINIONS_FOR_SUMMARY) {
+    core.info(
+      `#${issue.number} has ${opinions.length} opinions; need ${MIN_OPINIONS_FOR_SUMMARY}`,
+    );
+    return;
+  }
+
+  // Skip if we already posted a summary for this opinion count.
+  const existingSummary = comments.find(
+    (c) => c.body && c.body.includes(SUMMARY_MARKER),
+  );
+  if (existingSummary) {
+    const tag = `(opinions=${opinions.length})`;
+    if (existingSummary.body.includes(tag)) {
+      core.info(`#${issue.number} already has summary for ${opinions.length} opinions`);
+      return;
+    }
+  }
+
+  const tally = opinions.reduce((acc, o) => {
+    const s = (o.parsed.stance || "unknown").toLowerCase();
+    acc[s] = (acc[s] || 0) + 1;
+    return acc;
+  }, {});
+
+  const lines = [
+    SUMMARY_MARKER,
+    `## Panel summary (opinions=${opinions.length})`,
+    "",
+    "| Stance | Count |",
+    "|---|---|",
+    ...Object.entries(tally)
+      .sort((a, b) => b[1] - a[1])
+      .map(([stance, n]) => `| \`${stance}\` | ${n} |`),
+    "",
+    "### Panelists",
+    ...opinions.map(
+      (o) =>
+        `- @${o.author || "unknown"} — \`${o.parsed.agent || "?"}\`, stance \`${o.parsed.stance || "?"}\``,
+    ),
+    "",
+    "Once the team has picked a direction, remove the `panel-review` label",
+    "and set `judgement:objective` / `judgement:preference` to unblock",
+    "implementation.",
+  ];
+
+  await github.rest.issues.createComment({
+    owner, repo, issue_number: issue.number, body: lines.join("\n"),
+  });
+  core.info(`Posted summary on #${issue.number}`);
+}
+
+async function sweep({ github, context, core, specificIssueNumber, mode }) {
+  const { owner, repo } = context.repo;
+
+  let issues;
+  if (specificIssueNumber) {
+    const { data } = await github.rest.issues.get({
+      owner, repo, issue_number: specificIssueNumber,
+    });
+    issues = [data];
+  } else {
+    issues = await github.paginate(github.rest.issues.listForRepo, {
+      owner, repo, state: "open", labels: "panel-review", per_page: 100,
+    });
+  }
+
+  core.info(`Sweeping ${issues.length} panel-review issue(s) in mode=${mode}`);
+
+  for (const issue of issues) {
+    if (issue.pull_request) continue; // listForRepo mixes in PRs
+
+    if (mode === "brief" || mode === "both") {
+      await postBrief({ github, context, core, issue });
+    }
+    if (mode === "summarize" || mode === "both") {
+      await summarize({ github, context, core, issue });
+    }
+  }
+}
+
+module.exports = { postBrief, summarize, sweep };

--- a/.github/workflows/agent-panel-review.yml
+++ b/.github/workflows/agent-panel-review.yml
@@ -1,0 +1,88 @@
+name: Agent Panel Review
+
+# Collects multi-agent opinions on judgement-heavy issues before anyone
+# implements them.
+#
+# An issue becomes a candidate when it carries the `panel-review` label.
+# Typical triggers are `judgement:design` or `judgement:contested`, but the
+# author can add `panel-review` to any issue where they want multi-agent
+# input.
+#
+# The workflow itself does not invoke the panelists — it prepares a dispatch
+# brief and posts it to the issue. The actual panelists are the agent
+# workflows configured per-repo (Jules worker personas, Claude Code runs,
+# Codex, etc.). Each panelist responds by posting a comment in the format
+# documented in docs/issue-taxonomy.md ("Panel review" section).
+#
+# When the scheduled sweep finds a panel-review issue with enough opinions,
+# it posts a summary tally and leaves the label in place until a human (or
+# the author) removes it.
+
+on:
+  schedule:
+    # Weekly sweep. Panelists are slow; daily creates noise.
+    - cron: "0 14 * * 1" # Monday 14:00 UTC
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Specific issue to review. Leave blank to sweep all panel-review issues."
+        required: false
+        type: string
+      mode:
+        description: "brief = post dispatch brief; summarize = tally existing opinions; both."
+        required: false
+        default: "both"
+        type: choice
+        options:
+          - brief
+          - summarize
+          - both
+  issues:
+    # When someone adds the panel-review label, post a brief immediately.
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: agent-panel-review
+  cancel-in-progress: false
+
+jobs:
+  on-demand-label:
+    # Fast path: someone just applied `panel-review` to an issue.
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.label.name == 'panel-review'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/scripts/panel-review.js');
+            await script.postBrief({
+              github, context, core,
+              issue: context.payload.issue,
+            });
+
+  sweep:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          MODE: ${{ inputs.mode || 'both' }}
+        with:
+          script: |
+            const script = require('./.github/scripts/panel-review.js');
+            await script.sweep({
+              github, context, core,
+              specificIssueNumber: process.env.ISSUE_NUMBER
+                ? Number(process.env.ISSUE_NUMBER)
+                : null,
+              mode: process.env.MODE || 'both',
+            });

--- a/.github/workflows/issue-taxonomy-backfill.yml
+++ b/.github/workflows/issue-taxonomy-backfill.yml
@@ -1,16 +1,13 @@
 name: Issue Taxonomy Backfill
 
 # Applies the bulk backfill manifest (docs/issue-taxonomy-backfill.yml) to
-# existing issues. Two operations:
+# existing issues:
+#   - adds taxonomy labels (REST)
+#   - adds native sub-issue edges (GraphQL)
 #
-#   1. Add taxonomy labels to each listed issue (idempotent — won't add
-#      duplicates, won't remove existing labels).
-#   2. Attach sub-issue parent/child relationships declared in the
-#      manifest's `parents` section, via GraphQL.
-#
-# Safe to run multiple times. Labels must already exist in the repo
-# (run Labels Sync first). Prints a summary and fails if any issue
-# reference in the manifest is closed / missing.
+# Idempotent. Safe to run multiple times. Labels must already exist in
+# the repo (run Labels Sync first, or use the Taxonomy Rollout workflow
+# which chains both).
 
 on:
   workflow_dispatch:
@@ -20,25 +17,33 @@ on:
         required: false
         default: "true"
         type: choice
-        options:
-          - "true"
-          - "false"
+        options: ["true", "false"]
       only_labels:
         description: "Apply only labels, skip sub-issue linking."
         required: false
         default: "false"
         type: choice
-        options:
-          - "true"
-          - "false"
+        options: ["true", "false"]
       only_hierarchy:
         description: "Apply only sub-issue hierarchy, skip labels."
         required: false
         default: "false"
         type: choice
-        options:
-          - "true"
-          - "false"
+        options: ["true", "false"]
+  workflow_call:
+    inputs:
+      dry_run:
+        required: false
+        default: "true"
+        type: string
+      only_labels:
+        required: false
+        default: "false"
+        type: string
+      only_hierarchy:
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   issues: write
@@ -65,158 +70,14 @@ jobs:
           ONLY_HIERARCHY: ${{ inputs.only_hierarchy }}
         with:
           script: |
-            const fs = require('fs');
-            const yaml = require('js-yaml');
-
-            const manifest = yaml.load(
-              fs.readFileSync('docs/issue-taxonomy-backfill.yml', 'utf8')
-            );
+            const backfill = require('./.github/scripts/issue-backfill.js');
             const dry = process.env.DRY_RUN === 'true';
             const onlyLabels = process.env.ONLY_LABELS === 'true';
             const onlyHierarchy = process.env.ONLY_HIERARCHY === 'true';
-            const { owner, repo } = context.repo;
-
-            // ---------- Validate manifest -----------------------------
-            if (manifest.version !== 1) {
-              core.setFailed(`Unsupported manifest version: ${manifest.version}`);
-              return;
-            }
-
-            // ---------- Collect existing labels on each issue ---------
-            const labelApplyCount = { added: 0, already: 0, missing: 0 };
 
             if (!onlyHierarchy) {
-              for (const entry of manifest.issues) {
-                const n = entry.number;
-                const adds = entry.add || [];
-                if (adds.length === 0) continue;
-
-                let cur;
-                try {
-                  const { data } = await github.rest.issues.get({
-                    owner, repo, issue_number: n,
-                  });
-                  cur = data;
-                } catch (e) {
-                  core.warning(`#${n}: ${e.message}`);
-                  labelApplyCount.missing++;
-                  continue;
-                }
-                if (cur.state !== 'open') {
-                  core.info(`#${n}: skipping (state=${cur.state})`);
-                  continue;
-                }
-
-                const existing = new Set(cur.labels.map((l) => l.name || l));
-                const toAdd = adds.filter((l) => !existing.has(l));
-                if (toAdd.length === 0) {
-                  core.info(`#${n}: all labels already present`);
-                  labelApplyCount.already++;
-                  continue;
-                }
-
-                core.info(
-                  `#${n}: ${dry ? 'WOULD ADD' : 'ADDING'} ${toAdd.join(', ')}`,
-                );
-                if (!dry) {
-                  try {
-                    await github.rest.issues.addLabels({
-                      owner, repo, issue_number: n, labels: toAdd,
-                    });
-                    labelApplyCount.added++;
-                  } catch (e) {
-                    core.warning(
-                      `#${n}: addLabels failed (${e.message}). Did Labels Sync run?`,
-                    );
-                    labelApplyCount.missing++;
-                  }
-                } else {
-                  labelApplyCount.added++;
-                }
-              }
+              await backfill.applyLabels({ github, context, core, dryRun: dry });
             }
-
-            // ---------- Sub-issue hierarchy via GraphQL ---------------
-            const hierarchyCount = { added: 0, already: 0, skipped: 0 };
-
             if (!onlyLabels) {
-              // Resolve a cache of issueNumber -> GraphQL node id.
-              const resolveId = async (num) => {
-                const q = `
-                  query($owner:String!,$repo:String!,$n:Int!) {
-                    repository(owner:$owner, name:$repo) {
-                      issue(number:$n) { id }
-                    }
-                  }
-                `;
-                const res = await github.graphql(q, { owner, repo, n: num });
-                return res.repository.issue && res.repository.issue.id;
-              };
-
-              for (const [parentStr, spec] of Object.entries(manifest.parents || {})) {
-                const parentNum = Number(parentStr);
-                const parentId = await resolveId(parentNum);
-                if (!parentId) {
-                  core.warning(`parent #${parentNum} not found; skipping`);
-                  continue;
-                }
-
-                // Fetch existing sub-issues to avoid re-adding.
-                const existingQ = `
-                  query($id:ID!) {
-                    node(id:$id) {
-                      ... on Issue {
-                        subIssues(first:100) { nodes { number } }
-                      }
-                    }
-                  }
-                `;
-                const existingRes = await github.graphql(existingQ, { id: parentId });
-                const existingNums = new Set(
-                  (existingRes.node && existingRes.node.subIssues &&
-                   existingRes.node.subIssues.nodes || []).map((x) => x.number),
-                );
-
-                for (const childNum of spec.children || []) {
-                  if (existingNums.has(childNum)) {
-                    core.info(`#${parentNum} -> #${childNum}: already linked`);
-                    hierarchyCount.already++;
-                    continue;
-                  }
-                  const childId = await resolveId(childNum);
-                  if (!childId) {
-                    core.warning(`child #${childNum} not found; skipping`);
-                    hierarchyCount.skipped++;
-                    continue;
-                  }
-
-                  core.info(
-                    `#${parentNum} -> #${childNum}: ${dry ? 'WOULD LINK' : 'LINKING'}`,
-                  );
-                  if (!dry) {
-                    const mut = `
-                      mutation($parentId:ID!, $childId:ID!) {
-                        addSubIssue(input:{issueId:$parentId, subIssueId:$childId}) {
-                          issue { number }
-                        }
-                      }
-                    `;
-                    try {
-                      await github.graphql(mut, { parentId, childId });
-                      hierarchyCount.added++;
-                    } catch (e) {
-                      core.warning(
-                        `link #${parentNum} -> #${childNum} failed: ${e.message}`,
-                      );
-                      hierarchyCount.skipped++;
-                    }
-                  } else {
-                    hierarchyCount.added++;
-                  }
-                }
-              }
+              await backfill.applyHierarchy({ github, context, core, dryRun: dry });
             }
-
-            core.notice(
-              `backfill: labels(added=${labelApplyCount.added} already=${labelApplyCount.already} missing=${labelApplyCount.missing}) hierarchy(added=${hierarchyCount.added} already=${hierarchyCount.already} skipped=${hierarchyCount.skipped}) dry_run=${dry}`,
-            );

--- a/.github/workflows/issue-taxonomy-backfill.yml
+++ b/.github/workflows/issue-taxonomy-backfill.yml
@@ -1,0 +1,222 @@
+name: Issue Taxonomy Backfill
+
+# Applies the bulk backfill manifest (docs/issue-taxonomy-backfill.yml) to
+# existing issues. Two operations:
+#
+#   1. Add taxonomy labels to each listed issue (idempotent — won't add
+#      duplicates, won't remove existing labels).
+#   2. Attach sub-issue parent/child relationships declared in the
+#      manifest's `parents` section, via GraphQL.
+#
+# Safe to run multiple times. Labels must already exist in the repo
+# (run Labels Sync first). Prints a summary and fails if any issue
+# reference in the manifest is closed / missing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the planned changes without applying them."
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      only_labels:
+        description: "Apply only labels, skip sub-issue linking."
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      only_hierarchy:
+        description: "Apply only sub-issue hierarchy, skip labels."
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: issue-taxonomy-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install js-yaml
+        run: npm install --no-save js-yaml@4
+
+      - name: Apply backfill manifest
+        uses: actions/github-script@v7
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          ONLY_LABELS: ${{ inputs.only_labels }}
+          ONLY_HIERARCHY: ${{ inputs.only_hierarchy }}
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            const manifest = yaml.load(
+              fs.readFileSync('docs/issue-taxonomy-backfill.yml', 'utf8')
+            );
+            const dry = process.env.DRY_RUN === 'true';
+            const onlyLabels = process.env.ONLY_LABELS === 'true';
+            const onlyHierarchy = process.env.ONLY_HIERARCHY === 'true';
+            const { owner, repo } = context.repo;
+
+            // ---------- Validate manifest -----------------------------
+            if (manifest.version !== 1) {
+              core.setFailed(`Unsupported manifest version: ${manifest.version}`);
+              return;
+            }
+
+            // ---------- Collect existing labels on each issue ---------
+            const labelApplyCount = { added: 0, already: 0, missing: 0 };
+
+            if (!onlyHierarchy) {
+              for (const entry of manifest.issues) {
+                const n = entry.number;
+                const adds = entry.add || [];
+                if (adds.length === 0) continue;
+
+                let cur;
+                try {
+                  const { data } = await github.rest.issues.get({
+                    owner, repo, issue_number: n,
+                  });
+                  cur = data;
+                } catch (e) {
+                  core.warning(`#${n}: ${e.message}`);
+                  labelApplyCount.missing++;
+                  continue;
+                }
+                if (cur.state !== 'open') {
+                  core.info(`#${n}: skipping (state=${cur.state})`);
+                  continue;
+                }
+
+                const existing = new Set(cur.labels.map((l) => l.name || l));
+                const toAdd = adds.filter((l) => !existing.has(l));
+                if (toAdd.length === 0) {
+                  core.info(`#${n}: all labels already present`);
+                  labelApplyCount.already++;
+                  continue;
+                }
+
+                core.info(
+                  `#${n}: ${dry ? 'WOULD ADD' : 'ADDING'} ${toAdd.join(', ')}`,
+                );
+                if (!dry) {
+                  try {
+                    await github.rest.issues.addLabels({
+                      owner, repo, issue_number: n, labels: toAdd,
+                    });
+                    labelApplyCount.added++;
+                  } catch (e) {
+                    core.warning(
+                      `#${n}: addLabels failed (${e.message}). Did Labels Sync run?`,
+                    );
+                    labelApplyCount.missing++;
+                  }
+                } else {
+                  labelApplyCount.added++;
+                }
+              }
+            }
+
+            // ---------- Sub-issue hierarchy via GraphQL ---------------
+            const hierarchyCount = { added: 0, already: 0, skipped: 0 };
+
+            if (!onlyLabels) {
+              // Resolve a cache of issueNumber -> GraphQL node id.
+              const resolveId = async (num) => {
+                const q = `
+                  query($owner:String!,$repo:String!,$n:Int!) {
+                    repository(owner:$owner, name:$repo) {
+                      issue(number:$n) { id }
+                    }
+                  }
+                `;
+                const res = await github.graphql(q, { owner, repo, n: num });
+                return res.repository.issue && res.repository.issue.id;
+              };
+
+              for (const [parentStr, spec] of Object.entries(manifest.parents || {})) {
+                const parentNum = Number(parentStr);
+                const parentId = await resolveId(parentNum);
+                if (!parentId) {
+                  core.warning(`parent #${parentNum} not found; skipping`);
+                  continue;
+                }
+
+                // Fetch existing sub-issues to avoid re-adding.
+                const existingQ = `
+                  query($id:ID!) {
+                    node(id:$id) {
+                      ... on Issue {
+                        subIssues(first:100) { nodes { number } }
+                      }
+                    }
+                  }
+                `;
+                const existingRes = await github.graphql(existingQ, { id: parentId });
+                const existingNums = new Set(
+                  (existingRes.node && existingRes.node.subIssues &&
+                   existingRes.node.subIssues.nodes || []).map((x) => x.number),
+                );
+
+                for (const childNum of spec.children || []) {
+                  if (existingNums.has(childNum)) {
+                    core.info(`#${parentNum} -> #${childNum}: already linked`);
+                    hierarchyCount.already++;
+                    continue;
+                  }
+                  const childId = await resolveId(childNum);
+                  if (!childId) {
+                    core.warning(`child #${childNum} not found; skipping`);
+                    hierarchyCount.skipped++;
+                    continue;
+                  }
+
+                  core.info(
+                    `#${parentNum} -> #${childNum}: ${dry ? 'WOULD LINK' : 'LINKING'}`,
+                  );
+                  if (!dry) {
+                    const mut = `
+                      mutation($parentId:ID!, $childId:ID!) {
+                        addSubIssue(input:{issueId:$parentId, subIssueId:$childId}) {
+                          issue { number }
+                        }
+                      }
+                    `;
+                    try {
+                      await github.graphql(mut, { parentId, childId });
+                      hierarchyCount.added++;
+                    } catch (e) {
+                      core.warning(
+                        `link #${parentNum} -> #${childNum} failed: ${e.message}`,
+                      );
+                      hierarchyCount.skipped++;
+                    }
+                  } else {
+                    hierarchyCount.added++;
+                  }
+                }
+              }
+            }
+
+            core.notice(
+              `backfill: labels(added=${labelApplyCount.added} already=${labelApplyCount.already} missing=${labelApplyCount.missing}) hierarchy(added=${hierarchyCount.added} already=${hierarchyCount.already} skipped=${hierarchyCount.skipped}) dry_run=${dry}`,
+            );

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,99 @@
+name: Labels Sync
+
+# Applies the label manifest in .github/labels.yml to the repository.
+#
+# Idempotent: creates missing labels, updates color/description of existing
+# ones, and leaves labels not listed in the manifest alone (so the existing
+# `security`, `backend`, `critical`, etc. labels are preserved).
+#
+# Run manually after editing labels.yml. Not scheduled — label changes should
+# be intentional.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the diff without applying changes."
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install js-yaml
+        run: npm install --no-save js-yaml@4
+
+      - name: Sync labels
+        uses: actions/github-script@v7
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('js-yaml');
+
+            const manifest = yaml.load(
+              fs.readFileSync('.github/labels.yml', 'utf8')
+            );
+            const dryRun = process.env.DRY_RUN === 'true';
+
+            const { owner, repo } = context.repo;
+
+            // Page through existing labels.
+            const existing = new Map();
+            for await (const res of github.paginate.iterator(
+              github.rest.issues.listLabelsForRepo,
+              { owner, repo, per_page: 100 }
+            )) {
+              for (const l of res.data) existing.set(l.name, l);
+            }
+
+            let created = 0, updated = 0, skipped = 0;
+
+            for (const entry of manifest) {
+              const cur = existing.get(entry.name);
+              if (!cur) {
+                core.info(`CREATE ${entry.name}`);
+                if (!dryRun) {
+                  await github.rest.issues.createLabel({
+                    owner, repo,
+                    name: entry.name,
+                    color: entry.color,
+                    description: entry.description || '',
+                  });
+                }
+                created++;
+              } else if (
+                cur.color.toLowerCase() !== entry.color.toLowerCase() ||
+                (cur.description || '') !== (entry.description || '')
+              ) {
+                core.info(`UPDATE ${entry.name}`);
+                if (!dryRun) {
+                  await github.rest.issues.updateLabel({
+                    owner, repo,
+                    name: entry.name,
+                    color: entry.color,
+                    description: entry.description || '',
+                  });
+                }
+                updated++;
+              } else {
+                skipped++;
+              }
+            }
+
+            core.notice(
+              `labels-sync: created=${created} updated=${updated} skipped=${skipped} dry_run=${dryRun}`
+            );
+

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -3,11 +3,11 @@ name: Labels Sync
 # Applies the label manifest in .github/labels.yml to the repository.
 #
 # Idempotent: creates missing labels, updates color/description of existing
-# ones, and leaves labels not listed in the manifest alone (so the existing
-# `security`, `backend`, `critical`, etc. labels are preserved).
+# ones, and leaves labels not listed in the manifest alone (so the
+# existing `security`, `backend`, `critical`, etc. labels are preserved).
 #
-# Run manually after editing labels.yml. Not scheduled — label changes should
-# be intentional.
+# This workflow exists as a stand-alone admin tool (workflow_dispatch) and
+# as a callable building block (workflow_call) used by taxonomy-rollout.yml.
 
 on:
   workflow_dispatch:
@@ -17,9 +17,13 @@ on:
         required: false
         default: "false"
         type: choice
-        options:
-          - "true"
-          - "false"
+        options: ["true", "false"]
+  workflow_call:
+    inputs:
+      dry_run:
+        required: false
+        default: "false"
+        type: string
 
 permissions:
   issues: write
@@ -40,60 +44,8 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         with:
           script: |
-            const fs = require('fs');
-            const yaml = require('js-yaml');
-
-            const manifest = yaml.load(
-              fs.readFileSync('.github/labels.yml', 'utf8')
-            );
-            const dryRun = process.env.DRY_RUN === 'true';
-
-            const { owner, repo } = context.repo;
-
-            // Page through existing labels.
-            const existing = new Map();
-            for await (const res of github.paginate.iterator(
-              github.rest.issues.listLabelsForRepo,
-              { owner, repo, per_page: 100 }
-            )) {
-              for (const l of res.data) existing.set(l.name, l);
-            }
-
-            let created = 0, updated = 0, skipped = 0;
-
-            for (const entry of manifest) {
-              const cur = existing.get(entry.name);
-              if (!cur) {
-                core.info(`CREATE ${entry.name}`);
-                if (!dryRun) {
-                  await github.rest.issues.createLabel({
-                    owner, repo,
-                    name: entry.name,
-                    color: entry.color,
-                    description: entry.description || '',
-                  });
-                }
-                created++;
-              } else if (
-                cur.color.toLowerCase() !== entry.color.toLowerCase() ||
-                (cur.description || '') !== (entry.description || '')
-              ) {
-                core.info(`UPDATE ${entry.name}`);
-                if (!dryRun) {
-                  await github.rest.issues.updateLabel({
-                    owner, repo,
-                    name: entry.name,
-                    color: entry.color,
-                    description: entry.description || '',
-                  });
-                }
-                updated++;
-              } else {
-                skipped++;
-              }
-            }
-
-            core.notice(
-              `labels-sync: created=${created} updated=${updated} skipped=${skipped} dry_run=${dryRun}`
-            );
-
+            const { sync } = require('./.github/scripts/labels-sync.js');
+            await sync({
+              github, context, core,
+              dryRun: process.env.DRY_RUN === 'true',
+            });

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -24,6 +24,13 @@ on:
         required: false
         default: "false"
         type: string
+  # Auto-sync on changes to the manifest itself. Keeps the repo's labels
+  # in lock-step with .github/labels.yml without manual workflow_dispatch.
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/scripts/labels-sync.js
 
 permissions:
   issues: write

--- a/.github/workflows/taxonomy-rollout.yml
+++ b/.github/workflows/taxonomy-rollout.yml
@@ -1,0 +1,296 @@
+name: Taxonomy Rollout
+
+# Label-triggered, end-to-end rollout of the issue taxonomy migration.
+#
+# Normal flow:
+#
+#   1. Apply the `rollout:taxonomy` label to the migration tracking epic
+#      (issue #65).
+#   2. This workflow fires. It:
+#      - swaps the trigger label for `rollout:in-progress` (prevents
+#        double-fires)
+#      - creates / updates the label set from .github/labels.yml
+#      - runs the backfill manifest in dry-run mode
+#      - posts the preview as a comment on the epic
+#   3. A human reviews the preview. If it looks right, they apply
+#      `rollout:taxonomy-apply` to the same epic.
+#   4. This workflow fires again on that label. It:
+#      - runs the backfill for real
+#      - posts a completion summary
+#      - sets `rollout:done` and removes the in-progress/apply labels
+#
+# Manual overrides exist via workflow_dispatch. The whole chain is
+# idempotent and reversible.
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      epic_number:
+        description: "Issue number of the rollout epic (default 65)."
+        required: false
+        default: "65"
+        type: string
+      stage:
+        description: "Which stage to run."
+        required: false
+        default: "preview"
+        type: choice
+        options:
+          - "preview"
+          - "apply"
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: taxonomy-rollout
+  cancel-in-progress: false
+
+jobs:
+  route:
+    # Decide what stage to run based on the triggering label (or dispatch
+    # input). Exposed as outputs for downstream jobs.
+    runs-on: ubuntu-latest
+    outputs:
+      epic: ${{ steps.decide.outputs.epic }}
+      stage: ${{ steps.decide.outputs.stage }}
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - id: decide
+        uses: actions/github-script@v7
+        env:
+          DISPATCH_EPIC: ${{ inputs.epic_number }}
+          DISPATCH_STAGE: ${{ inputs.stage }}
+        with:
+          script: |
+            const ev = context.eventName;
+            let epic = null, stage = null, should = false;
+
+            if (ev === 'workflow_dispatch') {
+              epic = Number(process.env.DISPATCH_EPIC || 65);
+              stage = process.env.DISPATCH_STAGE || 'preview';
+              should = true;
+            } else if (ev === 'issues') {
+              const label = context.payload.label && context.payload.label.name;
+              epic = context.payload.issue && context.payload.issue.number;
+              if (label === 'rollout:taxonomy') { stage = 'preview'; should = true; }
+              else if (label === 'rollout:taxonomy-apply') { stage = 'apply'; should = true; }
+              else { should = false; }
+            }
+
+            core.setOutput('epic', epic || '');
+            core.setOutput('stage', stage || '');
+            core.setOutput('should_run', should ? 'true' : 'false');
+            core.info(`route: event=${ev} epic=${epic} stage=${stage} should=${should}`);
+
+  preview:
+    needs: route
+    if: needs.route.outputs.should_run == 'true' && needs.route.outputs.stage == 'preview'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install js-yaml
+        run: npm install --no-save js-yaml@4
+
+      - name: Mark in-progress, announce start
+        uses: actions/github-script@v7
+        env:
+          EPIC: ${{ needs.route.outputs.epic }}
+        with:
+          script: |
+            const n = Number(process.env.EPIC);
+            const { owner, repo } = context.repo;
+            // Swap trigger label → in-progress.
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: n, name: 'rollout:taxonomy',
+              });
+            } catch (e) { core.info(`remove rollout:taxonomy: ${e.message}`); }
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: n, labels: ['rollout:in-progress'],
+              });
+            } catch (e) { core.warning(`add rollout:in-progress: ${e.message}`); }
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: n,
+              body: [
+                '<!-- rollout:taxonomy:start -->',
+                '## Rollout started — preview stage',
+                '',
+                'Running `Labels Sync` and `Issue Taxonomy Backfill` (dry-run).',
+                'Preview diff will follow in the next comment.',
+                '',
+                `Run: ${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+              ].join('\n'),
+            });
+
+      - name: Sync labels (create real labels)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { sync } = require('./.github/scripts/labels-sync.js');
+            await sync({ github, context, core, dryRun: false });
+
+      - name: Backfill (dry-run) and collect preview
+        id: bf
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const backfill = require('./.github/scripts/issue-backfill.js');
+            const labelsRes = await backfill.applyLabels({
+              github, context, core, dryRun: true, collectPreview: true,
+            });
+            const hierRes = await backfill.applyHierarchy({
+              github, context, core, dryRun: true, collectPreview: true,
+            });
+            core.setOutput('labels_preview', labelsRes.preview.join('\n') || '(no label changes)');
+            core.setOutput('hierarchy_preview', hierRes.preview.join('\n') || '(no sub-issue edges to add)');
+            core.setOutput('labels_count', labelsRes.preview.length);
+            core.setOutput('hierarchy_count', hierRes.preview.length);
+
+      - name: Post preview to epic
+        uses: actions/github-script@v7
+        env:
+          EPIC: ${{ needs.route.outputs.epic }}
+          LABELS_PREVIEW: ${{ steps.bf.outputs.labels_preview }}
+          HIERARCHY_PREVIEW: ${{ steps.bf.outputs.hierarchy_preview }}
+          LABELS_COUNT: ${{ steps.bf.outputs.labels_count }}
+          HIERARCHY_COUNT: ${{ steps.bf.outputs.hierarchy_count }}
+        with:
+          script: |
+            const n = Number(process.env.EPIC);
+            const { owner, repo } = context.repo;
+            const labelsPreview = process.env.LABELS_PREVIEW;
+            const hierPreview = process.env.HIERARCHY_PREVIEW;
+            const body = [
+              '<!-- rollout:taxonomy:preview -->',
+              '## Rollout preview (dry-run)',
+              '',
+              `- **Labels**: ${process.env.LABELS_COUNT} change(s) planned`,
+              `- **Sub-issue edges**: ${process.env.HIERARCHY_COUNT} link(s) planned`,
+              '',
+              '### Label diff',
+              '```',
+              labelsPreview,
+              '```',
+              '',
+              '### Sub-issue edges',
+              '```',
+              hierPreview,
+              '```',
+              '',
+              '---',
+              '',
+              'To apply these changes, add the **`rollout:taxonomy-apply`**',
+              'label to this issue. To cancel, remove the',
+              '`rollout:in-progress` label.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: n, body,
+            });
+
+  apply:
+    needs: route
+    if: needs.route.outputs.should_run == 'true' && needs.route.outputs.stage == 'apply'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install js-yaml
+        run: npm install --no-save js-yaml@4
+
+      - name: Announce apply start
+        uses: actions/github-script@v7
+        env:
+          EPIC: ${{ needs.route.outputs.epic }}
+        with:
+          script: |
+            const n = Number(process.env.EPIC);
+            const { owner, repo } = context.repo;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: n,
+              body: [
+                '<!-- rollout:taxonomy:apply:start -->',
+                '## Rollout — apply stage',
+                '',
+                'Applying labels and sub-issue edges for real.',
+                `Run: ${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+              ].join('\n'),
+            });
+
+      - name: Backfill (apply for real)
+        id: bf
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const backfill = require('./.github/scripts/issue-backfill.js');
+            const labelsRes = await backfill.applyLabels({
+              github, context, core, dryRun: false, collectPreview: false,
+            });
+            const hierRes = await backfill.applyHierarchy({
+              github, context, core, dryRun: false, collectPreview: false,
+            });
+            core.setOutput('labels_added', labelsRes.added);
+            core.setOutput('labels_already', labelsRes.already);
+            core.setOutput('labels_missing', labelsRes.missing);
+            core.setOutput('hier_added', hierRes.added);
+            core.setOutput('hier_already', hierRes.already);
+            core.setOutput('hier_skipped', hierRes.skipped);
+
+      - name: Finalize labels and post summary
+        uses: actions/github-script@v7
+        env:
+          EPIC: ${{ needs.route.outputs.epic }}
+          LABELS_ADDED: ${{ steps.bf.outputs.labels_added }}
+          LABELS_ALREADY: ${{ steps.bf.outputs.labels_already }}
+          LABELS_MISSING: ${{ steps.bf.outputs.labels_missing }}
+          HIER_ADDED: ${{ steps.bf.outputs.hier_added }}
+          HIER_ALREADY: ${{ steps.bf.outputs.hier_already }}
+          HIER_SKIPPED: ${{ steps.bf.outputs.hier_skipped }}
+        with:
+          script: |
+            const n = Number(process.env.EPIC);
+            const { owner, repo } = context.repo;
+
+            // Clean up trigger / in-progress labels; set done.
+            for (const name of ['rollout:taxonomy-apply', 'rollout:in-progress']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: n, name,
+                });
+              } catch (e) { core.info(`remove ${name}: ${e.message}`); }
+            }
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: n, labels: ['rollout:done'],
+              });
+            } catch (e) { core.warning(`add rollout:done: ${e.message}`); }
+
+            const body = [
+              '<!-- rollout:taxonomy:apply:done -->',
+              '## Rollout complete',
+              '',
+              '| Metric | Count |',
+              '|---|---|',
+              `| Labels added | ${process.env.LABELS_ADDED} |`,
+              `| Labels already present | ${process.env.LABELS_ALREADY} |`,
+              `| Labels missing (manifest needs Labels Sync) | ${process.env.LABELS_MISSING} |`,
+              `| Sub-issue edges added | ${process.env.HIER_ADDED} |`,
+              `| Sub-issue edges already present | ${process.env.HIER_ALREADY} |`,
+              `| Sub-issue edges skipped | ${process.env.HIER_SKIPPED} |`,
+              '',
+              'Taxonomy migration rolled out. Issues are now machine-legible',
+              'across `type / complexity / effort / judgement` and the',
+              'tracking-issue body-checklists are now native sub-issue edges.',
+              '',
+              'Re-runnable: editing `docs/issue-taxonomy-backfill.yml` and',
+              're-applying `rollout:taxonomy` + `rollout:taxonomy-apply`',
+              'will pick up the new classifications idempotently.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: n, body,
+            });

--- a/.github/workflows/taxonomy-rollout.yml
+++ b/.github/workflows/taxonomy-rollout.yml
@@ -96,6 +96,16 @@ jobs:
       - name: Install js-yaml
         run: npm install --no-save js-yaml@4
 
+      # Bootstrap: create / update all labels FIRST so subsequent
+      # `rollout:in-progress` add and the backfill apply have everything
+      # they need. Idempotent.
+      - name: Sync labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { sync } = require('./.github/scripts/labels-sync.js');
+            await sync({ github, context, core, dryRun: false });
+
       - name: Mark in-progress, announce start
         uses: actions/github-script@v7
         env:
@@ -121,19 +131,12 @@ jobs:
                 '<!-- rollout:taxonomy:start -->',
                 '## Rollout started — preview stage',
                 '',
-                'Running `Labels Sync` and `Issue Taxonomy Backfill` (dry-run).',
+                'Labels synced. Running `Issue Taxonomy Backfill` (dry-run).',
                 'Preview diff will follow in the next comment.',
                 '',
                 `Run: ${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
               ].join('\n'),
             });
-
-      - name: Sync labels (create real labels)
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { sync } = require('./.github/scripts/labels-sync.js');
-            await sync({ github, context, core, dryRun: false });
 
       - name: Backfill (dry-run) and collect preview
         id: bf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,27 @@ open PR.
 **Agent priority order** (highest wins redundancy conflicts):
 `user > maxwell-daemon > claude > codex > jules > local > gaai`
 
+## Issue Taxonomy and Dispatch
+
+Before picking up an issue, agents must:
+
+1. Read [`docs/issue-taxonomy.md`](docs/issue-taxonomy.md) — the canonical
+   label taxonomy and dispatch contract.
+2. Confirm the issue is **pickable** per the rules in that doc: state is
+   `open`, no open PR references it, no active `claim:*` lease, and the
+   issue's `complexity:*` label falls within the agent's skill tier.
+3. Respect `judgement:design` and `judgement:contested` — **do not
+   implement** from those issues. They require panel review first (see
+   `.github/workflows/agent-panel-review.yml`).
+4. Respect `panel-review` — on those issues, post an opinion comment in the
+   documented format; do **not** open a PR from them.
+
+**Quick-win lane:** filter `label:quick-win label:complexity:trivial
+label:judgement:objective` for low-risk warmup work.
+
+Migration of existing issues to this taxonomy is tracked in
+[`docs/issue-migration-plan.md`](docs/issue-migration-plan.md).
+
 ## Project Overview
 
 `runner-dashboard` is the web UI control surface for the D-sorganization

--- a/docs/issue-migration-plan.md
+++ b/docs/issue-migration-plan.md
@@ -129,6 +129,33 @@ correct.
   and re-run dry-run.
 - Re-run with `dry_run=false` when the plan looks right.
 
+### Label-triggered rollout (recommended)
+
+For humans who would rather flip a switch than click through
+workflow-dispatch forms, the rollout is label-driven end-to-end. The
+orchestrator is `.github/workflows/taxonomy-rollout.yml`:
+
+1. Apply the **`rollout:taxonomy`** label to the migration epic (#65).
+2. The orchestrator fires automatically:
+   - swaps the trigger label for `rollout:in-progress`
+   - creates / updates labels from `.github/labels.yml`
+   - runs the backfill in **dry-run** mode
+   - posts the planned diff as a comment on the epic
+3. Review the preview comment.
+4. If it looks right, apply **`rollout:taxonomy-apply`** to the same
+   epic. The orchestrator fires again and:
+   - runs the backfill for real (labels + sub-issue edges)
+   - posts a completion summary table
+   - sets `rollout:done` and removes the in-progress/apply labels
+
+If the preview is wrong, do not apply. Edit the manifest, remove
+`rollout:in-progress`, and restart by re-applying `rollout:taxonomy`.
+
+The whole chain is idempotent — re-running never duplicates labels or
+sub-issue edges, and the manifest is the single source of truth. Manual
+`workflow_dispatch` of `Labels Sync` and `Issue Taxonomy Backfill`
+remains available as an admin escape hatch.
+
 ### Phase 5 — Projects v2 board (optional)
 
 A human org-admin creates one board:

--- a/docs/issue-migration-plan.md
+++ b/docs/issue-migration-plan.md
@@ -1,0 +1,191 @@
+# Issue Organization Migration Plan
+
+Migration from free-form issues + markdown-checklist tracking issues to a
+labeled, sub-issue-hierarchical, agent-dispatchable taxonomy.
+
+This is the plan; tracking of execution lives in the migration epic on
+GitHub.
+
+## Goal
+
+Make every issue legible to both humans and autonomous agents at a glance,
+so that:
+
+- Agents can self-select work that matches their skill tier.
+- Quick wins are surfaced distinctly from deep work.
+- Judgement-heavy issues are explicitly flagged for panel review before
+  anyone writes code.
+- Progress on large initiatives (auth, security review) is visible via real
+  parent/child links, not stale markdown checklists.
+
+See `docs/issue-taxonomy.md` for the taxonomy itself.
+
+## Constraints learned during scoping
+
+- **Org-level Issue Types** are not accessible via the MCP integration
+  (`403 Resource not accessible by integration`). We fall back to labels
+  instead of native Issue Types. This is not a meaningful loss — labels are
+  strictly more queryable.
+- **Projects v2 board creation** requires org-admin and is not available via
+  integration tooling. Board setup is a short manual step the admin performs
+  at the end; the taxonomy does not depend on it.
+- **Sub-issues** are available via the integration (`sub_issue_write`). This
+  is the real hierarchy mechanism.
+
+## Phases
+
+### Phase 0 — Scaffolding (this PR)
+
+Lands in one PR, no issue modifications.
+
+1. `docs/issue-taxonomy.md` — canonical reference.
+2. `docs/issue-migration-plan.md` — this document.
+3. `.github/ISSUE_TEMPLATE/` — structured forms for each `type:*`.
+4. `.github/labels.yml` — manifest of every label in the taxonomy.
+5. `.github/workflows/labels-sync.yml` — workflow that applies `labels.yml`
+   to the repo on-demand. Run once manually to create the new labels.
+6. `.github/workflows/agent-panel-review.yml` — the panel-review workflow,
+   in dry-run mode until panelists are wired up.
+7. `CLAUDE.md` — pointer to the taxonomy + dispatch contract.
+
+### Phase 1 — Label creation
+
+1. Merge Phase 0 PR.
+2. Run `Labels Sync` workflow manually. It creates every label in
+   `.github/labels.yml` with its color and description, and leaves existing
+   labels alone.
+3. Verify the label set in the repo.
+
+### Phase 2 — Pilot backfill (~10 issues)
+
+Hand-label a small sample that covers the range, to validate the taxonomy
+before we apply it to 45 issues.
+
+Suggested pilot set:
+
+- `#16` (auth) — `type:security, complexity:complex, effort:l, judgement:design, panel-review, wave:1`
+- `#17` (CORS) — `type:security, complexity:routine, effort:s, judgement:objective, wave:1`
+- `#36` (floating deps) — `type:chore, complexity:trivial, effort:xs, judgement:objective, quick-win`
+- `#46` (log injection) — `type:security, complexity:routine, effort:s, judgement:objective`
+- `#50` (SPEC docs) — `type:docs, complexity:trivial, effort:s, judgement:preference`
+- `#51` (frontend a11y) — `type:task, complexity:complex, effort:l, judgement:preference`
+- `#54` (low-severity misc) — `type:chore, complexity:trivial, effort:s, judgement:objective, quick-win`
+- `#55` (tracking) — `type:epic`
+- `#58` (keepalive diagnostics) — `type:bug, complexity:routine, effort:m, judgement:objective`
+- `#63` (auth epic) — `type:epic`
+
+Criteria for the pilot succeeding:
+
+- Every sampled issue cleanly fits the taxonomy without needing a new field
+  or value.
+- An agent simulation (e.g. "pick 3 quick wins for tier-1") returns a
+  correct set.
+- No two reviewers disagree strongly on a label choice for the same issue.
+
+### Phase 3 — Sub-issue conversion for #55 and #63
+
+Convert the existing markdown checklists in `#55` and `#63` into real
+parent/child sub-issue links. `#55` already references #16–#54 in its body;
+those are the children. `#63`'s body enumerates ~20 new child tickets to
+file as part of the auth epic.
+
+This is two operations:
+
+- For existing child issues that already exist (`#55` case): use the
+  `sub_issue_write` API to link them to the parent. No issue edits needed.
+- For proposed children that do not yet exist (`#63` case): file each
+  child, then link it.
+
+### Phase 4 — Bulk backfill
+
+With the pilot validated, label the remaining ~35 issues. Two acceptable
+paths:
+
+a. **Agent-assisted.** An agent reads each issue's body + title prefix and
+   proposes labels from the taxonomy. A human (or dashboard UI) approves
+   each.
+b. **Scripted best-guess.** A small script derives initial labels from
+   title prefix (`[CRITICAL]` → `critical`, title contains "SSRF" → adds
+   `security`, etc.) and leaves `judgement` blank for a human to fill. Good
+   enough to unblock agents; precision improves over time.
+
+The plan recommends **(a)**, because judgement labels are the hardest to
+derive mechanically and getting them wrong on critical security tickets
+would mis-route work.
+
+### Phase 5 — Projects v2 board (optional)
+
+A human org-admin creates one board:
+
+- Source: all open issues in this repo.
+- Columns: Status (built-in).
+- Custom fields (pull from label values):
+  - `Complexity` (single-select, values from `complexity:*`)
+  - `Effort` (single-select, values from `effort:*`)
+  - `Judgement` (single-select, values from `judgement:*`)
+  - `Wave` (single-select)
+  - `Quick Win` (boolean, derived from `quick-win` label)
+- Saved views:
+  - "Quick wins" — filter `Quick Win = true AND Judgement = objective`
+  - "Needs panel" — filter `label:panel-review`
+  - "Wave 1" — filter `Wave = 1`
+  - "By domain" — group-by skill-domain label
+
+The board is pure overlay: every field is derivable from labels, so the
+board going missing does not break anything.
+
+### Phase 6 — Dashboard integration (separate PR, later)
+
+Add a backend endpoint `GET /api/issues/dispatchable?tier=<n>&domain=<d>`
+that returns a ranked list of pickable issues per the dispatch contract in
+`docs/issue-taxonomy.md`. The dashboard UI surfaces this as a panel where
+operators (or agents, via token) can see what's available to work on.
+
+This is a feature, not a migration step, so it lives in its own issue/PR.
+
+### Phase 7 — CI enforcement (separate PR, later)
+
+Add a CI check that fails if a new non-`type:epic` issue is created without
+the required labels. Deferred until after the backfill so we don't block on
+our own legacy issues.
+
+## Risk controls
+
+- **Nothing in Phase 0 modifies any existing issue.** The PR is pure
+  addition: docs, templates, workflows, and a label manifest. Merging it is
+  reversible.
+- **Phase 1 (label creation) is additive.** Existing labels are untouched.
+- **Phase 2 (pilot) is 10 issues, each reviewable independently.**
+- **Phase 3 (sub-issue conversion) does not change issue bodies or labels
+  — it only adds parent/child relationships.** If we get it wrong, we
+  unlink.
+- **Phase 4 (bulk backfill) should gate on human approval.** The
+  orchestrator proposes labels; a human (or the agent that filed the
+  issue) confirms.
+
+## What changes for agents currently working in the repo
+
+- **In the short term: nothing.** Phase 0 adds docs and templates; it does
+  not change any issue agents are currently picking up.
+- **After Phase 2:** agents that look at labels get strictly more signal.
+  Agents that ignore labels are unaffected.
+- **After Phase 4:** agents can self-dispatch from the quick-win lane or
+  by complexity tier. Redundant-pick rate should drop. Agent workflows
+  (`Jules-Control-Tower.yml`, `Jules-Auto-Repair.yml`,
+  `Agent-Redundant-PR-Closer.yml`, `Agent-Lease-Reaper.yml`) do not need
+  edits — they already key off issue state and `claim:*` labels, which
+  are unchanged. They can be upgraded to use the new labels later.
+- **The existing `lease:` comment protocol and `claim:*` labels are
+  untouched.** Orthogonal mechanisms; they coexist.
+
+## Success criteria
+
+1. Every open issue carries a `type:*`, `complexity:*`, `effort:*`, and
+   `judgement:*` label.
+2. Every epic has real sub-issue children, not a markdown checklist.
+3. An agent asking "what should I work on?" can get a machine-readable
+   answer without reading issue bodies.
+4. At least one issue has gone through a full panel-review cycle
+   end-to-end.
+5. `docs/issue-taxonomy.md` is the cited reference in CLAUDE.md and
+   onboarding for new agents.

--- a/docs/issue-migration-plan.md
+++ b/docs/issue-migration-plan.md
@@ -129,6 +129,18 @@ correct.
   and re-run dry-run.
 - Re-run with `dry_run=false` when the plan looks right.
 
+### Bootstrap (first run only)
+
+When PR #64 merges, `Labels Sync` auto-runs because `.github/labels.yml`
+is in its `paths` filter — every taxonomy label including the
+`rollout:*` family is created within ~30s of the merge. After that, the
+label-triggered rollout works as documented.
+
+If you want to be paranoid (or run before the auto-sync completes),
+trigger `Taxonomy Rollout` via `workflow_dispatch` with `stage=preview`
+— its first step is a labels sync, so it bootstraps itself even if no
+labels exist yet.
+
 ### Label-triggered rollout (recommended)
 
 For humans who would rather flip a switch than click through

--- a/docs/issue-migration-plan.md
+++ b/docs/issue-migration-plan.md
@@ -98,20 +98,36 @@ This is two operations:
 
 ### Phase 4 — Bulk backfill
 
-With the pilot validated, label the remaining ~35 issues. Two acceptable
-paths:
+The full manifest is already written to
+[`docs/issue-taxonomy-backfill.yml`](issue-taxonomy-backfill.yml). It
+classifies all 45 open issues (plus the two tracking epics added during
+this migration) across the required taxonomy dimensions and declares the
+sub-issue children for tracking issue #55.
 
-a. **Agent-assisted.** An agent reads each issue's body + title prefix and
-   proposes labels from the taxonomy. A human (or dashboard UI) approves
-   each.
-b. **Scripted best-guess.** A small script derives initial labels from
-   title prefix (`[CRITICAL]` → `critical`, title contains "SSRF" → adds
-   `security`, etc.) and leaves `judgement` blank for a human to fill. Good
-   enough to unblock agents; precision improves over time.
+Application is a single workflow invocation:
 
-The plan recommends **(a)**, because judgement labels are the hardest to
-derive mechanically and getting them wrong on critical security tickets
-would mis-route work.
+1. `Labels Sync` workflow (`workflow_dispatch`) creates the label set
+   from `.github/labels.yml` — prerequisite for step 2.
+2. `Issue Taxonomy Backfill` workflow (`workflow_dispatch`) reads the
+   manifest and:
+   - Adds the listed labels to each issue (idempotent; existing labels
+     untouched).
+   - Adds native sub-issue links via GraphQL for every
+     parent → child edge declared in the manifest.
+   - Supports `dry_run=true` (default) so the planned changes can be
+     reviewed in the Action log before anything is applied.
+
+If any classification is wrong, edit the manifest and re-run the workflow.
+Labels are only **added**, never removed, so bad choices are cheap to
+correct.
+
+### Phase 4 review path (if you want human eyes before apply)
+
+- Run `Issue Taxonomy Backfill` with `dry_run=true` — no mutations. The
+  run log prints every `WOULD ADD` / `WOULD LINK` decision.
+- Sanity-check the log. If needed, edit `docs/issue-taxonomy-backfill.yml`
+  and re-run dry-run.
+- Re-run with `dry_run=false` when the plan looks right.
 
 ### Phase 5 — Projects v2 board (optional)
 

--- a/docs/issue-taxonomy-backfill.yml
+++ b/docs/issue-taxonomy-backfill.yml
@@ -1,0 +1,251 @@
+# Bulk backfill manifest for the issue taxonomy.
+#
+# Maps every currently-open issue to its proposed taxonomy labels and
+# (where applicable) a parent epic. Applied by
+# `.github/workflows/issue-taxonomy-backfill.yml` after `.github/labels.yml`
+# has been synced and the labels exist in the repo.
+#
+# Classification rules followed (see docs/issue-taxonomy.md):
+#   - type/complexity/effort/judgement labels are required on every non-
+#     epic issue.
+#   - `quick-win` is only applied when effort is xs/s AND complexity is
+#     trivial/routine AND judgement is objective/preference.
+#   - `panel-review` is applied to judgement:design and to any issue with
+#     live architectural trade-offs (auth strategy, mTLS vs signed
+#     envelopes, cost-cap policy, prompt-injection defense, etc.).
+#   - `wave:*` mirrors the execution order documented in tracking issue
+#     #55. Security findings under #55 keep the wave they were assigned.
+#   - Existing labels (severity, domain) are preserved; this manifest only
+#     **adds** labels.
+#
+# Safety:
+#   - The apply workflow is idempotent. Re-running does not add duplicate
+#     labels. Existing taxonomy labels (if any) are not removed.
+#   - `dry_run` input is provided so the manifest can be reviewed before
+#     any change lands.
+
+version: 1
+generated: "2026-04-24"
+
+# Parent/child relationships expressed as sub-issue links. The apply
+# workflow turns these into native sub-issue edges using GraphQL after
+# resolving issue numbers to GraphQL node IDs.
+parents:
+  55: # [TRACKING] Adversarial security review
+    children:
+      [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+       30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+       44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54]
+  63: # [EPIC] Multi-user identity, authorization, and attribution
+    # Children for #63 will be filed as part of Wave 1 of the epic; listed
+    # here for traceability but not yet created as issues.
+    children: []
+  65: # [EPIC] Migrate to label-based issue taxonomy
+    children: []
+
+issues:
+  # ---------------------------------------------------------------------
+  # Epics — no complexity/effort; wave only if applicable.
+  # ---------------------------------------------------------------------
+  - number: 55
+    title_hint: "[TRACKING] Adversarial security & quality review"
+    add: ["type:epic"]
+  - number: 63
+    title_hint: "[EPIC] Multi-user identity, authorization, and attribution"
+    add: ["type:epic", "judgement:design", "panel-review"]
+  - number: 65
+    title_hint: "[EPIC] Migrate to label-based issue taxonomy"
+    add: ["type:epic"]
+
+  # ---------------------------------------------------------------------
+  # Wave 1 — reachable-from-any-untrusted-host blockers
+  # ---------------------------------------------------------------------
+  - number: 16
+    title_hint: "No authentication on any /api/* endpoint"
+    add: ["type:security", "complexity:complex", "effort:l", "judgement:design",
+          "panel-review", "wave:1"]
+    rationale: "OAuth vs session vs token vs mTLS is a real design choice; blocks every other CORS/CSRF/SSRF exploit's preconditions."
+  - number: 17
+    title_hint: "CORS allow_origins=[*] with allow_credentials=True"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:1"]
+  - number: 19
+    title_hint: "Shell injection in Agent workflows via workflow_dispatch"
+    add: ["type:security", "complexity:routine", "effort:m", "judgement:objective",
+          "wave:1"]
+  - number: 20
+    title_hint: "Self-hosted runner d-sorg-fleet reacts to pull_request_target"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:design",
+          "panel-review", "wave:1"]
+  - number: 21
+    title_hint: "secrets: inherit passes every secret to 15+ reusable workflow calls"
+    add: ["type:security", "complexity:routine", "effort:m", "judgement:design",
+          "wave:1"]
+  - number: 26
+    title_hint: "Deploy scripts: curl | sh, sudoers, hardcoded username"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:design",
+          "panel-review", "wave:1"]
+
+  # ---------------------------------------------------------------------
+  # Wave 2 — remaining critical paths
+  # ---------------------------------------------------------------------
+  - number: 18
+    title_hint: "CSP unsafe-inline + CDN scripts no SRI"
+    add: ["type:security", "complexity:routine", "effort:m", "judgement:objective",
+          "wave:2"]
+  - number: 22
+    title_hint: "Command injection via local_apps.json health_command"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:2"]
+  - number: 23
+    title_hint: "Path traversal + SSRF via local_apps.json"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:2"]
+  - number: 24
+    title_hint: "Prompt injection: user-controlled failure text -> LLM agent"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:design",
+          "panel-review", "wave:2"]
+  - number: 25
+    title_hint: "assert used as a security gate"
+    add: ["type:security", "complexity:trivial", "effort:xs", "judgement:objective",
+          "quick-win", "wave:2"]
+  - number: 27
+    title_hint: "API endpoints echo subprocess stderr / raw exceptions"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "quick-win", "wave:2"]
+  - number: 28
+    title_hint: "SSRF via FLEET_NODES URLs"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:2"]
+  - number: 29
+    title_hint: "GH_TOKEN and ANTHROPIC_API_KEY exposure"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:design",
+          "panel-review", "wave:2"]
+
+  # ---------------------------------------------------------------------
+  # Wave 3 — high-severity hardening
+  # ---------------------------------------------------------------------
+  - number: 30
+    title_hint: "CSRF, unencoded params, window.open, DOMPurify bypass"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:objective",
+          "wave:3"]
+  - number: 31
+    title_hint: "No rate limiting -> financial DoS on agent dispatch"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:design",
+          "panel-review", "wave:3"]
+  - number: 32
+    title_hint: "Missing input validation on state-changing POST/PUT"
+    add: ["type:security", "complexity:routine", "effort:m", "judgement:objective",
+          "wave:3"]
+  - number: 33
+    title_hint: "Bare except Exception; no structured audit logging"
+    add: ["type:task", "complexity:routine", "effort:m", "judgement:preference",
+          "wave:3"]
+  - number: 34
+    title_hint: "systemd units ship with hardening off"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:3"]
+  - number: 35
+    title_hint: "Bandit skipped in CI, mypy non-strict, missing hooks"
+    add: ["type:chore", "complexity:routine", "effort:m", "judgement:preference",
+          "wave:3"]
+  - number: 36
+    title_hint: "Floating deps + third-party actions pinned to @v1/@v6"
+    add: ["type:chore", "complexity:routine", "effort:s", "judgement:objective",
+          "quick-win", "wave:3"]
+  - number: 37
+    title_hint: "Agent auto-fix loops: no approval gate, no $ cap"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:design",
+          "panel-review", "wave:3"]
+  - number: 38
+    title_hint: "Race conditions in autoscaler/remediation/attempt counter"
+    add: ["type:bug", "complexity:complex", "effort:m", "judgement:objective",
+          "wave:3"]
+  - number: 39
+    title_hint: "Plain HTTP between fleet nodes; no mTLS"
+    add: ["type:security", "complexity:complex", "effort:l", "judgement:design",
+          "panel-review", "wave:3"]
+  - number: 40
+    title_hint: "Missing LICENSE, SECURITY.md, CONTRIBUTING.md"
+    add: ["type:docs", "complexity:trivial", "effort:s", "judgement:preference",
+          "quick-win", "wave:3"]
+  - number: 41
+    title_hint: "Deploy scripts: lib.sh lacks set -euo pipefail, weak token regex"
+    add: ["type:chore", "complexity:routine", "effort:m", "judgement:objective",
+          "wave:3"]
+  - number: 42
+    title_hint: "SQL nosemgrep suppressions — audit parameterization"
+    add: ["type:security", "complexity:complex", "effort:m", "judgement:design",
+          "panel-review", "wave:3"]
+  - number: 43
+    title_hint: "Integration-test coverage missing for mutating routes"
+    add: ["type:task", "complexity:complex", "effort:l", "judgement:preference",
+          "wave:3"]
+  - number: 44
+    title_hint: "config files loaded without schema validation"
+    add: ["type:task", "complexity:routine", "effort:m", "judgement:objective",
+          "wave:3"]
+  - number: 45
+    title_hint: "routers/credentials.py enumerates installed tools without auth"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:3"]
+
+  # ---------------------------------------------------------------------
+  # Wave 4 — medium-severity polish
+  # ---------------------------------------------------------------------
+  - number: 46
+    title_hint: "Log injection: unescaped requested_by in audit log"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:4"]
+  - number: 47
+    title_hint: "GitHub API calls lack rate-limit handling"
+    add: ["type:task", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:4"]
+  - number: 48
+    title_hint: "Unbounded in-memory cache; inconsistent subprocess timeouts"
+    add: ["type:bug", "complexity:routine", "effort:m", "judgement:objective",
+          "wave:4"]
+  - number: 49
+    title_hint: "Hardcoded model name, embedded PowerShell, duplicated validation"
+    add: ["type:chore", "complexity:routine", "effort:m", "judgement:preference",
+          "wave:4"]
+  - number: 50
+    title_hint: "SPEC.md security section incomplete; no operator warnings"
+    add: ["type:docs", "complexity:trivial", "effort:s", "judgement:preference",
+          "wave:4"]
+  - number: 51
+    title_hint: "Frontend SPA: no a11y, alert(), 486KB monolith"
+    add: ["type:task", "complexity:complex", "effort:l", "judgement:preference",
+          "wave:4"]
+  - number: 52
+    title_hint: "GHA: missing concurrency, cron stampede, continue-on-error"
+    add: ["type:chore", "complexity:routine", "effort:m", "judgement:objective",
+          "wave:4"]
+  - number: 53
+    title_hint: "CI logs dumped to /tmp on shared self-hosted runner"
+    add: ["type:security", "complexity:routine", "effort:s", "judgement:objective",
+          "wave:4"]
+
+  # ---------------------------------------------------------------------
+  # Wave 5 — low severity / ongoing polish
+  # ---------------------------------------------------------------------
+  - number: 54
+    title_hint: "Assorted low-severity: hardcoded paths, log rotation, type Any"
+    add: ["type:chore", "complexity:trivial", "effort:s", "judgement:objective",
+          "quick-win", "wave:5"]
+
+  # ---------------------------------------------------------------------
+  # Non-security product work
+  # ---------------------------------------------------------------------
+  - number: 58
+    title_hint: "Fix deployed keepalive diagnostics drift"
+    add: ["type:bug", "complexity:routine", "effort:m", "judgement:objective"]
+  - number: 59
+    title_hint: "Add dedicated Diagnostics tab"
+    add: ["type:task", "complexity:routine", "effort:l", "judgement:preference"]
+  - number: 60
+    title_hint: "Generate Windows desktop launchers"
+    add: ["type:task", "complexity:routine", "effort:m", "judgement:preference"]
+  - number: 61
+    title_hint: "Design PWA/native launcher path"
+    add: ["type:research", "complexity:research", "effort:s", "judgement:design"]

--- a/docs/issue-taxonomy.md
+++ b/docs/issue-taxonomy.md
@@ -1,0 +1,290 @@
+# Issue Taxonomy and Agent Dispatch Contract
+
+This document is the **canonical reference** for how issues in
+`runner-dashboard` are categorized so that:
+
+1. Human maintainers can see priority and progress at a glance.
+2. Autonomous agents can pick up work they are qualified for and skip work they
+   are not.
+3. The dashboard (and any future orchestrator) can query structured metadata
+   instead of parsing free-text bodies.
+
+The taxonomy is **label-based**. Labels are the source of truth. A GitHub
+Projects v2 board layers views on top of the same labels but does not replace
+them — labels stay machine-readable even without the board.
+
+Every field in this document is **additive** to the existing severity/domain
+labels (`critical`, `high`, `medium`, `low`, `backend`, `frontend`, ...). Those
+stay as they are.
+
+---
+
+## Why this exists
+
+We run many autonomous agents against this repo (see `CLAUDE.md` for the
+priority order). Without structured metadata:
+
+- Agents redundantly pick the same issue or pick issues beyond their skill.
+- Quick wins are buried under larger tickets because both look the same on the
+  issue list.
+- Opinion-driven tickets get silently resolved the wrong way by whichever
+  agent reaches them first.
+- There is no way to ask "get me three fast, objective, backend tickets"
+  without reading every issue.
+
+The taxonomy fixes all four.
+
+---
+
+## Label dimensions
+
+Every non-epic issue **should** carry at minimum one label from each of the
+**required** dimensions below. Epics carry the `type:epic` label and may omit
+`effort` and `complexity` (those belong on the children).
+
+### 1. Type (required, single-valued)
+
+| Label | Meaning |
+|---|---|
+| `type:epic` | Parent tracking issue. No direct work happens here. Children are linked as sub-issues. |
+| `type:task` | Ordinary unit of work. Default for most issues. |
+| `type:bug` | Defect in existing behavior. |
+| `type:security` | Security finding. Often overlaps with `type:bug`; prefer `type:security` when the label `security` is present. |
+| `type:research` | Investigation / spike. Answer unknown; must investigate before implementation. |
+| `type:docs` | Documentation-only change. |
+| `type:chore` | Housekeeping: deps, CI, lint, formatting. |
+
+### 2. Complexity (required, single-valued) — **skill required of the agent**
+
+This dimension is deliberately **not about difficulty of the ticket** — it is
+about the **skill and breadth of context** an agent must bring. A small ticket
+can be deep if it touches a subtle invariant.
+
+Agent names do not appear here — orchestrators map complexity → agent pool.
+
+| Label | Meaning | Typical work |
+|---|---|---|
+| `complexity:trivial` | Single-file mechanical change. No judgement, no architectural awareness. | Rename a symbol, fix a typo, delete dead code, update a constant, bump a pinned version. |
+| `complexity:routine` | Well-scoped change, clear spec, may touch multiple files within one subsystem. | Add a validated field to a request payload, add a test for a documented behavior, add a route that mirrors an existing one. |
+| `complexity:complex` | Cross-cutting change, architectural awareness needed. May require reading 10+ files and understanding conventions. | Add a new FastAPI dependency that threads request context; introduce a new lease type in the autoscaler. |
+| `complexity:deep` | Requires deep codebase knowledge and/or novel design. | Reshape the dispatch contract; redesign runner ownership; rework the frontend state model. |
+| `complexity:research` | The right answer is unknown. Must investigate and write up options **before** anyone implements. | "How should we authenticate bots?"; "Is Playwright viable for the SPA?". |
+
+### 3. Effort (required, single-valued) — **size of the work**
+
+Independent of complexity. A `complexity:trivial` ticket can be `effort:l` if
+it touches 200 files. A `complexity:deep` ticket can be `effort:s` if the
+change itself is small once you know what to change.
+
+| Label | Rough bound | Notes |
+|---|---|---|
+| `effort:xs` | < 1 hour | Single PR, single file usually. Candidate for `quick-win`. |
+| `effort:s` | < 4 hours | Bounded, clear scope. |
+| `effort:m` | < 1 day | Normal feature or bugfix. |
+| `effort:l` | 1–3 days | Decompose if possible, but acceptable as-is. |
+| `effort:xl` | > 3 days | **Should be an epic with children**, not a single ticket. |
+
+### 4. Quick win (optional, boolean)
+
+| Label | Meaning |
+|---|---|
+| `quick-win` | High perceived value, low effort. Surface these to new contributors and fast agents. Typically `effort:xs`/`effort:s` and `complexity:trivial`/`complexity:routine`. |
+
+### 5. Judgement (required, single-valued) — **how much opinion is involved**
+
+This is the dimension the orchestrator uses to decide whether to dispatch a
+single agent or request a panel review first.
+
+| Label | Meaning | Dispatch rule |
+|---|---|---|
+| `judgement:objective` | Most competent agents would agree on the correct implementation. A spec or failing test defines success. | Dispatch directly. |
+| `judgement:preference` | Multiple valid approaches. Style, ergonomics, or naming matters, but the differences are small. | Dispatch directly; human review on PR is enough. |
+| `judgement:design` | Architectural decision with durable consequences. Needs deliberate choice. | **Do not dispatch for implementation until a design has been chosen.** Request a panel review or a human decision. |
+| `judgement:contested` | Active disagreement is already on the issue. | **Hold.** Panel review required. |
+
+### 6. Panel review (optional, boolean)
+
+| Label | Meaning |
+|---|---|
+| `panel-review` | Periodic agent-panel review is requested or in progress. The panel workflow (see `.github/workflows/agent-panel-review.yml`) will post opinions as comments on these issues on its schedule. |
+
+Typically paired with `judgement:design` or `judgement:contested`. Can also be
+applied to any issue where the author wants multi-agent input before work
+starts.
+
+### 7. Skill domain (optional, multi-valued)
+
+These already mostly exist. Keep them. They tell an orchestrator which agent
+pool has the relevant expertise.
+
+`backend`, `frontend`, `ci`, `github-actions`, `deploy`, `infra`, `docs`,
+`tests`, `security`, `code-quality`, `supply-chain`, `dependencies`,
+`observability`, `reliability`, `configuration`, `secrets`,
+`agent-safety`, `cost-control`, `a11y`, `governance`
+
+An issue may carry several of these. New domains are fine — keep names
+lowercase and hyphenated.
+
+### 8. Priority (required, single-valued)
+
+Existing convention, kept as-is:
+
+`critical`, `high`, `medium`, `low`
+
+A security severity and a work priority are not the same thing, but in this
+repo today they are aligned. If they diverge in future, split into
+`severity:*` and `priority:*`.
+
+### 9. Wave (optional, single-valued)
+
+Execution-order bucket, used by the meta-tracking issue #55. Values:
+`wave:1`, `wave:2`, `wave:3`, `wave:4`, `wave:5`.
+
+### 10. Lease (automatic, single-valued)
+
+Managed by the lease-reaper workflow. Do not set by hand.
+
+`claim:user`, `claim:maxwell-daemon`, `claim:claude`, `claim:codex`,
+`claim:jules`, `claim:local`, `claim:gaai`.
+
+---
+
+## Issue body contract
+
+In addition to labels, every non-epic issue body **should** start with a
+machine-parseable metadata block. Labels win if they disagree, but the block
+makes the intent legible in a single glance and lets agents without label
+access still triage.
+
+```markdown
+<!-- dispatch-metadata:v1
+type: task
+complexity: routine
+effort: s
+judgement: objective
+quick_win: true
+panel_review: false
+domains: [backend, security]
+wave: 2
+depends_on: [#16]
+blocks: []
+-->
+```
+
+Fields:
+
+- `type`, `complexity`, `effort`, `judgement` — required, one value each.
+- `quick_win`, `panel_review` — optional booleans, default `false`.
+- `domains` — list; must match existing domain labels.
+- `wave` — integer 1–5, or omitted.
+- `depends_on`, `blocks` — issue references. Use sub-issue links for real
+  parent/child; use these for lateral dependencies.
+
+The issue-template forms in `.github/ISSUE_TEMPLATE/` produce this block
+automatically.
+
+---
+
+## Agent dispatch contract
+
+Orchestrators (the dashboard, Jules Control Tower, future dispatchers) choose
+work using the following rules. Agents should self-enforce these, not rely on
+the orchestrator alone.
+
+### Pickable work
+
+An issue is **pickable** by an agent if **all** of the following hold:
+
+1. State is `open`.
+2. No open PR currently references it (check `closes #N` / `fixes #N`).
+3. No active `claim:*` lease.
+4. The agent's skill tier covers the issue's `complexity`. The mapping is
+   orchestrator-defined, but a reasonable default is:
+   - tier-1 agents: `complexity:trivial`, `complexity:routine`
+   - tier-2 agents: above + `complexity:complex`
+   - tier-3 agents: above + `complexity:deep`
+   - research-capable agents: `complexity:research`
+5. The agent's domain capabilities cover the issue's `domains` labels.
+6. `judgement` is **not** `judgement:design` or `judgement:contested` — unless
+   the agent is explicitly a panelist.
+7. The issue has a `dispatch-metadata` block or full label set. Missing
+   metadata means "unreviewed"; agents must not guess.
+
+### Quick-win lane
+
+Agents that want to do a low-risk warmup should filter for
+`quick-win AND complexity:(trivial|routine) AND effort:(xs|s) AND
+judgement:objective`. That is the safe pool.
+
+### Panel lane
+
+Issues with `panel-review` are explicitly seeking agent opinions, not code.
+The panel workflow enforces: comment with an opinion, do **not** open a PR.
+See the workflow file for the full contract.
+
+---
+
+## Panel review
+
+Some issues are opinion-driven (`judgement:design`, `judgement:contested`, or
+manually flagged `panel-review`). For those we want multiple agents to weigh
+in **before** anyone implements.
+
+The `Agent Panel Review` workflow runs on a schedule (weekly) and on-demand.
+For every open issue labeled `panel-review`, it:
+
+1. Collects the issue body, dispatch-metadata block, and the last N comments.
+2. Dispatches the panel — the actual agent pool is orchestrator-configured
+   (see the workflow file).
+3. Each panelist posts exactly one comment in a structured format:
+   ```
+   <!-- panel-opinion:v1 agent=<tier> stance=support|oppose|modify -->
+   ## Opinion
+   ...
+   ## Suggested approach
+   ...
+   ## Risks
+   ...
+   ```
+4. After all panelists post (or after a timeout), the workflow posts a
+   summary comment with a tally and the dominant stance. A human removes
+   the `panel-review` label and sets `judgement:objective` (or closes the
+   issue as `not planned`) to unblock implementation.
+
+Panelists **never** open PRs from panel-review issues. Implementation happens
+only after the judgement label is changed away from `design`/`contested`.
+
+---
+
+## Examples
+
+Two real issues, showing how they should be labeled:
+
+**#16 — "No authentication on any /api/* endpoint"**
+- `type:security`, `security`, `backend`, `critical`
+- `complexity:complex` (threading auth through 67 routes)
+- `effort:l`
+- `judgement:design` (OAuth-vs-token-vs-session is a real choice)
+- `panel-review` (once, to pick direction)
+- `wave:1`
+
+**#54 — "Assorted low-severity findings: hardcoded paths, log rotation, ..."**
+- `type:chore`, `code-quality`, `low`
+- `complexity:trivial`
+- `effort:s`
+- `judgement:objective`
+- `quick-win`
+
+---
+
+## Changes to existing process
+
+- **`[CRITICAL]/[HIGH]/[MEDIUM]/[LOW]` title prefixes** stay for now, but are
+  advisory. The priority label is authoritative.
+- **`[TRACKING]` and `[EPIC]` title prefixes** stay. Add `type:epic`.
+- **Sub-issue links** replace markdown checklists in epic bodies. Existing
+  checklists in #55 and #63 will be migrated by the migration epic.
+- **CI enforcement** is deliberately out of scope for the first migration.
+  After the backfill lands cleanly, a `ci-issue-taxonomy.yml` check can
+  enforce the required labels on new issues. See the migration plan for
+  details.

--- a/docs/issue-taxonomy.md
+++ b/docs/issue-taxonomy.md
@@ -140,7 +140,22 @@ repo today they are aligned. If they diverge in future, split into
 Execution-order bucket, used by the meta-tracking issue #55. Values:
 `wave:1`, `wave:2`, `wave:3`, `wave:4`, `wave:5`.
 
-### 10. Lease (automatic, single-valued)
+### 10. Rollout (label-triggered automation)
+
+These labels drive `Taxonomy Rollout` (`.github/workflows/taxonomy-rollout.yml`).
+Apply to an epic (not ordinary issues) to kick off a migration.
+
+| Label | Meaning |
+|---|---|
+| `rollout:taxonomy` | User-applied. Triggers the taxonomy rollout's **preview** stage (creates labels, runs backfill dry-run, posts preview comment). |
+| `rollout:taxonomy-apply` | User-applied **after reviewing the preview**. Triggers the **apply** stage (real label + sub-issue changes). |
+| `rollout:in-progress` | Workflow-managed. Indicates a rollout has started. Do not apply by hand. |
+| `rollout:done` | Workflow-managed. Indicates a rollout completed successfully. |
+
+The rollout chain is idempotent and reversible — labels are only added,
+sub-issue edges can be unlinked, and the manifest is editable.
+
+### 11. Lease (automatic, single-valued)
 
 Managed by the lease-reaper workflow. Do not set by hand.
 


### PR DESCRIPTION
## Summary

Scaffolding for a professional, label-based issue taxonomy and agent dispatch
contract. **No existing issues are modified by this PR** — everything here is
additive. Subsequent PRs / issue-admin operations will migrate existing
issues onto the taxonomy; the plan for that is in
`docs/issue-migration-plan.md`.

## What lands

- **`docs/issue-taxonomy.md`** — canonical reference. Defines the label
  dimensions: `type`, `complexity` (agent skill tier required),
  `effort` (size), `judgement` (objective / preference / design / contested),
  plus `quick-win`, `panel-review`, `wave:*` flags. Explains how agents
  self-select pickable work and names the quick-win lane.
- **`docs/issue-migration-plan.md`** — 7-phase plan. Phase 0 is this PR;
  Phase 1 creates labels via the sync workflow; Phase 2 pilots 10 issues;
  Phase 3 converts #55 and #63 checklists to real sub-issue links; Phase 4
  backfills the rest with human approval; Phases 5–7 are optional overlays.
- **`.github/labels.yml`** — manifest of every new label with color and
  description.
- **`.github/workflows/labels-sync.yml`** — idempotent workflow that applies
  `labels.yml` on manual dispatch. Creates missing, updates drifted, leaves
  existing labels alone.
- **`.github/ISSUE_TEMPLATE/`** — Issue Forms for `task`, `bug`, `epic`,
  `research`. Each emits a machine-parseable `<!-- dispatch-metadata:v1 -->`
  block so agents without label access can still triage.
- **`.github/workflows/agent-panel-review.yml`** + **`.github/scripts/panel-review.js`** —
  panel-review workflow. Posts a dispatch brief when an issue is labeled
  `panel-review`, and tallies structured `panel-opinion` comments into a
  summary on a weekly sweep. Panelists are separate agent workflows; this
  one curates the conversation.
- **`CLAUDE.md`** — new section pointing agents at the taxonomy and
  dispatch rules before picking work. The existing `lease:` protocol and
  `claim:*` labels are unchanged and orthogonal.

## Why

Today issue organization is free-form. With many agents picking work, that
means: agents pick beyond their skill tier, quick wins are buried, and
opinion-driven tickets get silently resolved the wrong way. The taxonomy
makes every issue machine-legible on four axes (type, complexity, effort,
judgement) so the dashboard — and any future orchestrator — can dispatch
agents by skill and flag opinion-heavy work for panel review before
implementation.

## What does not change

- Existing labels (`critical`, `high`, `backend`, `security`, `tracking`, …)
  stay as they are.
- The `lease:` comment + `claim:<agent>` label protocol is untouched.
- Existing agent workflows (Jules Control Tower, Lease Reaper, Redundant PR
  Closer, Auto-Repair) continue to work unmodified. They can opt into the
  new labels later.
- No existing issue is modified by this PR.

## Rollout

1. Merge this PR.
2. Run **Labels Sync** workflow manually (`workflow_dispatch`) to create the
   new labels.
3. File the migration tracking epic (done as a follow-up after this PR
   merges, per the plan).
4. Pilot-label ~10 issues; validate the taxonomy; bulk backfill the rest
   with human approval per issue.
5. (Optional, admin-only) create a Projects v2 board that pulls custom
   fields from these labels.

## Test plan

- [ ] `Labels Sync` workflow runs cleanly in dry-run mode
  (`workflow_dispatch` with `dry_run=true`).
- [ ] `Labels Sync` creates every new label when run for real; rerunning
  reports all `skipped`.
- [ ] `Agent Panel Review` sweep workflow runs with no `panel-review`
  issues and exits cleanly.
- [ ] Creating a new issue via the `Task` form produces the
  `dispatch-metadata` block in the body.
- [ ] Agents reading `CLAUDE.md` find the new section and follow the
  dispatch contract on their next pick.

https://claude.ai/code/session_0178M68roQMtuXkhbaECV77R

---
_Generated by [Claude Code](https://claude.ai/code/session_0178M68roQMtuXkhbaECV77R)_