### PR TITLE
feat(frontend): Issues sub-tab UI (#84)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -182,6 +182,31 @@ AI agent dispatch control panel. Configures and dispatches remediation plans
 to Jules, GAAI, Claude, or Codex agents. Shows dispatch history and plan
 status. Supports per-repo agent routing.
 
+Contains two sub-tabs:
+
+**PRs sub-tab** — the existing manual dispatch UI: failed run list, provider
+selection, plan preview, dispatch history, policy configuration, and Jules
+workflow health.
+
+**Issues sub-tab** — taxonomy-aware GitHub Issues browser and bulk dispatcher
+(`GET /api/issues?limit=2000`). Features:
+- Filter bar: repo, complexity (trivial/routine/complex/deep/research),
+  judgement (objective/preference/design/contested), and "pickable only" toggle.
+  Filter state persisted to `localStorage` with `issues:` prefix.
+- Multi-select table with columns: checkbox, repo, number, title (80-char
+  truncate + star for quick-win), type pill, complexity pill, effort, judgement
+  pill, pickable indicator.
+- Non-pickable rows are dimmed (opacity 0.6, red tint background); their
+  checkboxes are disabled with a `title` tooltip listing `pickable_blocked_by`.
+- `design` and `contested` judgement pills rendered red with a warning prefix.
+- Dispatch action bar (visible when items selected): provider dropdown, prompt
+  textarea, "Dispatch to selected" button.
+- Confirmation modal lists selected issues, shows a red warning banner for
+  `design`/`contested` judgements, and offers a "Force dispatch" checkbox when
+  non-pickable items are selected.
+- On confirm, POSTs to `POST /api/issues/dispatch` with `selection`,
+  `provider`, `prompt`, `force`, and `confirmation` fields.
+
 ### 3.13 Workflows Tab
 Browse and manually dispatch any workflow in any org repository. Supports
 input parameter forms generated from workflow `workflow_dispatch` definitions.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7825,6 +7825,514 @@
         );
       }
 
