### PR TITLE
feat(backend): add PR and issue aggregation APIs (#80, #81)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -78,6 +78,8 @@ surface task action details without exposing secrets.
 | `report_files.py` | Parse dated report files for the Reports tab |
 | `runner_autoscaler.py` | Dynamic runner count scaling logic |
 | `config_schema.py` | Config validation and atomic JSON writes |
+| `pr_inventory.py` | Fetch and normalise open PRs across repos (issue #80) |
+| `issue_inventory.py` | Fetch and normalise open issues with taxonomy (issue #81) |
 
 **Bounded domain routers (`backend/routers/`):**
 
@@ -711,3 +713,146 @@ the risk of secrets leaking through shell history.
 from `backend/requirements.txt` directly (via `pip install -r
 backend/requirements.txt`) rather than a hardcoded list, ensuring the deployed
 dependency set stays in sync with the source of truth automatically.
+
+---
+
+## 11. PR Inventory API
+
+Implemented in `backend/pr_inventory.py`; thin route shells in `backend/server.py`.
+
+### 11.1 `GET /api/prs`
+
+Aggregates open pull-requests across organisation repositories.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo` | string (repeatable) | all org repos | Filter to specific `owner/repo` slugs |
+| `include_drafts` | bool | `true` | Include draft PRs |
+| `author` | string | — | Filter by author login |
+| `label` | string (repeatable) | — | Match any of these labels |
+| `limit` | int | 500 | Maximum items returned (hard cap 2000) |
+
+**Response:**
+
+```json
+{
+  "items": [
+    {
+      "repository": "D-sorganization/runner-dashboard",
+      "number": 76,
+      "title": "...",
+      "url": "...",
+      "author": "dieter",
+      "draft": false,
+      "age_hours": 12.3,
+      "labels": ["bug", "ci"],
+      "requested_reviewers": ["alice"],
+      "head_ref": "fix/something",
+      "mergeable_state": "clean",
+      "agent_claim": null,
+      "linked_issues": [24, 43]
+    }
+  ],
+  "total": 1,
+  "errors": []
+}
+```
+
+- `agent_claim` — extracted from any `claim:*` label on the PR.
+- `linked_issues` — issue numbers found via `closes/fixes/resolves #N` in the PR body.
+- `errors` — per-repo error messages; a failing repo does not abort the whole request.
+- Responses are cached 30 seconds in-process keyed by query parameters.
+
+### 11.2 `GET /api/prs/{owner}/{repo}/{number}`
+
+Returns single-PR detail with extra fields not present in the list endpoint:
+
+| Field | Description |
+|---|---|
+| `body_excerpt` | First 2 KB of the PR body |
+| `checks` | List of `{name, conclusion, url}` from the commit check-runs API |
+| `files_changed` | Number of changed files |
+| `additions` | Lines added |
+| `deletions` | Lines deleted |
+
+---
+
+## 12. Issue Inventory API
+
+Implemented in `backend/issue_inventory.py`; thin route shell in `backend/server.py`.
+
+### 12.1 `GET /api/issues`
+
+Aggregates open issues across organisation repositories with taxonomy-aware
+filtering.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo` | string (repeatable) | all org repos | Filter to specific `owner/repo` slugs |
+| `state` | `open` \| `all` | `open` | Issue state |
+| `label` | string (repeatable) | — | Match any of these labels |
+| `assignee` | string | — | Filter by assignee login |
+| `pickable_only` | bool | `false` | Only return issues available for agent pickup |
+| `complexity` | string (repeatable) | — | Match any `complexity:*` value |
+| `effort` | string (repeatable) | — | Match any `effort:*` value |
+| `judgement` | string (repeatable) | — | Match any `judgement:*` value |
+| `limit` | int | 500 | Maximum items returned (hard cap 2000) |
+
+**Response:**
+
+```json
+{
+  "items": [
+    {
+      "repository": "D-sorganization/runner-dashboard",
+      "number": 76,
+      "title": "...",
+      "url": "...",
+      "author": "dieter",
+      "assignees": [],
+      "labels": ["bug", "ci"],
+      "age_hours": 12.3,
+      "taxonomy": {
+        "type": "task",
+        "complexity": "routine",
+        "effort": "m",
+        "judgement": "objective",
+        "quick_win": false,
+        "panel_review": false,
+        "domains": ["backend"],
+        "wave": 2
+      },
+      "agent_claim": null,
+      "claim_expires_at": null,
+      "linked_pr": null,
+      "pickable": true,
+      "pickable_blocked_by": []
+    }
+  ],
+  "errors": []
+}
+```
+
+**Taxonomy parsing** (`parse_taxonomy` in `issue_inventory.py`):
+Labels take precedence. Recognised prefixes: `type:*`, `complexity:*`,
+`effort:*`, `judgement:*`, `wave:*`, `domain:*`. Boolean flags: `quick-win`,
+`panel-review`.
+
+**Pickability rules** (`is_pickable` in `issue_inventory.py`):
+An issue is pickable when ALL of the following hold:
+
+1. `state == "open"`
+2. No linked open PR (`linked_pr == null`)
+3. No active `claim:*` label
+4. `judgement` not in `{"design", "contested"}`
+
+`pickable_blocked_by` lists the human-readable reasons when `pickable` is
+`false`.
+
+- Per-repo errors appear in `errors[]`; a failing repo does not abort the
+  whole request.
+- Responses are cached 30 seconds in-process.

--- a/backend/issue_inventory.py
+++ b/backend/issue_inventory.py
@@ -1,0 +1,347 @@
+"""Issue inventory — fetch and normalise open issues across repositories.
+
+This module is a thin data layer used by the ``/api/issues`` FastAPI route in
+``server.py``.  All GitHub interaction goes through the ``gh`` CLI.
+
+Taxonomy labels follow the schema in ``docs/issue-taxonomy.md``:
+  ``type:*``, ``complexity:*``, ``effort:*``, ``judgement:*``,
+  ``quick-win``, ``panel-review``, ``wave:*``, ``domain:*``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+log = logging.getLogger("dashboard")
+
+# ─── In-process cache ────────────────────────────────────────────────────────
+_cache: dict[str, tuple[Any, float]] = {}
+_CACHE_TTL = 30.0  # seconds
+
+# ─── Taxonomy constants ───────────────────────────────────────────────────────
+_BLOCKED_JUDGEMENTS = {"design", "contested"}
+
+
+def _cache_get(key: str) -> Any | None:
+    entry = _cache.get(key)
+    if entry is not None:
+        data, ts = entry
+        if time.monotonic() - ts < _CACHE_TTL:
+            return data
+    return None
+
+
+def _cache_set(key: str, data: Any) -> None:
+    _cache[key] = (data, time.monotonic())
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _run_gh(args: list[str], timeout: int = 30) -> tuple[int, str, str]:
+    """Run ``gh`` with the given arguments asynchronously."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "gh",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return 127, "", "gh CLI not found"
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        return proc.returncode or 0, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+    except (TimeoutError, asyncio.TimeoutError):  # noqa: UP041
+        proc.kill()
+        return -1, "", "gh command timed out"
+
+
+def _age_hours(created_at: str) -> float:
+    """Return hours since *created_at* (ISO-8601 UTC string), rounded to 1dp."""
+    try:
+        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        delta = datetime.now(tz=UTC) - created
+        return round(delta.total_seconds() / 3600, 1)
+    except (ValueError, AttributeError):
+        return 0.0
+
+
+def _parse_agent_claim(labels: list[str]) -> tuple[str | None, str | None]:
+    """Return ``(agent, claim_label)`` for a ``claim:*`` label, else ``(None, None)``."""
+    for lbl in labels:
+        if lbl.startswith("claim:"):
+            return lbl[len("claim:") :], lbl
+    return None, None
+
+
+def _parse_claim_expiry(body: str | None) -> str | None:
+    """Extract expiry timestamp from lease comment pattern in body."""
+    if not body:
+        return None
+    m = re.search(r"lease:\s+\S+\s+expires\s+(\S+)", body, re.IGNORECASE)
+    return m.group(1) if m else None
+
+
+# ─── Taxonomy parsing ─────────────────────────────────────────────────────────
+
+
+def parse_taxonomy(labels: list[str], body: str = "") -> dict:  # noqa: ARG001
+    """Parse issue taxonomy from label list.
+
+    Labels take precedence over any metadata in the body.  Valid prefixes:
+    ``type:``, ``complexity:``, ``effort:``, ``judgement:``, ``wave:``,
+    ``domain:``.  Boolean flags: ``quick-win``, ``panel-review``.
+
+    Parameters
+    ----------
+    labels:
+        List of label name strings on the issue.
+    body:
+        Issue body text (currently unused; reserved for future metadata
+        fallback).
+
+    Returns
+    -------
+    dict with keys: type, complexity, effort, judgement, quick_win,
+    panel_review, domains, wave.
+    """
+    taxonomy: dict[str, Any] = {
+        "type": None,
+        "complexity": None,
+        "effort": None,
+        "judgement": None,
+        "quick_win": False,
+        "panel_review": False,
+        "domains": [],
+        "wave": None,
+    }
+    domains: list[str] = []
+    for lbl in labels:
+        if lbl.startswith("type:"):
+            taxonomy["type"] = lbl[len("type:") :]
+        elif lbl.startswith("complexity:"):
+            taxonomy["complexity"] = lbl[len("complexity:") :]
+        elif lbl.startswith("effort:"):
+            taxonomy["effort"] = lbl[len("effort:") :]
+        elif lbl.startswith("judgement:"):
+            taxonomy["judgement"] = lbl[len("judgement:") :]
+        elif lbl.startswith("wave:"):
+            val = lbl[len("wave:") :]
+            try:
+                taxonomy["wave"] = int(val)
+            except ValueError:
+                taxonomy["wave"] = val
+        elif lbl.startswith("domain:"):
+            domains.append(lbl[len("domain:") :])
+        elif lbl == "quick-win":
+            taxonomy["quick_win"] = True
+        elif lbl == "panel-review":
+            taxonomy["panel_review"] = True
+    taxonomy["domains"] = domains
+    return taxonomy
+
+
+# ─── Pickability ──────────────────────────────────────────────────────────────
+
+
+def is_pickable(item: dict, has_open_pr: bool) -> tuple[bool, list[str]]:
+    """Determine whether an issue is available for agent pickup.
+
+    Rules (all must hold):
+
+    1. ``state == "open"`` (checked on the item itself).
+    2. No linked open PR (``has_open_pr`` must be *False*).
+    3. No active ``claim:*`` label.
+    4. ``judgement`` not in ``{"design", "contested"}``.
+
+    Returns
+    -------
+    ``(pickable, blocked_by)`` where *blocked_by* is a list of human-readable
+    reason strings when *pickable* is *False*.
+    """
+    blocked: list[str] = []
+
+    if item.get("state", "open") != "open":
+        blocked.append("state != open")
+
+    if has_open_pr:
+        blocked.append("has linked open PR")
+
+    if item.get("agent_claim") is not None:
+        blocked.append(f"active claim: {item['agent_claim']}")
+
+    judgement = (item.get("taxonomy") or {}).get("judgement")
+    if judgement in _BLOCKED_JUDGEMENTS:
+        blocked.append(f"judgement:{judgement} requires panel review")
+
+    return len(blocked) == 0, blocked
+
+
+# ─── Normalisation ────────────────────────────────────────────────────────────
+
+
+def _normalise_issue(issue: dict, full_name: str) -> dict:
+    """Convert a raw GitHub issue payload into the canonical inventory shape."""
+    labels: list[str] = [lbl["name"] for lbl in (issue.get("labels") or [])]
+    assignees: list[str] = [
+        a["login"] for a in (issue.get("assignees") or []) if isinstance(a, dict) and a.get("login")
+    ]
+    agent_claim, _ = _parse_agent_claim(labels)
+    claim_expires_at = _parse_claim_expiry(issue.get("body")) if agent_claim else None
+    taxonomy = parse_taxonomy(labels, issue.get("body") or "")
+    created_at: str = issue.get("created_at") or ""
+
+    return {
+        "repository": full_name,
+        "number": issue.get("number"),
+        "title": issue.get("title") or "",
+        "url": issue.get("html_url") or "",
+        "author": (issue.get("user") or {}).get("login") or "",
+        "assignees": assignees,
+        "labels": labels,
+        "state": issue.get("state") or "open",
+        "age_hours": _age_hours(created_at),
+        "taxonomy": taxonomy,
+        "agent_claim": agent_claim,
+        "claim_expires_at": claim_expires_at,
+        "linked_pr": None,  # populated by caller if PR data is available
+        "pickable": False,  # computed below
+        "pickable_blocked_by": [],
+    }
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
+async def fetch_repo_issues(full_name: str, state: str = "open") -> tuple[list[dict], str | None]:
+    """Fetch issues for *full_name* (``owner/repo``).
+
+    GitHub's issues API returns PRs too — we filter them out via the
+    ``pull_request`` key that is present on PR objects.
+
+    Returns ``(items, error_message)`` where *error_message* is *None* on
+    success.
+    """
+    gh_state = "open" if state == "open" else "all"
+    code, stdout, stderr = await _run_gh(
+        ["api", f"/repos/{full_name}/issues?state={gh_state}&per_page=100"],
+        timeout=30,
+    )
+    if code != 0:
+        msg = f"{full_name}: gh exit {code}: {stderr.strip()[:200]}"
+        log.warning("issue_inventory: %s", msg)
+        return [], msg
+    try:
+        raw = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        msg = f"{full_name}: JSON decode error: {exc}"
+        log.warning("issue_inventory: %s", msg)
+        return [], msg
+    if not isinstance(raw, list):
+        msg = f"{full_name}: unexpected response shape"
+        log.warning("issue_inventory: %s", msg)
+        return [], msg
+
+    items = []
+    for issue in raw:
+        # Skip pull-requests which appear in the issues endpoint
+        if issue.get("pull_request") is not None:
+            continue
+        items.append(_normalise_issue(issue, full_name))
+    return items, None
+
+
+async def fetch_all_issues(
+    repos: list[str],
+    *,
+    state: str = "open",
+    labels: list[str] | None = None,
+    assignee: str | None = None,
+    pickable_only: bool = False,
+    complexity: list[str] | None = None,
+    effort: list[str] | None = None,
+    judgement: list[str] | None = None,
+    limit: int = 500,
+) -> dict:
+    """Aggregate issues across *repos* with optional filters.
+
+    Parameters
+    ----------
+    repos:
+        List of ``owner/repo`` slugs.
+    state:
+        ``"open"`` (default) or ``"all"``.
+    labels:
+        Match any of these label names.
+    assignee:
+        Filter by assignee login.
+    pickable_only:
+        When *True*, only pickable issues are returned.
+    complexity / effort / judgement:
+        Filter by taxonomy dimension (match any provided value).
+    limit:
+        Maximum number of items (hard cap 2000).
+    """
+    limit = min(limit, 2000)
+    label_set: set[str] = set(labels) if labels else set()
+    complexity_set: set[str] = set(complexity) if complexity else set()
+    effort_set: set[str] = set(effort) if effort else set()
+    judgement_set: set[str] = set(judgement) if judgement else set()
+
+    cache_key = (
+        f"issues|{','.join(sorted(repos))}|{state}|{','.join(sorted(label_set))}"
+        f"|{assignee}|{pickable_only}|{','.join(sorted(complexity_set))}"
+        f"|{','.join(sorted(effort_set))}|{','.join(sorted(judgement_set))}|{limit}"
+    )
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    tasks = [fetch_repo_issues(repo, state) for repo in repos]
+    results = await asyncio.gather(*tasks)
+
+    items: list[dict] = []
+    errors: list[str] = []
+
+    for repo_items, err in results:
+        if err:
+            errors.append(err)
+            continue
+        for item in repo_items:
+            # Label filter
+            if label_set and not label_set.intersection(item["labels"]):
+                continue
+            # Assignee filter
+            if assignee and assignee not in item["assignees"]:
+                continue
+            # Taxonomy dimension filters
+            taxonomy = item.get("taxonomy") or {}
+            if complexity_set and taxonomy.get("complexity") not in complexity_set:
+                continue
+            if effort_set and taxonomy.get("effort") not in effort_set:
+                continue
+            if judgement_set and taxonomy.get("judgement") not in judgement_set:
+                continue
+
+            # Compute pickability (no open PR lookup here — caller can enrich)
+            pickable, blocked_by = is_pickable(item, has_open_pr=item["linked_pr"] is not None)
+            item["pickable"] = pickable
+            item["pickable_blocked_by"] = blocked_by
+
+            if pickable_only and not pickable:
+                continue
+            items.append(item)
+
+    items.sort(key=lambda x: x["age_hours"])
+    items = items[:limit]
+
+    result = {"items": items, "errors": errors}
+    _cache_set(cache_key, result)
+    return result

--- a/backend/pr_inventory.py
+++ b/backend/pr_inventory.py
@@ -1,0 +1,254 @@
+"""PR inventory — fetch and normalise open pull-requests across repositories.
+
+This module is a thin data layer used by the ``/api/prs`` and
+``/api/prs/{owner}/{repo}/{number}`` FastAPI routes in ``server.py``.
+All GitHub interaction goes through the ``gh`` CLI (same pattern as the rest of
+the backend) so no extra credentials are required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+log = logging.getLogger("dashboard")
+
+# ─── In-process cache ────────────────────────────────────────────────────────
+_cache: dict[str, tuple[Any, float]] = {}
+_CACHE_TTL = 30.0  # seconds
+
+
+def _cache_get(key: str) -> Any | None:
+    entry = _cache.get(key)
+    if entry is not None:
+        data, ts = entry
+        if time.monotonic() - ts < _CACHE_TTL:
+            return data
+    return None
+
+
+def _cache_set(key: str, data: Any) -> None:
+    _cache[key] = (data, time.monotonic())
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _run_gh(args: list[str], timeout: int = 30) -> tuple[int, str, str]:
+    """Run ``gh`` with the given arguments asynchronously."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "gh",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return 127, "", "gh CLI not found"
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        return proc.returncode or 0, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+    except (TimeoutError, asyncio.TimeoutError):  # noqa: UP041
+        proc.kill()
+        return -1, "", "gh command timed out"
+
+
+def _age_hours(created_at: str) -> float:
+    """Return hours since *created_at* (ISO-8601 UTC string), rounded to 1dp."""
+    try:
+        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        delta = datetime.now(tz=UTC) - created
+        return round(delta.total_seconds() / 3600, 1)
+    except (ValueError, AttributeError):
+        return 0.0
+
+
+def _parse_agent_claim(labels: list[str]) -> str | None:
+    """Return the agent name from a ``claim:*`` label, or *None*."""
+    for lbl in labels:
+        if lbl.startswith("claim:"):
+            return lbl[len("claim:") :]
+    return None
+
+
+def _parse_linked_issues(body: str | None) -> list[int]:
+    """Extract issue numbers referenced by closing keywords in *body*."""
+    if not body:
+        return []
+    matches = re.findall(r"(?:closes|fixes|resolves)\s+#(\d+)", body, re.IGNORECASE)
+    return sorted({int(m) for m in matches})
+
+
+def _normalise_pr(pr: dict, full_name: str) -> dict:
+    """Convert a raw GitHub PR payload into the canonical inventory shape."""
+    labels: list[str] = [lbl["name"] for lbl in (pr.get("labels") or [])]
+    reviewers: list[str] = [
+        r["login"] for r in (pr.get("requested_reviewers") or []) if isinstance(r, dict) and r.get("login")
+    ]
+    created_at: str = pr.get("created_at") or ""
+    return {
+        "repository": full_name,
+        "number": pr.get("number"),
+        "title": pr.get("title") or "",
+        "url": pr.get("html_url") or "",
+        "author": (pr.get("user") or {}).get("login") or "",
+        "draft": bool(pr.get("draft")),
+        "age_hours": _age_hours(created_at),
+        "labels": labels,
+        "requested_reviewers": reviewers,
+        "head_ref": (pr.get("head") or {}).get("ref") or "",
+        "mergeable_state": pr.get("mergeable_state") or None,
+        "agent_claim": _parse_agent_claim(labels),
+        "linked_issues": _parse_linked_issues(pr.get("body")),
+    }
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
+async def fetch_repo_prs(full_name: str) -> tuple[list[dict], str | None]:
+    """Fetch open PRs for *full_name* (``owner/repo``).
+
+    Returns ``(items, error_message)`` where *error_message* is *None* on
+    success.  Per-repo errors are surfaced in the ``errors`` array of the
+    aggregated response so a single unavailable repo does not fail the whole
+    request.
+    """
+    code, stdout, stderr = await _run_gh(
+        ["api", f"/repos/{full_name}/pulls?state=open&per_page=100"],
+        timeout=30,
+    )
+    if code != 0:
+        msg = f"{full_name}: gh exit {code}: {stderr.strip()[:200]}"
+        log.warning("pr_inventory: %s", msg)
+        return [], msg
+    try:
+        raw = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        msg = f"{full_name}: JSON decode error: {exc}"
+        log.warning("pr_inventory: %s", msg)
+        return [], msg
+    if not isinstance(raw, list):
+        msg = f"{full_name}: unexpected response shape"
+        log.warning("pr_inventory: %s", msg)
+        return [], msg
+    items = [_normalise_pr(pr, full_name) for pr in raw]
+    return items, None
+
+
+async def fetch_all_prs(
+    repos: list[str],
+    *,
+    include_drafts: bool = True,
+    author: str | None = None,
+    labels: list[str] | None = None,
+    limit: int = 500,
+) -> dict:
+    """Aggregate open PRs across *repos*.
+
+    Parameters
+    ----------
+    repos:
+        List of ``owner/repo`` slugs.
+    include_drafts:
+        When *False*, draft PRs are excluded.
+    author:
+        If set, only PRs by this login are returned.
+    labels:
+        If set, only PRs that have at least one of these labels are returned.
+    limit:
+        Maximum number of items to return (hard cap 2000).
+    """
+    limit = min(limit, 2000)
+    label_set: set[str] = set(labels) if labels else set()
+
+    cache_key = f"prs|{','.join(sorted(repos))}|{include_drafts}|{author}|{','.join(sorted(label_set))}|{limit}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    tasks = [fetch_repo_prs(repo) for repo in repos]
+    results = await asyncio.gather(*tasks)
+
+    items: list[dict] = []
+    errors: list[str] = []
+
+    for repo_items, err in results:
+        if err:
+            errors.append(err)
+            continue
+        for item in repo_items:
+            if not include_drafts and item["draft"]:
+                continue
+            if author and item["author"] != author:
+                continue
+            if label_set and not label_set.intersection(item["labels"]):
+                continue
+            items.append(item)
+
+    # Sort by age descending (newest first)
+    items.sort(key=lambda x: x["age_hours"])
+    items = items[:limit]
+
+    result = {"items": items, "total": len(items), "errors": errors}
+    _cache_set(cache_key, result)
+    return result
+
+
+async def fetch_pr_detail(owner: str, repo: str, number: int) -> dict:
+    """Fetch single PR with extra fields: body_excerpt, checks, files stats."""
+    full_name = f"{owner}/{repo}"
+    cache_key = f"pr_detail|{full_name}|{number}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    # Base PR data
+    code, stdout, stderr = await _run_gh(
+        ["api", f"/repos/{full_name}/pulls/{number}"],
+        timeout=20,
+    )
+    if code != 0:
+        raise ValueError(f"GitHub API error for {full_name}#{number}: {stderr.strip()[:200]}")
+    try:
+        pr = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"JSON decode error for {full_name}#{number}: {exc}") from exc
+
+    base = _normalise_pr(pr, full_name)
+    body: str = pr.get("body") or ""
+    base["body_excerpt"] = body[:2048]
+    base["files_changed"] = pr.get("changed_files") or 0
+    base["additions"] = pr.get("additions") or 0
+    base["deletions"] = pr.get("deletions") or 0
+
+    # Check runs
+    head_sha: str = (pr.get("head") or {}).get("sha") or ""
+    checks: list[dict] = []
+    if head_sha:
+        chk_code, chk_out, _ = await _run_gh(
+            ["api", f"/repos/{full_name}/commits/{head_sha}/check-runs?per_page=100"],
+            timeout=20,
+        )
+        if chk_code == 0:
+            try:
+                chk_data = json.loads(chk_out)
+                for run in chk_data.get("check_runs") or []:
+                    checks.append(
+                        {
+                            "name": run.get("name") or "",
+                            "conclusion": run.get("conclusion"),
+                            "url": run.get("html_url") or "",
+                        }
+                    )
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+    base["checks"] = checks
+    _cache_set(cache_key, base)
+    return base

--- a/backend/server.py
+++ b/backend/server.py
@@ -54,6 +54,8 @@ import agent_remediation  # noqa: E402
 import config_schema  # noqa: E402
 import deployment_drift  # noqa: E402
 import dispatch_contract  # noqa: E402
+import issue_inventory  # noqa: E402
+import pr_inventory  # noqa: E402
 import scheduled_workflows as scheduled_workflow_inventory  # noqa: E402
 import usage_monitoring  # noqa: E402
 from local_app_monitoring import collect_local_apps  # noqa: E402
@@ -3263,6 +3265,116 @@ async def get_repos(request: Request):
     result = {"repos": results, "total_count": len(results), "org": ORG}
     _cache_set("repos", result)
     return result
+
+
+# ─── PR Inventory API ────────────────────────────────────────────────────────
+
+
+@app.get("/api/prs")
+async def get_prs(
+    repo: list[str] | None = None,
+    include_drafts: bool = True,
+    author: str | None = None,
+    label: list[str] | None = None,
+    limit: int = 500,
+) -> dict:
+    """Aggregate open pull-requests across organisation repositories.
+
+    Query parameters
+    ----------------
+    repo:
+        Repeatable ``owner/repo`` slug filter; defaults to all repos returned
+        by ``_get_recent_org_repos()``.
+    include_drafts:
+        Include draft PRs (default ``true``).
+    author:
+        Filter to a specific author login.
+    label:
+        Repeatable; match any of the listed labels.
+    limit:
+        Maximum items returned (default 500, max 2000).
+    """
+    if repo:
+        repos = list(repo)
+    else:
+        org_repos = await _get_recent_org_repos(limit=50)
+        repos = [r["full_name"] for r in org_repos]
+
+    return await pr_inventory.fetch_all_prs(
+        repos,
+        include_drafts=include_drafts,
+        author=author,
+        labels=list(label) if label else None,
+        limit=limit,
+    )
+
+
+@app.get("/api/prs/{owner}/{repo_name}/{number}")
+async def get_pr_detail(owner: str, repo_name: str, number: int) -> dict:
+    """Return detailed information for a single pull-request.
+
+    Extra fields compared to the list endpoint: ``body_excerpt`` (first 2 KB),
+    ``checks`` (list of ``{name, conclusion, url}``), ``files_changed``,
+    ``additions``, ``deletions``.
+    """
+    try:
+        return await pr_inventory.fetch_pr_detail(owner, repo_name, number)
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+# ─── Issue Inventory API ──────────────────────────────────────────────────────
+
+
+@app.get("/api/issues")
+async def get_issues(
+    repo: list[str] | None = None,
+    state: str = "open",
+    label: list[str] | None = None,
+    assignee: str | None = None,
+    pickable_only: bool = False,
+    complexity: list[str] | None = None,
+    effort: list[str] | None = None,
+    judgement: list[str] | None = None,
+    limit: int = 500,
+) -> dict:
+    """Aggregate open issues across organisation repositories.
+
+    Query parameters
+    ----------------
+    repo:
+        Repeatable ``owner/repo`` slug filter; defaults to all repos returned
+        by ``_get_recent_org_repos()``.
+    state:
+        ``open`` (default) or ``all``.
+    label:
+        Repeatable; match any of the listed labels.
+    assignee:
+        Filter by assignee login.
+    pickable_only:
+        When ``true``, only issues available for agent pickup are returned.
+    complexity / effort / judgement:
+        Repeatable taxonomy dimension filters (match any provided value).
+    limit:
+        Maximum items returned (default 500, max 2000).
+    """
+    if repo:
+        repos = list(repo)
+    else:
+        org_repos = await _get_recent_org_repos(limit=50)
+        repos = [r["full_name"] for r in org_repos]
+
+    return await issue_inventory.fetch_all_issues(
+        repos,
+        state=state,
+        labels=list(label) if label else None,
+        assignee=assignee,
+        pickable_only=pickable_only,
+        complexity=list(complexity) if complexity else None,
+        effort=list(effort) if effort else None,
+        judgement=list(judgement) if judgement else None,
+        limit=limit,
+    )
 
 
 # ─── Daily Reports API ──────────────────────────────────────────────────────

--- a/tests/test_issue_inventory.py
+++ b/tests/test_issue_inventory.py
@@ -1,0 +1,336 @@
+"""Unit tests for backend/issue_inventory.py (issue #81)."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+import issue_inventory  # noqa: E402
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_issue(
+    number: int = 1,
+    title: str = "Test issue",
+    author: str = "alice",
+    labels: list[str] | None = None,
+    assignees: list[str] | None = None,
+    body: str = "",
+    created_at: str | None = None,
+    state: str = "open",
+) -> dict:
+    if created_at is None:
+        created_at = datetime.now(tz=timezone.utc).isoformat()
+    return {
+        "number": number,
+        "title": title,
+        "html_url": f"https://github.com/org/repo/issues/{number}",
+        "user": {"login": author},
+        "labels": [{"name": lbl} for lbl in (labels or [])],
+        "assignees": [{"login": a} for a in (assignees or [])],
+        "body": body,
+        "created_at": created_at,
+        "state": state,
+    }
+
+
+# ─── parse_taxonomy ───────────────────────────────────────────────────────────
+
+
+class TestParseTaxonomy:
+    def test_empty_labels(self) -> None:
+        result = issue_inventory.parse_taxonomy([])
+        assert result["type"] is None
+        assert result["complexity"] is None
+        assert result["effort"] is None
+        assert result["judgement"] is None
+        assert result["quick_win"] is False
+        assert result["panel_review"] is False
+        assert result["domains"] == []
+        assert result["wave"] is None
+
+    def test_type_label(self) -> None:
+        result = issue_inventory.parse_taxonomy(["type:task"])
+        assert result["type"] == "task"
+
+    def test_complexity_label(self) -> None:
+        result = issue_inventory.parse_taxonomy(["complexity:routine"])
+        assert result["complexity"] == "routine"
+
+    def test_effort_label(self) -> None:
+        result = issue_inventory.parse_taxonomy(["effort:m"])
+        assert result["effort"] == "m"
+
+    def test_judgement_label(self) -> None:
+        result = issue_inventory.parse_taxonomy(["judgement:objective"])
+        assert result["judgement"] == "objective"
+
+    def test_quick_win_flag(self) -> None:
+        result = issue_inventory.parse_taxonomy(["quick-win"])
+        assert result["quick_win"] is True
+
+    def test_panel_review_flag(self) -> None:
+        result = issue_inventory.parse_taxonomy(["panel-review"])
+        assert result["panel_review"] is True
+
+    def test_wave_integer(self) -> None:
+        result = issue_inventory.parse_taxonomy(["wave:2"])
+        assert result["wave"] == 2
+
+    def test_domain_labels(self) -> None:
+        result = issue_inventory.parse_taxonomy(["domain:backend", "domain:ci"])
+        assert set(result["domains"]) == {"backend", "ci"}
+
+    def test_full_taxonomy(self) -> None:
+        labels = [
+            "type:task",
+            "complexity:trivial",
+            "effort:s",
+            "judgement:objective",
+            "quick-win",
+            "wave:1",
+            "domain:backend",
+        ]
+        result = issue_inventory.parse_taxonomy(labels)
+        assert result["type"] == "task"
+        assert result["complexity"] == "trivial"
+        assert result["effort"] == "s"
+        assert result["judgement"] == "objective"
+        assert result["quick_win"] is True
+        assert result["wave"] == 1
+        assert "backend" in result["domains"]
+
+    def test_unknown_labels_ignored(self) -> None:
+        result = issue_inventory.parse_taxonomy(["bug", "needs-triage"])
+        assert result["type"] is None
+        assert result["complexity"] is None
+
+    def test_claim_label_not_in_taxonomy(self) -> None:
+        result = issue_inventory.parse_taxonomy(["claim:claude"])
+        assert result["type"] is None
+
+    def test_wave_non_integer_stored_as_string(self) -> None:
+        result = issue_inventory.parse_taxonomy(["wave:alpha"])
+        assert result["wave"] == "alpha"
+
+
+# ─── is_pickable ──────────────────────────────────────────────────────────────
+
+
+class TestIsPickable:
+    def _base_item(self, **kwargs) -> dict:
+        item = {
+            "state": "open",
+            "agent_claim": None,
+            "taxonomy": {
+                "type": "task",
+                "complexity": "routine",
+                "effort": "m",
+                "judgement": "objective",
+                "quick_win": False,
+                "panel_review": False,
+                "domains": [],
+                "wave": None,
+            },
+            "linked_pr": None,
+        }
+        item.update(kwargs)
+        return item
+
+    def test_open_no_claim_no_pr_is_pickable(self) -> None:
+        item = self._base_item()
+        pickable, blocked = issue_inventory.is_pickable(item, has_open_pr=False)
+        assert pickable is True
+        assert blocked == []
+
+    def test_closed_issue_not_pickable(self) -> None:
+        item = self._base_item(state="closed")
+        pickable, blocked = issue_inventory.is_pickable(item, has_open_pr=False)
+        assert pickable is False
+        assert any("state" in r for r in blocked)
+
+    def test_has_linked_pr_not_pickable(self) -> None:
+        item = self._base_item()
+        pickable, blocked = issue_inventory.is_pickable(item, has_open_pr=True)
+        assert pickable is False
+        assert any("PR" in r for r in blocked)
+
+    def test_active_claim_not_pickable(self) -> None:
+        item = self._base_item(agent_claim="claude")
+        pickable, blocked = issue_inventory.is_pickable(item, has_open_pr=False)
+        assert pickable is False
+        assert any("claim" in r for r in blocked)
+
+    def test_design_judgement_not_pickable(self) -> None:
+        item = self._base_item()
+        item["taxonomy"]["judgement"] = "design"
+        pickable, blocked = issue_inventory.is_pickable(item, has_open_pr=False)
+        assert pickable is False
+        assert any("design" in r for r in blocked)
+
+    def test_contested_judgement_not_pickable(self) -> None:
+        item = self._base_item()
+        item["taxonomy"]["judgement"] = "contested"
+        pickable, blocked = issue_inventory.is_pickable(item, has_open_pr=False)
+        assert pickable is False
+
+    def test_multiple_blockers_reported(self) -> None:
+        item = self._base_item(state="closed", agent_claim="jules")
+        item["taxonomy"]["judgement"] = "design"
+        pickable, blocked = issue_inventory.is_pickable(item, has_open_pr=True)
+        assert pickable is False
+        assert len(blocked) >= 2
+
+
+# ─── linked_pr resolution ────────────────────────────────────────────────────
+
+
+class TestLinkedPr:
+    """linked_pr is set by the caller (fetch_all_issues) based on PR data.
+    Here we verify that normalise_issue defaults it to None."""
+
+    def test_linked_pr_defaults_to_none(self) -> None:
+        raw = _make_issue(1, "Test")
+        result = issue_inventory._normalise_issue(raw, "org/repo")
+        assert result["linked_pr"] is None
+
+
+# ─── age_hours ────────────────────────────────────────────────────────────────
+
+
+class TestAgeHours:
+    def test_recent_issue(self) -> None:
+        created = datetime.now(tz=timezone.utc) - timedelta(hours=3)
+        age = issue_inventory._age_hours(created.isoformat())
+        assert 2.9 <= age <= 3.1
+
+    def test_invalid_returns_zero(self) -> None:
+        assert issue_inventory._age_hours("bad") == 0.0
+
+    def test_z_suffix(self) -> None:
+        created = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        ts = created.strftime("%Y-%m-%dT%H:%M:%SZ")
+        age = issue_inventory._age_hours(ts)
+        assert 0.9 <= age <= 1.1
+
+
+# ─── fetch_repo_issues ────────────────────────────────────────────────────────
+
+
+class TestFetchRepoIssues:
+    @pytest.mark.asyncio
+    async def test_gh_failure_returns_error(self) -> None:
+        with patch.object(issue_inventory, "_run_gh", new=AsyncMock(return_value=(1, "", "auth error"))):
+            items, err = await issue_inventory.fetch_repo_issues("org/repo")
+        assert items == []
+        assert err is not None
+        assert "org/repo" in err
+
+    @pytest.mark.asyncio
+    async def test_prs_filtered_out(self) -> None:
+        """Issues endpoint returns PRs too; they must be excluded."""
+        import json
+
+        raw = [
+            _make_issue(1, "Real issue"),
+            {**_make_issue(2, "A PR"), "pull_request": {"url": "..."}},
+        ]
+        with patch.object(issue_inventory, "_run_gh", new=AsyncMock(return_value=(0, json.dumps(raw), ""))):
+            items, err = await issue_inventory.fetch_repo_issues("org/repo")
+        assert err is None
+        assert len(items) == 1
+        assert items[0]["number"] == 1
+
+    @pytest.mark.asyncio
+    async def test_json_error_returns_error(self) -> None:
+        with patch.object(issue_inventory, "_run_gh", new=AsyncMock(return_value=(0, "oops", ""))):
+            items, err = await issue_inventory.fetch_repo_issues("org/repo")
+        assert items == []
+        assert err is not None
+
+
+# ─── fetch_all_issues ────────────────────────────────────────────────────────
+
+
+class TestFetchAllIssues:
+    @pytest.mark.asyncio
+    async def test_per_repo_error_captured(self) -> None:
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            if full_name == "org/bad":
+                return [], "org/bad: gh exit 1: not found"
+            raw = _make_issue(1, "Good issue")
+            return [issue_inventory._normalise_issue(raw, full_name)], None
+
+        with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
+            result = await issue_inventory.fetch_all_issues(["org/good", "org/bad"])
+
+        assert any("org/bad" in e for e in result["errors"])
+        assert len(result["items"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_pickable_only_filter(self) -> None:
+        raw_pickable = _make_issue(1, "Pickable", labels=["type:task", "judgement:objective"])
+        raw_blocked = _make_issue(2, "Contested", labels=["judgement:contested"])
+
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            return [
+                issue_inventory._normalise_issue(raw_pickable, full_name),
+                issue_inventory._normalise_issue(raw_blocked, full_name),
+            ], None
+
+        with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
+            result = await issue_inventory.fetch_all_issues(["org/repo"], pickable_only=True)
+
+        assert all(i["pickable"] for i in result["items"])
+
+    @pytest.mark.asyncio
+    async def test_complexity_filter(self) -> None:
+        issues = [
+            _make_issue(1, "Trivial", labels=["complexity:trivial"]),
+            _make_issue(2, "Routine", labels=["complexity:routine"]),
+        ]
+
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            return [issue_inventory._normalise_issue(i, full_name) for i in issues], None
+
+        with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
+            result = await issue_inventory.fetch_all_issues(["org/repo"], complexity=["trivial"])
+
+        assert result["items"][0]["taxonomy"]["complexity"] == "trivial"
+        assert len(result["items"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_limit_respected(self) -> None:
+        issues = [_make_issue(i, f"Issue {i}") for i in range(20)]
+
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            return [issue_inventory._normalise_issue(i, full_name) for i in issues], None
+
+        with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
+            result = await issue_inventory.fetch_all_issues(["org/repo"], limit=5)
+
+        assert len(result["items"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_assignee_filter(self) -> None:
+        issues = [
+            _make_issue(1, "Alice issue", assignees=["alice"]),
+            _make_issue(2, "Bob issue", assignees=["bob"]),
+        ]
+
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            return [issue_inventory._normalise_issue(i, full_name) for i in issues], None
+
+        with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
+            result = await issue_inventory.fetch_all_issues(["org/repo"], assignee="alice")
+
+        assert len(result["items"]) == 1
+        assert "alice" in result["items"][0]["assignees"]

--- a/tests/test_pr_inventory.py
+++ b/tests/test_pr_inventory.py
@@ -1,0 +1,271 @@
+"""Unit tests for backend/pr_inventory.py (issue #80)."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+import pr_inventory  # noqa: E402
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_pr(
+    number: int = 1,
+    title: str = "Test PR",
+    author: str = "alice",
+    draft: bool = False,
+    labels: list[str] | None = None,
+    reviewers: list[str] | None = None,
+    body: str = "",
+    created_at: str | None = None,
+    head_ref: str = "fix/thing",
+    mergeable_state: str = "clean",
+) -> dict:
+    if created_at is None:
+        created_at = datetime.now(tz=timezone.utc).isoformat()
+    return {
+        "number": number,
+        "title": title,
+        "html_url": f"https://github.com/org/repo/pull/{number}",
+        "user": {"login": author},
+        "draft": draft,
+        "labels": [{"name": lbl} for lbl in (labels or [])],
+        "requested_reviewers": [{"login": r} for r in (reviewers or [])],
+        "body": body,
+        "created_at": created_at,
+        "head": {"ref": head_ref},
+        "mergeable_state": mergeable_state,
+    }
+
+
+# ─── _normalise_pr ────────────────────────────────────────────────────────────
+
+
+class TestNormalisePr:
+    def test_basic_fields(self) -> None:
+        raw = _make_pr(number=42, title="Add feature", author="bob")
+        result = pr_inventory._normalise_pr(raw, "org/repo")
+        assert result["repository"] == "org/repo"
+        assert result["number"] == 42
+        assert result["title"] == "Add feature"
+        assert result["author"] == "bob"
+        assert result["draft"] is False
+
+    def test_labels_extracted(self) -> None:
+        raw = _make_pr(labels=["bug", "ci"])
+        result = pr_inventory._normalise_pr(raw, "org/repo")
+        assert set(result["labels"]) == {"bug", "ci"}
+
+    def test_requested_reviewers(self) -> None:
+        raw = _make_pr(reviewers=["alice", "bob"])
+        result = pr_inventory._normalise_pr(raw, "org/repo")
+        assert set(result["requested_reviewers"]) == {"alice", "bob"}
+
+    def test_draft_flag(self) -> None:
+        raw = _make_pr(draft=True)
+        result = pr_inventory._normalise_pr(raw, "org/repo")
+        assert result["draft"] is True
+
+    def test_head_ref(self) -> None:
+        raw = _make_pr(head_ref="feat/new-thing")
+        result = pr_inventory._normalise_pr(raw, "org/repo")
+        assert result["head_ref"] == "feat/new-thing"
+
+    def test_mergeable_state(self) -> None:
+        raw = _make_pr(mergeable_state="dirty")
+        result = pr_inventory._normalise_pr(raw, "org/repo")
+        assert result["mergeable_state"] == "dirty"
+
+
+# ─── age_hours ────────────────────────────────────────────────────────────────
+
+
+class TestAgeHours:
+    def test_recent_pr(self) -> None:
+        """A PR created 2 hours ago should report age ~2.0."""
+        created = datetime.now(tz=timezone.utc) - timedelta(hours=2)
+        age = pr_inventory._age_hours(created.isoformat())
+        assert 1.9 <= age <= 2.1
+
+    def test_old_pr(self) -> None:
+        created = datetime.now(tz=timezone.utc) - timedelta(hours=48)
+        age = pr_inventory._age_hours(created.isoformat())
+        assert 47.9 <= age <= 48.1
+
+    def test_invalid_date_returns_zero(self) -> None:
+        assert pr_inventory._age_hours("not-a-date") == 0.0
+
+    def test_z_suffix_handled(self) -> None:
+        """ISO-8601 Z suffix should be accepted."""
+        created = datetime.now(tz=timezone.utc) - timedelta(hours=5)
+        ts = created.strftime("%Y-%m-%dT%H:%M:%SZ")
+        age = pr_inventory._age_hours(ts)
+        assert 4.9 <= age <= 5.1
+
+    def test_result_is_rounded_to_one_decimal(self) -> None:
+        created = datetime.now(tz=timezone.utc) - timedelta(hours=1, minutes=6)
+        age = pr_inventory._age_hours(created.isoformat())
+        assert age == round(age, 1)
+
+
+# ─── linked_issues ────────────────────────────────────────────────────────────
+
+
+class TestParseLinkedIssues:
+    def test_closes_keyword(self) -> None:
+        body = "This PR closes #42."
+        assert pr_inventory._parse_linked_issues(body) == [42]
+
+    def test_fixes_keyword(self) -> None:
+        body = "fixes #10"
+        assert pr_inventory._parse_linked_issues(body) == [10]
+
+    def test_resolves_keyword(self) -> None:
+        body = "resolves #99"
+        assert pr_inventory._parse_linked_issues(body) == [99]
+
+    def test_case_insensitive(self) -> None:
+        body = "CLOSES #1 FIXES #2 RESOLVES #3"
+        assert pr_inventory._parse_linked_issues(body) == [1, 2, 3]
+
+    def test_multiple_issues(self) -> None:
+        body = "closes #5 and closes #10 and fixes #3"
+        assert pr_inventory._parse_linked_issues(body) == [3, 5, 10]
+
+    def test_no_keywords(self) -> None:
+        assert pr_inventory._parse_linked_issues("Just a description.") == []
+
+    def test_empty_body(self) -> None:
+        assert pr_inventory._parse_linked_issues("") == []
+
+    def test_none_body(self) -> None:
+        assert pr_inventory._parse_linked_issues(None) == []
+
+    def test_deduplicates(self) -> None:
+        body = "closes #7 closes #7"
+        assert pr_inventory._parse_linked_issues(body) == [7]
+
+
+# ─── agent_claim parsing ──────────────────────────────────────────────────────
+
+
+class TestParseAgentClaim:
+    def test_claim_label(self) -> None:
+        assert pr_inventory._parse_agent_claim(["claim:claude"]) == "claude"
+
+    def test_no_claim(self) -> None:
+        assert pr_inventory._parse_agent_claim(["bug", "ci"]) is None
+
+    def test_first_claim_wins(self) -> None:
+        result = pr_inventory._parse_agent_claim(["claim:jules", "claim:codex"])
+        assert result in ("jules", "codex")
+
+    def test_empty_labels(self) -> None:
+        assert pr_inventory._parse_agent_claim([]) is None
+
+
+# ─── per-repo error capture ───────────────────────────────────────────────────
+
+
+class TestFetchRepoPrs:
+    @pytest.mark.asyncio
+    async def test_gh_failure_returns_error(self) -> None:
+        with patch.object(pr_inventory, "_run_gh", new=AsyncMock(return_value=(1, "", "auth error"))):
+            items, err = await pr_inventory.fetch_repo_prs("org/repo")
+        assert items == []
+        assert err is not None
+        assert "org/repo" in err
+
+    @pytest.mark.asyncio
+    async def test_json_decode_error_returns_error(self) -> None:
+        with patch.object(pr_inventory, "_run_gh", new=AsyncMock(return_value=(0, "not json", ""))):
+            items, err = await pr_inventory.fetch_repo_prs("org/repo")
+        assert items == []
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_success_returns_normalised_items(self) -> None:
+        import json
+
+        raw = [_make_pr(1, "Fix bug", "alice")]
+        with patch.object(pr_inventory, "_run_gh", new=AsyncMock(return_value=(0, json.dumps(raw), ""))):
+            items, err = await pr_inventory.fetch_repo_prs("org/repo")
+        assert err is None
+        assert len(items) == 1
+        assert items[0]["number"] == 1
+        assert items[0]["author"] == "alice"
+
+
+# ─── fetch_all_prs error isolation ───────────────────────────────────────────
+
+
+class TestFetchAllPrs:
+    @pytest.mark.asyncio
+    async def test_per_repo_error_captured(self) -> None:
+        """An error for one repo should appear in errors[] but not fail others."""
+        import json
+
+        ok_prs = [_make_pr(1, "Ok PR", "bob")]
+
+        async def fake_fetch(full_name: str) -> tuple[list, str | None]:
+            if full_name == "org/bad":
+                return [], "org/bad: gh exit 1: auth error"
+            return [pr_inventory._normalise_pr(p, full_name) for p in ok_prs], None
+
+        with patch.object(pr_inventory, "fetch_repo_prs", side_effect=fake_fetch):
+            result = await pr_inventory.fetch_all_prs(
+                ["org/good", "org/bad"],
+                include_drafts=True,
+            )
+
+        assert result["errors"] != []
+        assert any("org/bad" in e for e in result["errors"])
+        assert result["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_draft_filter(self) -> None:
+        import json
+
+        prs = [_make_pr(1, "Draft", draft=True), _make_pr(2, "Normal", draft=False)]
+
+        async def fake_fetch(full_name: str) -> tuple[list, str | None]:
+            return [pr_inventory._normalise_pr(p, full_name) for p in prs], None
+
+        with patch.object(pr_inventory, "fetch_repo_prs", side_effect=fake_fetch):
+            result = await pr_inventory.fetch_all_prs(["org/repo"], include_drafts=False)
+
+        assert result["total"] == 1
+        assert result["items"][0]["draft"] is False
+
+    @pytest.mark.asyncio
+    async def test_author_filter(self) -> None:
+        prs = [_make_pr(1, "Alice PR", author="alice"), _make_pr(2, "Bob PR", author="bob")]
+
+        async def fake_fetch(full_name: str) -> tuple[list, str | None]:
+            return [pr_inventory._normalise_pr(p, full_name) for p in prs], None
+
+        with patch.object(pr_inventory, "fetch_repo_prs", side_effect=fake_fetch):
+            result = await pr_inventory.fetch_all_prs(["org/repo"], author="alice")
+
+        assert result["total"] == 1
+        assert result["items"][0]["author"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_limit_respected(self) -> None:
+        prs = [_make_pr(i, f"PR {i}") for i in range(10)]
+
+        async def fake_fetch(full_name: str) -> tuple[list, str | None]:
+            return [pr_inventory._normalise_pr(p, full_name) for p in prs], None
+
+        with patch.object(pr_inventory, "fetch_repo_prs", side_effect=fake_fetch):
+            result = await pr_inventory.fetch_all_prs(["org/repo"], limit=3)
+
+        assert result["total"] == 3


### PR DESCRIPTION
## Summary

- Adds `GET /api/prs` to aggregate open pull-requests across org repos with filters for drafts, author, labels, and limit (issue #80)
- Adds `GET /api/prs/{owner}/{repo}/{number}` for single-PR detail (body excerpt, check-runs, file stats)
- Adds `GET /api/issues` to aggregate open issues with taxonomy-aware filters: complexity, effort, judgement, pickable_only (issue #81)
- Creates `backend/pr_inventory.py` and `backend/issue_inventory.py` as the data layer; server.py routes are thin shells
- All responses cache 30 s in-process; per-repo failures go to `errors[]` without aborting the whole request
- Updates SPEC.md with sections 11 (PR Inventory API) and 12 (Issue Inventory API)
- Adds 63 unit tests across `tests/test_pr_inventory.py` and `tests/test_issue_inventory.py`

## Test plan

- [ ] `pytest tests/test_pr_inventory.py tests/test_issue_inventory.py -q` — 63 tests pass
- [ ] `ruff check backend/` — no issues
- [ ] `mypy backend/ --ignore-missing-imports` — no issues on the new modules
- [ ] Manual: `GET /api/prs` returns `{items, total, errors}` shape
- [ ] Manual: `GET /api/issues?pickable_only=true` excludes contested/design/claimed issues
- [ ] Manual: `GET /api/prs/D-sorganization/runner-dashboard/80` returns detail with `checks` field

Closes #80
Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)