### PR TITLE
feat(frontend): add SubTabs component and refactor Remediation tab (#79)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -106,6 +106,15 @@ All application logic is contained within `frontend/index.html`. There is no
 npm project, no `package.json`, and no build toolchain. The file is served
 directly by the FastAPI backend.
 
+**Shared helper components** defined near the top of the script block:
+
+- `Collapse` — collapsible section with header and chevron.
+- `SubTabs` — horizontal sub-tab strip rendered inside a tab panel. Props:
+  `tabs` (array of `{ key, label, badge, disabled }`), `activeKey`, `onChange`,
+  `storageKey` (optional localStorage persistence key), `rightBadge` (optional
+  element flush-right of the strip). Active tab is persisted to localStorage
+  when `storageKey` is provided.
+
 `frontend/index.html` is the **sole canonical frontend source**. No other
 frontend implementation exists in the repository. The previously present
 `RunnerDashboard.jsx` was an unused JSX archive that violated DRY; it was
@@ -181,6 +190,16 @@ Health status of local registered applications (processes, services defined in
 AI agent dispatch control panel. Configures and dispatches remediation plans
 to Jules, GAAI, Claude, or Codex agents. Shows dispatch history and plan
 status. Supports per-repo agent routing.
+
+The Remediation tab uses the `SubTabs` component to expose three sub-tabs:
+
+- **Automations** (default) — all existing agent dispatch and policy
+  configuration UI.
+- **PRs** — placeholder for future PR dispatch (issue #83).
+- **Issues** — placeholder for future issue dispatch (issue #84).
+
+The active sub-tab is persisted to `localStorage` under the key
+`remediation-subtab`.
 
 ### 3.13 Workflows Tab
 Browse and manually dispatch any workflow in any org repository. Supports

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1219,6 +1219,17 @@
           font-size: 10px;
         }
       }
+
+      /* ── SubTabs ── */
+      .subtabs { display: flex; flex-direction: row; justify-content: space-between; border-bottom: 1px solid var(--border); padding: 0 8px; }
+      .subtabs-strip { display: flex; flex-direction: row; gap: 4px; }
+      .subtab { background: none; border: none; border-bottom: 2px solid transparent; padding: 8px 14px; color: var(--text-muted); cursor: pointer; font-size: 13px; font-weight: 500; }
+      .subtab:hover { color: var(--text-primary); }
+      .subtab.active { color: var(--text-primary); border-bottom-color: var(--accent-blue); }
+      .subtab-badge { display: inline-block; margin-left: 6px; padding: 0 6px; border-radius: 10px; font-size: 11px; background: var(--bg-tertiary); color: var(--text-muted); }
+      .subtab.active .subtab-badge { background: rgba(88,166,255,0.15); color: var(--accent-blue); }
+      .subtab:disabled { opacity: 0.5; cursor: not-allowed; }
+      .subtabs-right { display: flex; align-items: center; }
     </style>
   </head>
   <body>
@@ -1708,6 +1719,51 @@
             { className: "section-body" + (o ? "" : " collapsed") },
             p.children,
           ),
+        );
+      }
+
+      function SubTabs(p) {
+        var tabs = p.tabs || [];
+        var storageKey = p.storageKey;
+        var initialKey = storageKey
+          ? (localStorage.getItem(storageKey) || tabs[0] && tabs[0].key)
+          : (tabs[0] && tabs[0].key);
+        var ia = React.useState(initialKey);
+        var internalActive = ia[0],
+          setInternalActive = ia[1];
+        var activeKey = p.activeKey !== undefined ? p.activeKey : internalActive;
+        function handleChange(key) {
+          if (p.activeKey === undefined) {
+            setInternalActive(key);
+          }
+          if (storageKey) {
+            try { localStorage.setItem(storageKey, key); } catch (e) {}
+          }
+          if (p.onChange) p.onChange(key);
+        }
+        return h(
+          "div",
+          { className: "subtabs" },
+          h(
+            "div",
+            { className: "subtabs-strip" },
+            tabs.map(function (tab) {
+              return h(
+                "button",
+                {
+                  key: tab.key,
+                  className: "subtab" + (activeKey === tab.key ? " active" : ""),
+                  disabled: tab.disabled || false,
+                  onClick: function () { if (!tab.disabled) handleChange(tab.key); },
+                },
+                tab.label,
+                tab.badge != null
+                  ? h("span", { className: "subtab-badge" }, tab.badge)
+                  : null,
+              );
+            }),
+          ),
+          p.rightBadge ? h("div", { className: "subtabs-right" }, p.rightBadge) : null,
         );
       }
 
@@ -7938,10 +7994,30 @@
           setEditingDefaultProvider(false);
         }
         var accepted = !!(plan && plan.decision && plan.decision.accepted);
+        var sta = React.useState(
+          (function () {
+            try { return localStorage.getItem("remediation-subtab") || "automations"; } catch (e) { return "automations"; }
+          })()
+        );
+        var subTab = sta[0],
+          setSubTab = sta[1];
 
         return h(
           "div",
           null,
+          h(SubTabs, {
+            tabs: [
+              { key: "automations", label: "Automations" },
+              { key: "prs", label: "PRs", disabled: true },
+              { key: "issues", label: "Issues", disabled: true },
+            ],
+            activeKey: subTab,
+            onChange: setSubTab,
+            storageKey: "remediation-subtab",
+          }),
+          subTab === "automations" && h(
+            "div",
+            null,
           // ── Manual Dispatch section (TOP) ────────────────────────────────
           h(
             "div",
@@ -9144,6 +9220,19 @@
               ),
             ),
           ),
+          ),
+          subTab === "prs" &&
+            h(
+              "div",
+              { style: { padding: "24px", color: "var(--text-muted)" } },
+              "PR dispatch coming soon",
+            ),
+          subTab === "issues" &&
+            h(
+              "div",
+              { style: { padding: "24px", color: "var(--text-muted)" } },
+              "Issue dispatch coming soon",
+            ),
         );
       }
 


### PR DESCRIPTION
## Summary

- Adds reusable `SubTabs` helper component (`frontend/index.html`) with controlled/uncontrolled modes, `localStorage` persistence via `storageKey`, badge chips per tab, disabled state, and an optional `rightBadge` slot
- Adds matching CSS classes (`.subtabs`, `.subtabs-strip`, `.subtab`, `.subtab-badge`, `.subtabs-right`) using the existing dark-theme CSS variables
- Refactors `RemediationTab` to render a `SubTabs` strip at the top with three sub-tabs: **Automations** (all existing content, default), **PRs** (disabled placeholder, issue #83), **Issues** (disabled placeholder, issue #84); active sub-tab persisted to `localStorage` key `remediation-subtab`
- Updates `SPEC.md` to document the `SubTabs` component and the Remediation tab sub-tab structure

## Test plan

- [ ] Open the dashboard in a browser and navigate to the Remediation tab
- [ ] Confirm the Automations / PRs / Issues sub-tab strip appears at the top
- [ ] Confirm PRs and Issues tabs are visually dimmed and not clickable
- [ ] Confirm all existing Automations content (dispatch, policy, history) renders identically under the Automations sub-tab
- [ ] Reload the page and confirm the active sub-tab is restored from localStorage
- [ ] Visually confirm sub-tab strip matches the dark-theme styling (accent blue underline on active tab)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)