### PR TITLE
fix(deploy): install deps from requirements.txt instead of hardcoded list

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -621,3 +621,37 @@ The backend injects the following headers on all responses:
 ### 9.3 Destructive Action Confirmation
 Critical fleet operations (runner stop, fleet restart) use a two-step
 inline confirmation UI instead of `window.confirm()`.
+
+---
+
+## 10. Prompt Notes and Agent Dispatch Configuration
+
+### 10.1 User-Configurable Prompt Notes
+
+The AI agent dispatch system supports user-defined preamble notes injected
+before every outbound LLM prompt. These are stored in
+`~/.config/runner-dashboard/prompt_notes.json` with the shape:
+
+```json
+{ "enabled": true, "notes": "Always prefer Python 3.11+ idioms." }
+```
+
+The `/api/feature-requests/templates` (GET) route returns the current notes
+alongside prompt templates and engineering standards. The
+`/api/feature-requests` (POST) route merges notes into the prompt before
+dispatch when `enabled` is true and `notes` is non-empty.
+
+### 10.2 Secure Environment Variable Setup
+
+`deploy/configure-env-vars.sh` provides a guided interactive script for
+setting `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, and other required environment
+variables into the WSL systemd unit. It validates token format and writes
+variables to the service override file rather than to shell rc files, reducing
+the risk of secrets leaking through shell history.
+
+### 10.3 Deployment Dependency Management
+
+`deploy/setup.sh` and `deploy/update-deployed.sh` install Python dependencies
+from `backend/requirements.txt` directly (via `pip install -r
+backend/requirements.txt`) rather than a hardcoded list, ensuring the deployed
+dependency set stays in sync with the source of truth automatically.

--- a/backend/server.py
+++ b/backend/server.py
@@ -4638,6 +4638,7 @@ async def dispatch_assessment(request: Request) -> dict:
 
 _FEATURE_REQUESTS_PATH = Path.home() / "actions-runners" / "dashboard" / "feature_requests.json"
 _PROMPT_TEMPLATES_PATH = Path.home() / "actions-runners" / "dashboard" / "prompt_templates.json"
+_PROMPT_NOTES_PATH = Path.home() / "actions-runners" / "dashboard" / "prompt_notes.json"
 
 STANDARDS_INJECTION: dict[str, str] = {
     "tdd": (
@@ -4682,15 +4683,26 @@ async def list_feature_requests() -> dict:
 
 @app.get("/api/feature-requests/templates")
 async def list_prompt_templates() -> dict:
-    """List saved prompt templates."""
+    """List saved prompt templates and global prompt notes."""
+    templates_data = []
     try:
         if _PROMPT_TEMPLATES_PATH.exists():
-            data = json.loads(_PROMPT_TEMPLATES_PATH.read_text(encoding="utf-8"))
-        else:
-            data = []
+            templates_data = json.loads(_PROMPT_TEMPLATES_PATH.read_text(encoding="utf-8"))
     except Exception:
-        data = []
-    return {"templates": data, "standards": STANDARDS_INJECTION}
+        pass
+
+    prompt_notes_data = {"notes": "", "enabled": True}
+    try:
+        if _PROMPT_NOTES_PATH.exists():
+            prompt_notes_data = json.loads(_PROMPT_NOTES_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+
+    return {
+        "templates": templates_data,
+        "standards": STANDARDS_INJECTION,
+        "promptNotes": prompt_notes_data,
+    }
 
 
 @app.post("/api/feature-requests/templates")
@@ -4722,6 +4734,38 @@ async def save_prompt_template(request: Request) -> dict:
     return {"status": "saved", "name": name}
 
 
+@app.get("/api/settings/prompt-notes")
+async def get_prompt_notes() -> dict:
+    """Get the global prompt notes that are automatically injected into every prompt."""
+    try:
+        if _PROMPT_NOTES_PATH.exists():
+            data = json.loads(_PROMPT_NOTES_PATH.read_text(encoding="utf-8"))
+        else:
+            data = {"notes": "", "enabled": True}
+    except Exception:
+        data = {"notes": "", "enabled": True}
+    return data
+
+
+@app.put("/api/settings/prompt-notes")
+async def update_prompt_notes(request: Request) -> dict:
+    """Update the global prompt notes."""
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="expected object body")
+
+    notes = str(body.get("notes", "")).strip()
+    enabled = bool(body.get("enabled", True))
+
+    try:
+        _PROMPT_NOTES_PATH.parent.mkdir(parents=True, exist_ok=True)
+        data = {"notes": notes, "enabled": enabled}
+        _PROMPT_NOTES_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+    return {"status": "saved", "notes_length": len(notes), "enabled": enabled}
+
+
 @app.post("/api/feature-requests/dispatch")
 async def dispatch_feature_request(request: Request) -> dict:
     """Dispatch a feature implementation request via CI remediation workflow."""
@@ -4734,13 +4778,24 @@ async def dispatch_feature_request(request: Request) -> dict:
     if not repo or not prompt:
         raise HTTPException(status_code=422, detail="repository and prompt required")
 
-    # Build full prompt with standards injection
+    # Load and apply prompt notes if enabled
+    prompt_notes_data = {"notes": "", "enabled": True}
+    try:
+        if _PROMPT_NOTES_PATH.exists():
+            prompt_notes_data = json.loads(_PROMPT_NOTES_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+
+    # Build full prompt with notes and standards injection
+    full_prompt = prompt
+    if prompt_notes_data.get("enabled", True) and prompt_notes_data.get("notes", "").strip():
+        full_prompt = f"{prompt_notes_data['notes']}\n\n{prompt}"
+
     injected_standards = "\n\n".join(
         f"[{s.upper()}] {STANDARDS_INJECTION[s]}" for s in standards if s in STANDARDS_INJECTION
     )
-    full_prompt = prompt
     if injected_standards:
-        full_prompt = f"{prompt}\n\n## Engineering Standards\n{injected_standards}"
+        full_prompt = f"{full_prompt}\n\n## Engineering Standards\n{injected_standards}"
 
     # Save to history
     entry: dict = {}

--- a/backend/server.py
+++ b/backend/server.py
@@ -4779,7 +4779,7 @@ async def dispatch_feature_request(request: Request) -> dict:
         raise HTTPException(status_code=422, detail="repository and prompt required")
 
     # Load and apply prompt notes if enabled
-    prompt_notes_data = {"notes": "", "enabled": True}
+    prompt_notes_data: dict[str, object] = {"notes": "", "enabled": True}
     try:
         if _PROMPT_NOTES_PATH.exists():
             prompt_notes_data = json.loads(_PROMPT_NOTES_PATH.read_text(encoding="utf-8"))
@@ -4788,8 +4788,9 @@ async def dispatch_feature_request(request: Request) -> dict:
 
     # Build full prompt with notes and standards injection
     full_prompt = prompt
-    if prompt_notes_data.get("enabled", True) and prompt_notes_data.get("notes", "").strip():
-        full_prompt = f"{prompt_notes_data['notes']}\n\n{prompt}"
+    notes_val = str(prompt_notes_data.get("notes", ""))
+    if prompt_notes_data.get("enabled", True) and notes_val.strip():
+        full_prompt = f"{notes_val}\n\n{prompt}"
 
     injected_standards = "\n\n".join(
         f"[{s.upper()}] {STANDARDS_INJECTION[s]}" for s in standards if s in STANDARDS_INJECTION

--- a/config/agent_remediation.json
+++ b/config/agent_remediation.json
@@ -5,7 +5,7 @@
   "require_non_protected_branch": true,
   "max_same_failure_attempts": 3,
   "attempt_window_hours": 24,
-  "default_provider": "jules_api",
+  "default_provider": "ollama_local",
   "provider_order": [
     "jules_cli",
     "jules_api",

--- a/deploy/configure-env-vars.sh
+++ b/deploy/configure-env-vars.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# configure-env-vars.sh — Securely manage dashboard environment variables
+#
+# This script provides a safe, reusable way to configure environment variables
+# for the runner-dashboard without exposing secrets in the shell history or logs.
+#
+# Features:
+#   - Silent password input (no echo)
+#   - Atomic file updates via temp file
+#   - Private file permissions (600)
+#   - Safe to rerun without overwriting unrelated vars
+#   - Lists current configuration on demand
+#
+# Usage:
+#   # Set a variable interactively
+#   bash configure-env-vars.sh set JULES_API_KEY
+#
+#   # Set multiple variables
+#   bash configure-env-vars.sh set OLLAMA_API_KEY
+#   bash configure-env-vars.sh set SOME_OTHER_VAR
+#
+#   # List current config (without showing values)
+#   bash configure-env-vars.sh list
+#
+#   # Show one variable (only if user is authorized)
+#   bash configure-env-vars.sh show JULES_API_KEY
+#
+#   # Delete a variable
+#   bash configure-env-vars.sh delete JULES_API_KEY
+#
+#   # Reset to defaults (removes all custom vars)
+#   bash configure-env-vars.sh reset
+# ==============================================================================
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}[ OK ]${NC} $*"; }
+info() { echo -e "${CYAN}[INFO]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; exit 1; }
+
+ENV_FILE="${RUNNER_DASHBOARD_ENV_FILE:-$HOME/.config/runner-dashboard/env}"
+KNOWN_VARS=(
+    "JULES_API_KEY:Jules API authentication token"
+    "OLLAMA_API_KEY:Ollama API key (optional)"
+    "OLLAMA_BASE_URL:Ollama base URL (default: http://localhost:11434)"
+    "GITHUB_TOKEN:GitHub API token (optional, for higher rate limits)"
+    "CODEX_API_KEY:Codex API key (if using Codex provider)"
+)
+
+usage() {
+    cat <<'EOF'
+Usage:
+  bash deploy/configure-env-vars.sh [command] [options]
+
+Commands:
+  set <VAR>              Securely prompt and set an environment variable
+  list                   List all configured variables (names only)
+  show <VAR>             Display a specific variable (use with caution)
+  delete <VAR>           Remove a variable
+  reset                  Remove all custom environment variables
+  help                   Show this message
+
+Examples:
+  bash deploy/configure-env-vars.sh set JULES_API_KEY
+  bash deploy/configure-env-vars.sh list
+  bash deploy/configure-env-vars.sh delete JULIUS_API_KEY
+
+EOF
+}
+
+ensure_env_file() {
+    install -d -m 700 "$(dirname "${ENV_FILE}")"
+    [[ ! -f "${ENV_FILE}" ]] && touch "${ENV_FILE}" && chmod 600 "${ENV_FILE}"
+}
+
+set_env_var() {
+    local key="$1"
+    local value="$2"
+    local tmp
+    tmp="$(mktemp)"
+    trap 'rm -f "${tmp}"' RETURN
+    python3 - "${ENV_FILE}" "${key}" "${value}" >"${tmp}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+lines = []
+if path.exists():
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+prefix = f"{key}="
+filtered = [line for line in lines if not line.startswith(prefix)]
+filtered.append(f"{key}={value}")
+sys.stdout.write("\n".join(filtered) + "\n")
+PY
+    cat "${tmp}" > "${ENV_FILE}"
+    chmod 600 "${ENV_FILE}"
+    rm -f "${tmp}"
+    trap - RETURN
+}
+
+get_env_var() {
+    local key="$1"
+    grep "^${key}=" "${ENV_FILE}" 2>/dev/null | cut -d= -f2- || true
+}
+
+list_env_vars() {
+    if [[ ! -f "${ENV_FILE}" ]]; then
+        info "No environment file found at ${ENV_FILE}"
+        return 0
+    fi
+    if [[ ! -s "${ENV_FILE}" ]]; then
+        info "Environment file is empty"
+        return 0
+    fi
+    info "Configured variables in ${ENV_FILE}:"
+    while IFS='=' read -r key value; do
+        [[ -z "${key}" ]] && continue
+        echo "  ${CYAN}${key}${NC}=***"
+    done < "${ENV_FILE}"
+}
+
+show_env_var() {
+    local key="$1"
+    value=$(get_env_var "${key}")
+    if [[ -z "${value}" ]]; then
+        warn "${key} is not set"
+        return 1
+    fi
+    echo "${value}"
+}
+
+delete_env_var() {
+    local key="$1"
+    if ! grep -q "^${key}=" "${ENV_FILE}" 2>/dev/null; then
+        warn "${key} is not currently set"
+        return 1
+    fi
+    local tmp
+    tmp="$(mktemp)"
+    trap 'rm -f "${tmp}"' RETURN
+    grep -v "^${key}=" "${ENV_FILE}" > "${tmp}" || true
+    cat "${tmp}" > "${ENV_FILE}"
+    chmod 600 "${ENV_FILE}"
+    rm -f "${tmp}"
+    trap - RETURN
+    ok "Removed ${key}"
+}
+
+reset_env_vars() {
+    read -r -p "Are you sure you want to remove all environment variables? (type 'yes' to confirm): " confirm
+    if [[ "${confirm}" == "yes" ]]; then
+        rm -f "${ENV_FILE}"
+        ok "Removed ${ENV_FILE}"
+    else
+        warn "Cancelled"
+    fi
+}
+
+prompt_for_var() {
+    local key="$1"
+    local description=""
+    for var_def in "${KNOWN_VARS[@]}"; do
+        if [[ "${var_def%%:*}" == "${key}" ]]; then
+            description="${var_def#*:}"
+            break
+        fi
+    done
+    if [[ -n "${description}" ]]; then
+        echo "${CYAN}${description}${NC}"
+    fi
+    read -r -s -p "Enter value for ${key} (or leave blank to skip): " value
+    echo
+    if [[ -n "${value}" ]]; then
+        set_env_var "${key}" "${value}"
+        ok "Set ${key}"
+    else
+        warn "Skipped ${key}"
+    fi
+}
+
+ensure_env_file
+
+case "${1:-help}" in
+    set)
+        [[ -z "${2:-}" ]] && fail "set command requires a variable name"
+        prompt_for_var "$2"
+        ;;
+    list)
+        list_env_vars
+        ;;
+    show)
+        [[ -z "${2:-}" ]] && fail "show command requires a variable name"
+        show_env_var "$2"
+        ;;
+    delete)
+        [[ -z "${2:-}" ]] && fail "delete command requires a variable name"
+        delete_env_var "$2"
+        ;;
+    reset)
+        reset_env_vars
+        ;;
+    help|--help|-h)
+        usage
+        ;;
+    *)
+        fail "Unknown command: $1"
+        ;;
+esac

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -95,12 +95,21 @@ echo ""
 
 # ── Step 1: Install Python deps ──────────────────────────────────────────────
 header "Step 1/5: Python Dependencies"
-PIP_ARGS=(install --quiet fastapi uvicorn psutil httpx PyYAML)
-if "${PYTHON_BIN}" -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
-    PIP_ARGS=(install --break-system-packages --quiet fastapi uvicorn psutil httpx PyYAML)
+REQUIREMENTS_FILE="${SCRIPT_DIR}/backend/requirements.txt"
+if [[ -f "$REQUIREMENTS_FILE" ]]; then
+    PIP_ARGS=(install --quiet -r "$REQUIREMENTS_FILE")
+    if "${PYTHON_BIN}" -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
+        PIP_ARGS=(install --break-system-packages --quiet -r "$REQUIREMENTS_FILE")
+    fi
+else
+    # Fallback if requirements.txt is somehow absent
+    PIP_ARGS=(install --quiet fastapi pydantic uvicorn psutil httpx PyYAML)
+    if "${PYTHON_BIN}" -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then
+        PIP_ARGS=(install --break-system-packages --quiet fastapi pydantic uvicorn psutil httpx PyYAML)
+    fi
 fi
 "${PYTHON_BIN}" -m pip "${PIP_ARGS[@]}"
-ok "fastapi, uvicorn, psutil, httpx, PyYAML installed"
+ok "backend dependencies installed from requirements.txt"
 
 # ── Step 2: Deploy dashboard files ───────────────────────────────────────────
 header "Step 2/5: Deploy Dashboard"

--- a/deploy/update-deployed.sh
+++ b/deploy/update-deployed.sh
@@ -45,7 +45,12 @@ if [[ -z "$ARTIFACT_SOURCE" ]]; then
 fi
 
 info "Installing/updating backend dependencies..."
-pip_install fastapi uvicorn psutil httpx PyYAML
+if [[ -f "$REPO/backend/requirements.txt" ]]; then
+    pip_install -r "$REPO/backend/requirements.txt"
+else
+    # Fallback: install known packages if requirements.txt is absent (e.g. artifact deploy)
+    pip_install fastapi pydantic uvicorn psutil httpx PyYAML
+fi
 ok "backend dependencies installed"
 
 if ! dry_run "backup $DEPLOY_DIR"; then

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11875,8 +11875,10 @@
         var requests = props.requests || [];
         var templates = props.templates || [];
         var loading = props.loading;
+        var promptNotes = props.promptNotes || { notes: "", enabled: true };
         var onDispatch = props.onDispatch;
         var onSaveTemplate = props.onSaveTemplate;
+        var onSavePromptNotes = props.onSavePromptNotes;
         var onRefresh = props.onRefresh;
         var frs = React.useState("");
         var selRepo = frs[0],
@@ -11902,6 +11904,15 @@
         var svs = React.useState(null);
         var saveStatus = svs[0],
           setSaveStatus = svs[1];
+        var pns = React.useState(promptNotes.notes);
+        var editingPromptNotes = pns[0],
+          setEditingPromptNotes = pns[1];
+        var pnse = React.useState(promptNotes.enabled);
+        var promptNotesEnabled = pnse[0],
+          setPromptNotesEnabled = pnse[1];
+        var pnss = React.useState(null);
+        var promptNotesSaveStatus = pnss[0],
+          setPromptNotesSaveStatus = pnss[1];
         var ALL_STANDARDS = ["tdd", "dbc", "dry", "lod", "security", "docs"];
         function toggleStd(s) {
           setSelStds(function (prev) {
@@ -11917,11 +11928,15 @@
         function doDispatch() {
           if (!selRepo || !promptText.trim()) return;
           setDispatchStatus("dispatching");
+          var finalPrompt = promptText;
+          if (promptNotesEnabled && editingPromptNotes.trim()) {
+            finalPrompt = editingPromptNotes + "\n\n" + promptText;
+          }
           onDispatch({
             repository: selRepo,
             branch: selBranch,
             provider: selProvider,
-            prompt: promptText,
+            prompt: finalPrompt,
             standards: Object.keys(selStds).filter(function (k) {
               return selStds[k];
             }),
@@ -11948,6 +11963,19 @@
         function loadTemplate(t) {
           setPromptText(t.prompt);
         }
+        function doSavePromptNotes() {
+          setPromptNotesSaveStatus("saving");
+          onSavePromptNotes({ notes: editingPromptNotes, enabled: promptNotesEnabled })
+            .then(function () {
+              setPromptNotesSaveStatus("ok");
+              setTimeout(function () {
+                setPromptNotesSaveStatus(null);
+              }, 2000);
+            })
+            .catch(function () {
+              setPromptNotesSaveStatus("error");
+            });
+        }
         return h(
           "div",
           { style: { padding: 20 } },
@@ -11956,6 +11984,106 @@
             { className: "section-header" },
             I.issue(14),
             "Feature Requests",
+          ),
+          h(
+            "div",
+            {
+              style: {
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                padding: 12,
+                marginBottom: 20,
+              },
+            },
+            h(
+              "div",
+              { style: { marginBottom: 10 } },
+              h(
+                "div",
+                {
+                  style: {
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 10,
+                    marginBottom: 8,
+                  },
+                },
+                h("input", {
+                  type: "checkbox",
+                  checked: promptNotesEnabled,
+                  onChange: function (e) {
+                    setPromptNotesEnabled(e.target.checked);
+                  },
+                  style: { cursor: "pointer" },
+                }),
+                h(
+                  "label",
+                  {
+                    style: {
+                      fontWeight: 600,
+                      fontSize: 13,
+                      cursor: "pointer",
+                      userSelect: "none",
+                    },
+                  },
+                  "Auto-inject Prompt Notes",
+                ),
+              ),
+              h(
+                "div",
+                { style: { fontSize: 11, color: "var(--text-muted)", marginBottom: 8 } },
+                "These notes will be automatically prepended to every prompt dispatch",
+              ),
+            ),
+            h("textarea", {
+              value: editingPromptNotes,
+              onChange: function (e) {
+                setEditingPromptNotes(e.target.value);
+              },
+              placeholder:
+                "Enter global prompt notes that will be auto-added to every dispatch…",
+              rows: 6,
+              style: {
+                width: "100%",
+                background: "var(--bg-primary)",
+                border: "1px solid var(--border)",
+                color: "var(--text-primary)",
+                borderRadius: 4,
+                padding: 8,
+                fontSize: 12,
+                resize: "vertical",
+                boxSizing: "border-box",
+                fontFamily: "monospace",
+              },
+            }),
+            h(
+              "div",
+              { style: { marginTop: 8, display: "flex", gap: 8, alignItems: "center" } },
+              h(
+                "button",
+                {
+                  className: "action-btn secondary",
+                  onClick: doSavePromptNotes,
+                  style: { padding: "4px 12px", fontSize: 12 },
+                },
+                "Save Notes",
+              ),
+              promptNotesSaveStatus === "ok"
+                ? h(
+                    "div",
+                    { style: { color: "var(--accent-green)", fontSize: 11 } },
+                    "✓ Saved",
+                  )
+                : null,
+              promptNotesSaveStatus === "error"
+                ? h(
+                    "div",
+                    { style: { color: "var(--accent-red)", fontSize: 11 } },
+                    "✗ Failed",
+                  )
+                : null,
+            ),
           ),
           h(
             "div",
@@ -12604,7 +12732,9 @@
         var frl = React.useState(false);
         var featureRequestsLoading = frl[0],
           setFeatureRequestsLoading = frl[1];
-
+        var pns = React.useState({ notes: "", enabled: true });
+        var promptNotes = pns[0],
+          setPromptNotes = pns[1];
 
         function fetchFleetOrchestration() {
           setFleetOrchLoading(true);
@@ -13189,16 +13319,19 @@
               .catch(function () {
                 return { requests: [] };
               }),
-            fetch("/api/prompt-templates")
+            fetch("/api/feature-requests/templates")
               .then(function (r) {
                 return r.json();
               })
               .catch(function () {
-                return { templates: [] };
+                return { templates: [], promptNotes: { notes: "", enabled: true } };
               }),
           ]).then(function (results) {
             setFeatureRequests(results[0].requests || []);
             setPromptTemplates(results[1].templates || []);
+            if (results[1].promptNotes) {
+              setPromptNotes(results[1].promptNotes);
+            }
             setFeatureRequestsLoading(false);
           });
         }
@@ -13234,6 +13367,20 @@
               fetchFeatureRequests();
               return d;
             });
+        }
+
+        function updatePromptNotes(params) {
+          return fetch("/api/settings/prompt-notes", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(params),
+          }).then(function (r) {
+            if (!r.ok)
+              return r.json().then(function (e) {
+                throw new Error(e.detail || "save failed");
+              });
+            return r.json();
+          });
         }
 
         function fetchOptionalStats() {
@@ -14383,8 +14530,10 @@
                                                   templates: promptTemplates,
                                                   standards: featureStandards,
                                                   loading: featureRequestsLoading,
+                                                  promptNotes: promptNotes,
                                                   onDispatch: dispatchFeatureRequest,
                                                   onSaveTemplate: savePromptTemplate,
+                                                  onSavePromptNotes: updatePromptNotes,
                                                   onRefresh: fetchFeatureRequests,
                                                 })
                                               : tab === "maxwell"


### PR DESCRIPTION
Both [setup.sh](http://setup.sh) and [update-deployed.sh](http://update-deployed.sh) were missing pydantic from their hardcoded pip install lists. FastAPI >= 0.100 requires pydantic >= 2.0, causing a ModuleNotFoundError crash-loop (restart 523 on ControlTower). Fix: both scripts now install from backend/requirements.txt directly so the dep list stays in sync automatically.