+      // ════════════════════════ ISSUES SUB-TAB ════════════════════════
+      function IssuesSubTab() {
+        var issuesState = React.useState([]);
+        var issues = issuesState[0], setIssues = issuesState[1];
+        var loadingState = React.useState(false);
+        var loading = loadingState[0], setLoading = loadingState[1];
+        var errorState = React.useState(null);
+        var fetchError = errorState[0], setFetchError = errorState[1];
+
+        // Filters
+        var repoFState = React.useState(function () { return localStorage.getItem('issues:filter_repo') || ''; });
+        var repoFilter = repoFState[0], setRepoFilter = repoFState[1];
+        var complexFState = React.useState(function () { return localStorage.getItem('issues:filter_complexity') || ''; });
+        var complexFilter = complexFState[0], setComplexFilter = complexFState[1];
+        var judgeFState = React.useState(function () { return localStorage.getItem('issues:filter_judgement') || ''; });
+        var judgeFilter = judgeFState[0], setJudgeFilter = judgeFState[1];
+        var pickableFState = React.useState(function () { return localStorage.getItem('issues:filter_pickable') === '1'; });
+        var pickableOnly = pickableFState[0], setPickableOnly = pickableFState[1];
+
+        // Selection
+        var selectedState = React.useState({});
+        var selected = selectedState[0], setSelected = selectedState[1];
+
+        // Dispatch action bar
+        var providerState = React.useState('jules_api');
+        var dispatchProvider = providerState[0], setDispatchProvider = providerState[1];
+        var promptState = React.useState('');
+        var dispatchPrompt = promptState[0], setDispatchPrompt = promptState[1];
+
+        // Modal
+        var modalState = React.useState(false);
+        var showModal = modalState[0], setShowModal = modalState[1];
+        var forceState = React.useState(false);
+        var forceDispatch = forceState[0], setForceDispatch = forceState[1];
+        var dispatchResultState = React.useState(null);
+        var dispatchResult = dispatchResultState[0], setDispatchResult = dispatchResultState[1];
+
+        function fetchIssues() {
+          setLoading(true);
+          setFetchError(null);
+          fetch('/api/issues?limit=2000')
+            .then(function (r) {
+              if (!r.ok) { throw new Error('HTTP ' + r.status); }
+              return r.json();
+            })
+            .then(function (data) {
+              setIssues(Array.isArray(data) ? data : (data.issues || []));
+              setLoading(false);
+            })
+            .catch(function (err) {
+              setFetchError(err.message || 'Failed to load issues');
+              setLoading(false);
+            });
+        }
+
+        React.useEffect(function () { fetchIssues(); }, []);
+
+        // Persist filters
+        React.useEffect(function () { localStorage.setItem('issues:filter_repo', repoFilter); }, [repoFilter]);
+        React.useEffect(function () { localStorage.setItem('issues:filter_complexity', complexFilter); }, [complexFilter]);
+        React.useEffect(function () { localStorage.setItem('issues:filter_judgement', judgeFilter); }, [judgeFilter]);
+        React.useEffect(function () { localStorage.setItem('issues:filter_pickable', pickableOnly ? '1' : '0'); }, [pickableOnly]);
+
+        var repos = Array.from(new Set(issues.map(function (i) { return i.repo || i.repository || ''; }).filter(Boolean))).sort();
+
+        var filtered = issues.filter(function (issue) {
+          var taxonomy = issue.taxonomy || {};
+          var repo = issue.repo || issue.repository || '';
+          if (repoFilter && repo !== repoFilter) return false;
+          if (complexFilter && taxonomy.complexity !== complexFilter) return false;
+          if (judgeFilter && taxonomy.judgement !== judgeFilter) return false;
+          if (pickableOnly && !issue.pickable) return false;
+          return true;
+        });
+
+        var selectedItems = filtered.filter(function (issue) {
+          return selected[issue.number + ':' + (issue.repo || issue.repository || '')];
+        });
+        var selectedCount = selectedItems.length;
+        var hasNonPickable = selectedItems.some(function (i) { return !i.pickable; });
+        var hasDangerous = selectedItems.some(function (i) {
+          var j = (i.taxonomy || {}).judgement;
+          return j === 'design' || j === 'contested';
+        });
+
+        function toggleSelect(issue) {
+          var key = issue.number + ':' + (issue.repo || issue.repository || '');
+          setSelected(function (prev) {
+            var next = Object.assign({}, prev);
+            if (next[key]) { delete next[key]; } else { next[key] = true; }
+            return next;
+          });
+        }
+
+        function toggleAll(checked) {
+          if (!checked) { setSelected({}); return; }
+          var next = {};
+          filtered.forEach(function (issue) {
+            if (issue.pickable !== false) {
+              next[issue.number + ':' + (issue.repo || issue.repository || '')] = true;
+            }
+          });
+          setSelected(next);
+        }
+
+        function getTypeStyle(type) {
+          var map = {
+            epic: { background: 'rgba(110,118,129,0.2)', color: '#8b949e' },
+            task: { background: 'rgba(88,166,255,0.2)', color: '#58a6ff' },
+            bug: { background: 'rgba(248,81,73,0.2)', color: '#f85149' },
+            security: { background: 'rgba(248,81,73,0.2)', color: '#f85149' },
+            research: { background: 'rgba(188,140,255,0.2)', color: '#bc8cff' },
+            docs: { background: 'rgba(56,189,248,0.2)', color: '#38bdf8' },
+            chore: { background: 'rgba(110,118,129,0.2)', color: '#8b949e' },
+          };
+          return map[type] || { background: 'rgba(110,118,129,0.15)', color: '#8b949e' };
+        }
+
+        function getComplexityStyle(complexity) {
+          var map = {
+            trivial: { background: 'rgba(63,185,80,0.2)', color: '#3fb950' },
+            routine: { background: 'rgba(88,166,255,0.2)', color: '#58a6ff' },
+            complex: { background: 'rgba(210,153,34,0.2)', color: '#d2993a' },
+            deep: { background: 'rgba(248,81,73,0.2)', color: '#f85149' },
+            research: { background: 'rgba(188,140,255,0.2)', color: '#bc8cff' },
+          };
+          return map[complexity] || { background: 'rgba(110,118,129,0.15)', color: '#8b949e' };
+        }
+
+        function getJudgementStyle(judgement) {
+          if (judgement === 'design' || judgement === 'contested') {
+            return { background: 'rgba(220,38,38,0.2)', color: '#ef4444' };
+          }
+          var map = {
+            objective: { background: 'rgba(63,185,80,0.15)', color: '#3fb950' },
+            preference: { background: 'rgba(210,153,34,0.15)', color: '#d2993a' },
+          };
+          return map[judgement] || { background: 'rgba(110,118,129,0.15)', color: '#8b949e' };
+        }
+
+        function pillStyle(style) {
+          return Object.assign({
+            display: 'inline-block',
+            padding: '1px 7px',
+            borderRadius: 10,
+            fontSize: 11,
+            fontWeight: 600,
+            whiteSpace: 'nowrap',
+          }, style);
+        }
+
+        function doDispatch() {
+          var items = selectedItems.map(function (i) {
+            return { repo: i.repo || i.repository || '', number: i.number };
+          });
+          setDispatchResult(null);
+          fetch('/api/issues/dispatch', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: JSON.stringify({
+              selection: { mode: 'list', items: items },
+              provider: dispatchProvider,
+              prompt: dispatchPrompt,
+              force: forceDispatch,
+              confirmation: { approved_by: 'dashboard-user' },
+            }),
+          })
+            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+            .then(function (result) {
+              if (result.ok) {
+                setDispatchResult({ type: 'success', text: 'Dispatched ' + items.length + ' issue(s) successfully.' });
+                setSelected({});
+              } else {
+                setDispatchResult({ type: 'error', text: 'Dispatch failed: ' + (result.data.detail || JSON.stringify(result.data)) });
+              }
+              setShowModal(false);
+              setForceDispatch(false);
+            })
+            .catch(function (err) {
+              setDispatchResult({ type: 'error', text: 'Dispatch error: ' + err.message });
+              setShowModal(false);
+            });
+        }
+
+        var providerOptions = ['jules_api', 'codex_cli', 'claude_code_cli', 'ollama_local', 'cline'];
+
+        return h('div', { style: { padding: '0 0 16px 0' } },
+          // Filter bar
+          h('div', {
+            style: {
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              marginBottom: 12,
+              padding: '10px 12px',
+              background: 'var(--bg-secondary)',
+              borderRadius: 8,
+              border: '1px solid var(--border)',
+            }
+          },
+            h('select', {
+              value: repoFilter,
+              onChange: function (e) { setRepoFilter(e.target.value); setSelected({}); },
+              style: { fontSize: 12, padding: '3px 6px', background: 'var(--bg-input)', color: 'var(--text-primary)', border: '1px solid var(--border)', borderRadius: 4 },
+            },
+              h('option', { value: '' }, 'All repos'),
+              repos.map(function (r) { return h('option', { key: r, value: r }, r); })
+            ),
+            h('select', {
+              value: complexFilter,
+              onChange: function (e) { setComplexFilter(e.target.value); setSelected({}); },
+              style: { fontSize: 12, padding: '3px 6px', background: 'var(--bg-input)', color: 'var(--text-primary)', border: '1px solid var(--border)', borderRadius: 4 },
+            },
+              h('option', { value: '' }, 'All complexity'),
+              ['trivial', 'routine', 'complex', 'deep', 'research'].map(function (c) { return h('option', { key: c, value: c }, c); })
+            ),
+            h('select', {
+              value: judgeFilter,
+              onChange: function (e) { setJudgeFilter(e.target.value); setSelected({}); },
+              style: { fontSize: 12, padding: '3px 6px', background: 'var(--bg-input)', color: 'var(--text-primary)', border: '1px solid var(--border)', borderRadius: 4 },
+            },
+              h('option', { value: '' }, 'All judgement'),
+              ['objective', 'preference', 'design', 'contested'].map(function (j) { return h('option', { key: j, value: j }, j); })
+            ),
+            h('label', { style: { display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, cursor: 'pointer', userSelect: 'none' } },
+              h('input', {
+                type: 'checkbox',
+                checked: pickableOnly,
+                onChange: function (e) { setPickableOnly(e.target.checked); setSelected({}); },
+              }),
+              'Pickable only'
+            ),
+            h('button', {
+              className: 'btn',
+              onClick: fetchIssues,
+              style: { marginLeft: 'auto' },
+            }, I.refresh(12), 'Refresh'),
+          ),
+
+          // Dispatch result banner
+          dispatchResult ? h('div', {
+            style: {
+              marginBottom: 10,
+              padding: '8px 12px',
+              borderRadius: 6,
+              fontSize: 12,
+              background: dispatchResult.type === 'success' ? 'rgba(63,185,80,0.12)' : 'rgba(248,81,73,0.12)',
+              color: dispatchResult.type === 'success' ? 'var(--accent-green)' : 'var(--accent-red)',
+            }
+          }, dispatchResult.text) : null,
+
+          // Loading / error
+          loading ? h('div', { style: { color: 'var(--text-muted)', fontSize: 12, padding: '12px 0' } }, 'Loading issues...') : null,
+          fetchError ? h('div', {
+            style: {
+              padding: '10px 12px', borderRadius: 8,
+              background: 'rgba(248,81,73,0.12)', color: 'var(--accent-red)', fontSize: 12,
+            }
+          }, fetchError) : null,
+
+          // Table
+          !loading && !fetchError ? h('div', { style: { overflowX: 'auto' } },
+            filtered.length === 0
+              ? h('div', { style: { color: 'var(--text-muted)', fontSize: 13, padding: '24px 0', textAlign: 'center' } }, 'No issues match the current filters.')
+              : h('table', {
+                  style: {
+                    width: '100%',
+                    borderCollapse: 'collapse',
+                    fontSize: 12,
+                  }
+                },
+                h('thead', null,
+                  h('tr', { style: { borderBottom: '1px solid var(--border)' } },
+                    h('th', { style: { padding: '6px 8px', textAlign: 'center', width: 28 } },
+                      h('input', {
+                        type: 'checkbox',
+                        onChange: function (e) { toggleAll(e.target.checked); },
+                        checked: filtered.length > 0 && filtered.filter(function (i) { return i.pickable !== false; }).every(function (i) {
+                          return selected[i.number + ':' + (i.repo || i.repository || '')];
+                        }),
+                      })
+                    ),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'left' } }, 'Repo'),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'left' } }, '#'),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'left' } }, 'Title'),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'left' } }, 'Type'),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'left' } }, 'Complexity'),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'left' } }, 'Effort'),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'left' } }, 'Judgement'),
+                    h('th', { style: { padding: '6px 8px', textAlign: 'center' } }, 'Pickable'),
+                  )
+                ),
+                h('tbody', null,
+                  filtered.map(function (issue) {
+                    var taxonomy = issue.taxonomy || {};
+                    var repo = issue.repo || issue.repository || '';
+                    var key = issue.number + ':' + repo;
+                    var isSelected = !!selected[key];
+                    var pickable = issue.pickable !== false;
+                    var blockedBy = issue.pickable_blocked_by || [];
+                    var title = (issue.title || '');
+                    var truncTitle = title.length > 80 ? title.slice(0, 80) + '…' : title;
+                    var issueUrl = issue.html_url || ('https://github.com/' + repo + '/issues/' + issue.number);
+                    var repoUrl = 'https://github.com/' + repo;
+                    var typeStyle = getTypeStyle(taxonomy.type || taxonomy.issue_type);
+                    var complexityStyle = getComplexityStyle(taxonomy.complexity);
+                    var judgementStyle = getJudgementStyle(taxonomy.judgement);
+                    var isDangerous = taxonomy.judgement === 'design' || taxonomy.judgement === 'contested';
+                    return h('tr', {
+                      key: key,
+                      style: {
+                        borderBottom: '1px solid var(--border)',
+                        opacity: pickable ? 1 : 0.6,
+                        background: pickable ? 'transparent' : 'rgba(255,0,0,0.04)',
+                      }
+                    },
+                      h('td', { style: { padding: '6px 8px', textAlign: 'center' } },
+                        h('input', {
+                          type: 'checkbox',
+                          checked: isSelected,
+                          disabled: !pickable,
+                          title: !pickable && blockedBy.length ? blockedBy.join(', ') : undefined,
+                          style: pickable ? {} : { cursor: 'not-allowed', opacity: 0.5 },
+                          onChange: function () { if (pickable) toggleSelect(issue); },
+                        })
+                      ),
+                      h('td', { style: { padding: '6px 8px', whiteSpace: 'nowrap' } },
+                        h('a', { href: repoUrl, target: '_blank', rel: 'noreferrer', style: { color: 'var(--text-secondary)', textDecoration: 'none' } }, repo)
+                      ),
+                      h('td', { style: { padding: '6px 8px', whiteSpace: 'nowrap' } },
+                        h('a', { href: issueUrl, target: '_blank', rel: 'noreferrer', style: { color: 'var(--accent-blue)', textDecoration: 'none' } }, '#' + issue.number)
+                      ),
+                      h('td', { style: { padding: '6px 8px', maxWidth: 300 } },
+                        taxonomy.quick_win ? h('span', { style: { color: '#f0c040', marginRight: 4 } }, '★') : null,
+                        h('span', { title: title }, truncTitle)
+                      ),
+                      h('td', { style: { padding: '6px 8px' } },
+                        taxonomy.type || taxonomy.issue_type
+                          ? h('span', { style: pillStyle(typeStyle) }, taxonomy.type || taxonomy.issue_type)
+                          : h('span', { style: { color: 'var(--text-muted)' } }, '—')
+                      ),
+                      h('td', { style: { padding: '6px 8px' } },
+                        taxonomy.complexity
+                          ? h('span', { style: pillStyle(complexityStyle) }, taxonomy.complexity)
+                          : h('span', { style: { color: 'var(--text-muted)' } }, '—')
+                      ),
+                      h('td', { style: { padding: '6px 8px', whiteSpace: 'nowrap' } }, taxonomy.effort || '—'),
+                      h('td', { style: { padding: '6px 8px' } },
+                        taxonomy.judgement
+                          ? h('span', { style: pillStyle(judgementStyle) },
+                              isDangerous ? '🛑 ' : '',
+                              taxonomy.judgement
+                            )
+                          : h('span', { style: { color: 'var(--text-muted)' } }, '—')
+                      ),
+                      h('td', { style: { padding: '6px 8px', textAlign: 'center' } },
+                        pickable
+                          ? h('span', { style: { color: '#3fb950', fontSize: 14 } }, '✓')
+                          : h('span', { title: blockedBy.join(', '), style: { color: '#f85149', fontSize: 14, cursor: 'help' } }, '✗')
+                      )
+                    );
+                  })
+                )
+              )
+          ) : null,
+
+          // Action bar
+          selectedCount > 0 ? h('div', {
+            style: {
+              marginTop: 16,
+              padding: '12px 16px',
+              background: 'var(--bg-secondary)',
+              border: '1px solid var(--border)',
+              borderRadius: 8,
+              display: 'flex',
+              gap: 12,
+              alignItems: 'flex-start',
+              flexWrap: 'wrap',
+            }
+          },
+            h('div', { style: { fontSize: 12, color: 'var(--text-secondary)', alignSelf: 'center' } },
+              selectedCount + ' issue' + (selectedCount !== 1 ? 's' : '') + ' selected'
+            ),
+            h('select', {
+              value: dispatchProvider,
+              onChange: function (e) { setDispatchProvider(e.target.value); },
+              style: { fontSize: 12, padding: '4px 8px', background: 'var(--bg-input)', color: 'var(--text-primary)', border: '1px solid var(--border)', borderRadius: 4 },
+            },
+              providerOptions.map(function (p) { return h('option', { key: p, value: p }, p); })
+            ),
+            h('textarea', {
+              value: dispatchPrompt,
+              onChange: function (e) { setDispatchPrompt(e.target.value); },
+              placeholder: 'Optional prompt / instructions for agent…',
+              rows: 2,
+              style: {
+                flex: '1 1 200px',
+                fontSize: 12,
+                padding: '4px 8px',
+                background: 'var(--bg-input)',
+                color: 'var(--text-primary)',
+                border: '1px solid var(--border)',
+                borderRadius: 4,
+                resize: 'vertical',
+                minWidth: 150,
+              },
+            }),
+            h('button', {
+              className: 'btn btn-primary',
+              onClick: function () { setShowModal(true); setForceDispatch(false); },
+            }, 'Dispatch to selected'),
+          ) : null,
+
+          // Confirmation modal
+          showModal ? h('div', {
+            style: {
+              position: 'fixed',
+              inset: 0,
+              background: 'rgba(0,0,0,0.6)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              zIndex: 1000,
+            },
+            onClick: function (e) { if (e.target === e.currentTarget) { setShowModal(false); } },
+          },
+            h('div', {
+              style: {
+                background: 'var(--bg-primary)',
+                border: '1px solid var(--border)',
+                borderRadius: 10,
+                padding: 24,
+                maxWidth: 540,
+                width: '90vw',
+                maxHeight: '80vh',
+                overflowY: 'auto',
+              }
+            },
+              h('h3', { style: { margin: '0 0 12px 0', fontSize: 15 } }, 'Confirm Dispatch'),
+
+              hasDangerous ? h('div', {
+                style: {
+                  marginBottom: 12,
+                  padding: '8px 12px',
+                  borderRadius: 6,
+                  background: 'rgba(220,38,38,0.15)',
+                  color: '#ef4444',
+                  fontSize: 12,
+                  fontWeight: 600,
+                }
+              }, '🛑 Warning: one or more selected issues have judgement:design or judgement:contested. These require panel review and should not be auto-dispatched.') : null,
+
+              h('div', { style: { fontSize: 12, marginBottom: 10, color: 'var(--text-secondary)' } },
+                'Dispatching ' + selectedCount + ' issue' + (selectedCount !== 1 ? 's' : '') + ' to provider: ',
+                h('strong', null, dispatchProvider)
+              ),
+
+              h('div', { style: { maxHeight: 200, overflowY: 'auto', marginBottom: 12 } },
+                selectedItems.map(function (issue) {
+                  var repo = issue.repo || issue.repository || '';
+                  return h('div', {
+                    key: issue.number + ':' + repo,
+                    style: {
+                      padding: '4px 8px',
+                      fontSize: 12,
+                      borderBottom: '1px solid var(--border)',
+                      opacity: issue.pickable === false ? 0.6 : 1,
+                    }
+                  },
+                    h('span', { style: { color: 'var(--text-muted)' } }, repo + ' '),
+                    h('strong', null, '#' + issue.number),
+                    ' — ',
+                    h('span', null, (issue.title || '').slice(0, 80)),
+                    issue.pickable === false ? h('span', { style: { color: '#f85149', marginLeft: 6 } }, '(non-pickable)') : null
+                  );
+                })
+              ),
+
+              hasNonPickable ? h('label', {
+                style: { display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, marginBottom: 12, cursor: 'pointer' }
+              },
+                h('input', {
+                  type: 'checkbox',
+                  checked: forceDispatch,
+                  onChange: function (e) { setForceDispatch(e.target.checked); },
+                }),
+                h('span', { style: { color: '#f85149', fontWeight: 600 } }, 'Force dispatch (include non-pickable issues)')
+              ) : null,
+
+              h('div', { style: { display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 16 } },
+                h('button', {
+                  className: 'btn',
+                  onClick: function () { setShowModal(false); },
+                }, 'Cancel'),
+                h('button', {
+                  className: 'btn btn-primary',
+                  onClick: doDispatch,
+                }, 'Confirm Dispatch'),
+              )
+            )
+          ) : null,
+        );
+      }
+
       // ════════════════════════ MAIN APP ════════════════════════
       function RemediationTab(p) {
         var config = p.config || {};
@@ -7939,9 +8447,55 @@
         }
         var accepted = !!(plan && plan.decision && plan.decision.accepted);
 
