### PR TITLE
docs: governance files and security documentation (#40, #50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,20 @@ build/
 node_modules/
 deployment.json
 .DS_Store
+
+# Secrets and credentials
+*.pem
+*.key
+*.p12
+*.pfx
+.env.*
+!.env.example
+*.token
+*_token.txt
+secrets.json
+credentials.json
+
+# Runtime state
+backend/.venv/
+*.pyc
+*.pyo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to Runner Dashboard
+
+Thank you for contributing to the D-sorganization Runner Dashboard. This guide
+covers the development setup, agent coordination protocol, PR requirements, and
+code style rules.
+
+## Dev Setup
+
+```bash
+# Clone the repo
+git clone git@github.com:D-sorganization/runner-dashboard.git
+cd runner-dashboard
+
+# Quick start — installs deps in a venv and starts the server on :8321
+./start-dashboard.sh
+
+# Stop
+./stop-dashboard.sh
+
+# Manual setup
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python server.py
+```
+
+Open http://localhost:8321 in your browser.
+
+**Requirements:** Python 3.11+, a GitHub PAT with `repo` and `admin:org` scopes.
+
+### Lint and format
+
+```bash
+ruff check backend/        # lint
+ruff format backend/       # format
+ruff check backend/ --fix  # auto-fix lint issues
+```
+
+### Type check
+
+```bash
+pip install mypy types-PyYAML types-requests
+mypy backend/ --ignore-missing-imports
+```
+
+### Tests
+
+```bash
+pip install pytest pytest-cov
+pytest tests/ -q --tb=short
+```
+
+### Pre-commit hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit install --hook-type pre-push
+pre-commit run --all-files
+```
+
+## Agent Coordination Protocol
+
+If you are an AI agent picking up an issue, you **must** acquire a coordination
+lease before starting work to avoid redundant parallel effort.
+
+**Lease protocol:**
+
+1. Read `docs/agent-coordination-strategy.md` for full protocol details.
+2. Post a lease comment on the issue before beginning work:
+   ```
+   lease: <agent-id> expires <ISO-8601 timestamp +2h>
+   ```
+3. Renew the lease every 2 hours if work is still ongoing.
+4. Release the lease (or let it expire naturally) when the PR is opened or work
+   is abandoned.
+
+The Agent Lease Reaper workflow sweeps expired leases every 30 minutes.
+`claim:<agent>` labels are automatically removed when leases expire without an
+open PR.
+
+**Agent priority order** (highest wins redundancy conflicts):
+`user > maxwell-daemon > claude > codex > jules > local > gaai`
+
+Before picking up an issue, confirm it is **pickable**: state is `open`, no
+open PR references it, no active `claim:*` lease, and the issue's
+`complexity:*` label is within your skill tier. Do not implement from issues
+labelled `judgement:design` or `judgement:contested` — those require panel
+review first.
+
+## PR Requirements
+
+1. **CI Standard must pass** (`ci-standard.yml`): ruff lint, ruff format, mypy
+   type check, pip-audit, and the pytest suite all run on every PR.
+2. **Update SPEC.md** if your PR adds or changes any documented behavior in the
+   backend. Spec Check (`ci-spec-check.yml`) will fail if backend source files
+   change without a corresponding SPEC.md update. Apply the `spec-exempt` label
+   only if the change genuinely has no spec impact.
+3. **Conventional Commits**: use `feat:`, `fix:`, `chore:`, `docs:` prefixes in
+   commit messages.
+4. **Branch naming**: use `feat/`, `fix/`, `chore/`, or `docs/` prefixes.
+
+## Code Style
+
+### Python (backend/)
+
+- Python 3.11+ only. Use `match`/`case`, `X | Y` unions, `datetime.UTC`.
+- All public functions must have full type annotations.
+- Use the `logging` module via `log = logging.getLogger("dashboard")`. Never
+  use `print()`.
+- Prefer `pathlib.Path` over `os.path`.
+- Keep functions focused; functions over ~50 lines are candidates for
+  extraction.
+- Imports: stdlib → third-party → local, sorted within groups (ruff enforces).
+- No wildcard imports (`from module import *`).
+- No debug statements (`breakpoint()`, `import pdb`).
+- Constants in `UPPER_SNAKE_CASE` at module level.
+- FastAPI route handlers should be `async` where I/O is involved.
+
+### Frontend (frontend/)
+
+- **No build step.** The frontend is a single `index.html` served directly.
+- **No JSX.** Use `h()` (aliased from `React.createElement`) for all elements.
+- **No npm / node_modules.** All dependencies are loaded from CDN via
+  `<script>` tags.
+- State managed with React hooks (`useState`, `useEffect`, `useCallback`).
+- Tabs are top-level components defined in the single file.
+- Styling via inline styles and a minimal CSS block in `<style>`.
+- No TypeScript — plain JavaScript with JSDoc comments for complex types.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present D-sorganization contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ The dashboard is a local FastAPI server that proxies the GitHub API and exposes
 system metrics. The frontend is a self-contained React SPA served directly as
 a static HTML file — no build step, no npm, no node_modules.
 
+## Security
+
+> **Security Notice**: This dashboard provides full control over your GitHub
+> Actions runner fleet. It has no built-in authentication. Restrict network
+> access to trusted operators only. See [SECURITY.md](SECURITY.md) for the
+> vulnerability disclosure policy.
+
 ## Features
 
 - **Fleet Tab** — Real-time runner status (idle/active/offline), per-runner

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Only the current major version receives security fixes.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Report security vulnerabilities via GitHub Security Advisories:
+
+> https://github.com/D-sorganization/runner-dashboard/security/advisories/new
+
+Provide as much detail as possible: steps to reproduce, potential impact,
+and any suggested mitigations.
+
+## Response SLA
+
+- **Acknowledgement:** within 48 hours of receiving the report.
+- **Critical vulnerabilities:** patch released within 14 days.
+- **Non-critical vulnerabilities:** patch released in the next scheduled release.
+
+We will keep you informed as the fix progresses and credit you in the release
+notes unless you request otherwise.
+
+## Out of Scope
+
+The following are outside the scope of this security policy:
+
+- **Denial of service on self-hosted infrastructure** — the dashboard runs on
+  operator-controlled hardware; resource exhaustion attacks against that
+  infrastructure are an operator responsibility.
+- **Physical access attacks** — attacks that require physical access to the
+  host machine running the dashboard.
+- **Issues in third-party CDN dependencies** — report those to the upstream
+  project.
+- **Social engineering** — attacks targeting operators rather than the software.

--- a/SPEC.md
+++ b/SPEC.md
@@ -621,3 +621,30 @@ The backend injects the following headers on all responses:
 ### 9.3 Destructive Action Confirmation
 Critical fleet operations (runner stop, fleet restart) use a two-step
 inline confirmation UI instead of `window.confirm()`.
+
+### 9.4 Token Handling
+`GH_TOKEN` and `ANTHROPIC_API_KEY` must be supplied as environment variables
+only — never hardcoded in source files or configuration. The recommended setup
+path is the `configure-env-vars.sh` script, which writes tokens to the systemd
+override file so they are not visible in the process environment of child
+processes and are not stored in shell history.
+
+### 9.5 Network Exposure
+The dashboard backend binds to `0.0.0.0:8321` by default so that multi-node
+fleet monitoring works across the local network. Operators who do not need
+cross-node access should bind to `127.0.0.1` instead (set the `HOST`
+environment variable or modify the `systemd` unit file). No TLS is provided
+by the dashboard itself; use a reverse proxy (nginx, Caddy) in front of the
+service when HTTPS is required.
+
+### 9.6 Operator Hardening Checklist
+- Restrict network access to port 8321 via firewall rules (`ufw`, `iptables`,
+  or cloud security groups); do not expose it publicly.
+- Rotate `GH_TOKEN` and `ANTHROPIC_API_KEY` on a regular schedule (at minimum
+  whenever a team member departs).
+- Keep Python dependencies current: run `pip-audit` and `pip install -U -r
+  requirements.txt` during routine maintenance windows.
+- Review agent dispatch logs in the Remediation tab regularly to detect
+  unexpected or unauthorized agent invocations.
+- Consider binding to `127.0.0.1` and using a reverse proxy with
+  authentication if the dashboard is accessible to untrusted network segments.


### PR DESCRIPTION
Closes #40
Closes #50

## Summary

- **LICENSE**: MIT License, 2024-present, D-sorganization contributors.
- **SECURITY.md**: Supported versions table, private disclosure instructions via GitHub Security Advisories, 48h acknowledgement / 14-day critical patch SLA, out-of-scope items (DoS on self-hosted infra, physical access).
- **CONTRIBUTING.md**: Dev setup commands, agent coordination lease protocol summary, PR requirements (CI Standard, SPEC.md update rule), Python and frontend code style.
- **.gitignore**: Appended secret/credential file patterns (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `.env.*`, `*.token`, `*_token.txt`, `secrets.json`, `credentials.json`) and runtime state entries (`backend/.venv/`, `*.pyc`, `*.pyo`) without duplicating existing entries.
- **SPEC.md**: Added sections 9.4 (Token Handling — env-var-only, `configure-env-vars.sh`), 9.5 (Network Exposure — default `0.0.0.0:8321`, reverse proxy guidance), 9.6 (Operator Hardening Checklist).
- **README.md**: Added a Security Notice section near the top warning that the dashboard has no built-in authentication and linking to SECURITY.md.

## Test plan

- [x] `ruff check backend/` passes
- [x] `ruff format --check backend/` passes
- [x] All new files created at repo root
- [x] .gitignore has no duplicate patterns
- [x] SPEC.md section 9 now has subsections 9.1–9.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)