+        // Sub-tab state: "prs" | "issues"
+        var stsState = React.useState("prs");
+        var activeSubTab = stsState[0], setActiveSubTab = stsState[1];
+
+        var subTabStyle = function (isActive) {
+          return {
+            padding: "6px 16px",
+            fontSize: 13,
+            fontWeight: isActive ? 600 : 400,
+            background: "transparent",
+            border: "none",
+            borderBottom: isActive ? "2px solid var(--accent-blue)" : "2px solid transparent",
+            color: isActive ? "var(--accent-blue)" : "var(--text-secondary)",
+            cursor: "pointer",
+          };
+        };
+
+        if (activeSubTab === "issues") {
+          return h("div", null,
+            h("div", {
+              style: {
+                display: "flex",
+                gap: 4,
+                borderBottom: "1px solid var(--border)",
+                marginBottom: 16,
+              }
+            },
+              h("button", { style: subTabStyle(false), onClick: function () { setActiveSubTab("prs"); } }, "PRs"),
+              h("button", { style: subTabStyle(true), onClick: function () { setActiveSubTab("issues"); } }, "Issues")
+            ),
+            h(IssuesSubTab, {})
+          );
+        }
+
         return h(
           "div",
           null,
+          // ── Sub-tab bar ──────────────────────────────────────────────────
+          h("div", {
+            style: {
+              display: "flex",
+              gap: 4,
+              borderBottom: "1px solid var(--border)",
+              marginBottom: 16,
+            }
+          },
+            h("button", { style: subTabStyle(true), onClick: function () { setActiveSubTab("prs"); } }, "PRs"),
+            h("button", { style: subTabStyle(false), onClick: function () { setActiveSubTab("issues"); } }, "Issues")
+          ),
           // ── Manual Dispatch section (TOP) ────────────────────────────────
           h(
             "div",


### PR DESCRIPTION
## Summary

- Adds `IssuesSubTab` component to `frontend/index.html` — a taxonomy-aware Issues browser with filter bar, multi-select table, and bulk dispatch
- Wraps the existing `RemediationTab` content in a **PRs** sub-tab; adds an **Issues** sub-tab alongside it
- Updates `SPEC.md` section 3.12 with the new sub-tab behavior

## Features implemented

- Fetches `GET /api/issues?limit=2000` on mount and refresh
- Filter bar: repo, complexity, judgement, "pickable only" toggle — all persisted to `localStorage` with `issues:` prefix
- Multi-select table: checkbox, repo, #, title (80-char truncate + ★ quick-win), type pill, complexity pill, effort, judgement pill, pickable indicator
- Non-pickable rows: `opacity: 0.6`, red-tinted background; checkboxes disabled with `title` tooltip listing `pickable_blocked_by`
- `design`/`contested` judgement pills rendered red with 🛑 prefix
- Dispatch action bar (provider dropdown, prompt textarea, dispatch button) shown when items selected
- Confirmation modal: lists issues, red warning banner for dangerous judgements, "Force dispatch" checkbox for non-pickable items
- POSTs to `/api/issues/dispatch` with `selection`, `provider`, `prompt`, `force`, `confirmation`

## Test plan

- [ ] Navigate to Remediation tab — verify PRs / Issues sub-tab bar appears
- [ ] PRs sub-tab shows existing manual dispatch UI unchanged
- [ ] Issues sub-tab fetches and displays issues table (or graceful empty/error state)
- [ ] Filter bar filters table; filters persist across page refreshes via localStorage
- [ ] Non-pickable rows are dimmed, checkboxes disabled, tooltip shows blocked-by reasons
- [ ] Selecting pickable items shows dispatch action bar
- [ ] Dispatch button opens confirmation modal; dangerous-judgement warning appears when applicable
- [ ] Force dispatch checkbox appears only when non-pickable items are selected
- [ ] Confirm dispatch POSTs to `/api/issues/dispatch` correctly

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)