### PR TITLE
feat(frontend): Header Quick Dispatch dropdown (#86)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -113,6 +113,25 @@ removed in issue #3 to enforce a single source of truth. A CI test
 (`test_jsx_archive_removed`) prevents re-introduction of a parallel
 implementation.
 
+#### Header Quick Dispatch
+
+The main header contains a **Quick Dispatch** button (⚡ Quick Dispatch ▾),
+flush-right next to the refresh control. Clicking it opens a popover form that
+lets any operator dispatch an ad-hoc agent task to any org repository without
+navigating to a specific tab. The popover provides:
+
+- **Repository** dropdown — populated from `GET /api/repos`
+- **Provider** dropdown — populated from `GET /api/agents/providers`
+- **Model** text field — shown only for providers that support model selection
+  (`claude_code_cli`, `codex_cli`); defaults to `claude-opus-4-7`
+- **Branch ref** text field — defaults to `main`
+- **Prompt** textarea — minimum 10 characters
+- **Dispatch** button — POSTs to `POST /api/agents/quick-dispatch`; shows a
+  loading state, surfaces errors inline, and auto-closes on success
+
+Click-outside closes the popover. Rate-limit errors (HTTP 429) are surfaced
+with a human-readable message.
+
 ### 2.3 Deployment
 
 The dashboard runs as a systemd service (`runner-dashboard.service`) on the
@@ -332,6 +351,13 @@ All endpoints are served under `http://localhost:8321/api/`.
 | POST | `/api/agent-remediation/dispatch` | Dispatch a remediation plan (GAAI/Claude/Codex) |
 | POST | `/api/agent-remediation/dispatch-jules` | Dispatch via Jules API |
 | GET | `/api/agent-remediation/history` | Remediation dispatch history |
+
+### Quick Dispatch
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/agents/providers` | Available agent providers and their availability status |
+| POST | `/api/agents/quick-dispatch` | Dispatch an ad-hoc agent task to any repository |
 
 ### Credentials
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -5603,6 +5603,131 @@ async def generate_launchers() -> dict:
     }
 
 
+# ─── Quick Dispatch ──────────────────────────────────────────────────────────
+
+
+_QUICK_DISPATCH_HISTORY_PATH = Path.home() / "actions-runners" / "dashboard" / "quick_dispatch_history.json"
+_PROVIDERS_WITH_MODEL_SELECTION = frozenset({"claude_code_cli", "codex_cli"})
+_quick_dispatch_lock = asyncio.Lock()
+
+
+@app.get("/api/agents/providers")
+async def get_agent_providers() -> dict:
+    """Return available agent providers and their availability status."""
+    availability = agent_remediation.probe_provider_availability()
+    return {
+        "providers": {pid: p.to_dict() for pid, p in agent_remediation.PROVIDERS.items()},
+        "availability": {pid: s.to_dict() for pid, s in availability.items()},
+        "providers_with_model_selection": sorted(_PROVIDERS_WITH_MODEL_SELECTION),
+    }
+
+
+@app.post("/api/agents/quick-dispatch")
+async def quick_dispatch_agent(request: Request) -> dict:
+    """Dispatch an ad-hoc agent task to any repository (issue #86)."""
+    client_ip = request.client.host if request.client else "unknown"
+    check_dispatch_rate(client_ip)
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=422, detail="expected object body")
+
+    repository = str(body.get("repository", "")).strip()
+    prompt = str(body.get("prompt", "")).strip()
+    provider = str(body.get("provider", "claude_code_cli")).strip()
+    model = str(body.get("model", "")).strip()
+    ref = str(body.get("ref", "main")).strip() or "main"
+    task_kind = str(body.get("task_kind", "adhoc")).strip()
+
+    if not repository:
+        raise HTTPException(status_code=422, detail="repository is required")
+    if len(prompt) < 10:
+        raise HTTPException(status_code=422, detail="prompt must be at least 10 characters")
+    if provider not in agent_remediation.PROVIDERS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"unknown provider '{provider}'; valid: {sorted(agent_remediation.PROVIDERS)}",
+        )
+
+    # Normalize repository to bare name for workflow inputs
+    repo_name = repository.removeprefix(f"{ORG}/")
+
+    # Load and apply prompt notes if enabled
+    prompt_notes_data: dict[str, object] = {"notes": "", "enabled": True}
+    try:
+        if _PROMPT_NOTES_PATH.exists():
+            prompt_notes_data = json.loads(_PROMPT_NOTES_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+
+    full_prompt = prompt
+    notes_val = str(prompt_notes_data.get("notes", ""))
+    if prompt_notes_data.get("enabled", True) and notes_val.strip():
+        full_prompt = f"{notes_val}\n\n{prompt}"
+
+    # Record in history
+    entry: dict = {}
+    async with _quick_dispatch_lock:
+        try:
+            history: list[dict] = []
+            if _QUICK_DISPATCH_HISTORY_PATH.exists():
+                history = json.loads(_QUICK_DISPATCH_HISTORY_PATH.read_text(encoding="utf-8"))
+            entry = {
+                "id": str(int(datetime.now(UTC).timestamp())),
+                "repository": f"{ORG}/{repo_name}",
+                "provider": provider,
+                "model": model,
+                "ref": ref,
+                "task_kind": task_kind,
+                "prompt": prompt[:500],
+                "status": "dispatched",
+                "created_at": datetime.now(UTC).isoformat(),
+            }
+            history.append(entry)
+            config_schema.atomic_write_json(_QUICK_DISPATCH_HISTORY_PATH, history[-200:])
+        except Exception:
+            pass
+
+    # Build workflow inputs and dispatch
+    workflow_inputs: dict[str, str] = {
+        "target_repository": f"{ORG}/{repo_name}",
+        "branch": ref,
+        "provider": provider,
+        "prompt": full_prompt[:10000],
+        "task_kind": task_kind,
+    }
+    if model and provider in _PROVIDERS_WITH_MODEL_SELECTION:
+        workflow_inputs["model"] = model
+
+    endpoint = f"/repos/{ORG}/Repository_Management/actions/workflows/Jules-Feature-Request.yml/dispatches"
+    payload = {"ref": "main", "inputs": workflow_inputs}
+
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".json", delete=False) as f:
+        json.dump(payload, f)
+        pf = f.name
+    try:
+        code, _, stderr = await run_cmd(
+            ["gh", "api", endpoint, "--method", "POST", "--input", pf],
+            timeout=30,
+            cwd=REPO_ROOT,
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            Path(pf).unlink()
+
+    if code != 0:
+        log.warning("quick_dispatch failed (provider=%s repo=%s): %s", provider, repo_name, stderr.strip()[:200])
+        # Surface the error to the caller
+        raise HTTPException(status_code=502, detail=f"Dispatch workflow failed: {stderr.strip()[:200]}")
+
+    log.info("quick_dispatch accepted: provider=%s repo=%s ref=%s", provider, repo_name, ref)
+    return {
+        "status": "dispatched",
+        "repository": f"{ORG}/{repo_name}",
+        "provider": provider,
+        "entry_id": entry.get("id", ""),
+    }
+
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12960,6 +12960,351 @@
       }
 
 
+      // ── Quick Dispatch Popover (issue #86) ────────────────────────────────────
+      var PROVIDERS_WITH_MODEL = ["claude_code_cli", "codex_cli"];
+
+      function QuickDispatchPopover() {
+        var os = React.useState(false);
+        var open = os[0], setOpen = os[1];
+
+        var rs = React.useState([]);
+        var repoList = rs[0], setRepoList = rs[1];
+
+        var ps = React.useState([]);
+        var providerList = ps[0], setProviderList = ps[1];
+
+        var fms = React.useState({
+          repository: "",
+          provider: "claude_code_cli",
+          model: "claude-opus-4-7",
+          ref: "main",
+          prompt: "",
+        });
+        var form = fms[0], setForm = fms[1];
+
+        var ls = React.useState(false);
+        var loading = ls[0], setLoading = ls[1];
+
+        var es = React.useState(null);
+        var error = es[0], setError = es[1];
+
+        var ss = React.useState(null);
+        var successMsg = ss[0], setSuccessMsg = ss[1];
+
+        var popoverRef = React.useRef(null);
+        var triggerRef = React.useRef(null);
+
+        // Close on outside click
+        React.useEffect(function () {
+          if (!open) return;
+          function onMouseDown(e) {
+            if (
+              popoverRef.current && !popoverRef.current.contains(e.target) &&
+              triggerRef.current && !triggerRef.current.contains(e.target)
+            ) {
+              setOpen(false);
+            }
+          }
+          document.addEventListener("mousedown", onMouseDown);
+          return function () { document.removeEventListener("mousedown", onMouseDown); };
+        }, [open]);
+
+        // Fetch repos and providers when popover opens
+        React.useEffect(function () {
+          if (!open) return;
+          if (repoList.length === 0) {
+            fetch("/api/repos")
+              .then(function (r) { return r.json(); })
+              .then(function (d) {
+                var repos = (d && d.repos) ? d.repos : [];
+                setRepoList(repos);
+                if (repos.length > 0 && !form.repository) {
+                  setForm(function (prev) {
+                    return Object.assign({}, prev, { repository: repos[0].full_name || repos[0].name || "" });
+                  });
+                }
+              })
+              .catch(function () {});
+          }
+          if (providerList.length === 0) {
+            fetch("/api/agents/providers")
+              .then(function (r) { return r.json(); })
+              .then(function (d) {
+                var providers = d && d.providers ? Object.keys(d.providers) : ["claude_code_cli"];
+                setProviderList(providers);
+              })
+              .catch(function () {
+                setProviderList(["claude_code_cli", "jules_api", "codex_cli"]);
+              });
+          }
+        }, [open]);
+
+        function handleToggle() {
+          setOpen(function (prev) { return !prev; });
+          setError(null);
+          setSuccessMsg(null);
+        }
+
+        function handleFormChange(field, value) {
+          setForm(function (prev) { return Object.assign({}, prev, { [field]: value }); });
+        }
+
+        function handleCancel() {
+          setOpen(false);
+          setError(null);
+          setSuccessMsg(null);
+        }
+
+        function handleDispatch() {
+          setError(null);
+          if (!form.repository) {
+            setError("Please select a repository.");
+            return;
+          }
+          if (!form.prompt || form.prompt.trim().length < 10) {
+            setError("Prompt must be at least 10 characters.");
+            return;
+          }
+          setLoading(true);
+          var body = {
+            repository: form.repository,
+            prompt: form.prompt.trim(),
+            provider: form.provider,
+            ref: form.ref || "main",
+            task_kind: "adhoc",
+          };
+          if (PROVIDERS_WITH_MODEL.indexOf(form.provider) !== -1 && form.model.trim()) {
+            body.model = form.model.trim();
+          }
+          fetch("/api/agents/quick-dispatch", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
+            body: JSON.stringify(body),
+          })
+            .then(function (r) {
+              return r.json().then(function (d) { return { ok: r.ok, status: r.status, data: d }; });
+            })
+            .then(function (result) {
+              setLoading(false);
+              if (!result.ok) {
+                if (result.status === 429) {
+                  setError("Rate limited. Try again in a moment.");
+                } else {
+                  setError((result.data && result.data.detail) || "Dispatch failed.");
+                }
+                return;
+              }
+              setSuccessMsg("✓ Dispatched!");
+              setForm(function (prev) {
+                return Object.assign({}, prev, { prompt: "" });
+              });
+              setTimeout(function () {
+                setOpen(false);
+                setSuccessMsg(null);
+              }, 1800);
+            })
+            .catch(function () {
+              setLoading(false);
+              setError("Network error. Please try again.");
+            });
+        }
+
+        var showModel = PROVIDERS_WITH_MODEL.indexOf(form.provider) !== -1;
+
+        var labelStyle = {
+          fontSize: 12,
+          color: "var(--text-muted)",
+          marginBottom: 3,
+          display: "block",
+        };
+        var inputStyle = {
+          width: "100%",
+          background: "var(--bg-primary)",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+          padding: "5px 10px",
+          color: "var(--text-primary)",
+          fontSize: 13,
+          outline: "none",
+          boxSizing: "border-box",
+        };
+        var rowStyle = { marginBottom: 10 };
+
+        return h(
+          "div",
+          { style: { position: "relative", display: "inline-block" } },
+          h(
+            "button",
+            {
+              ref: triggerRef,
+              className: "btn btn-blue",
+              style: {
+                fontSize: 13,
+                padding: "6px 12px",
+                fontWeight: 600,
+                background: "rgba(88,166,255,0.15)",
+              },
+              onClick: handleToggle,
+              title: "Open Quick Dispatch",
+            },
+            "⚡ Quick Dispatch ▾",
+          ),
+          open
+            ? h(
+                "div",
+                {
+                  ref: popoverRef,
+                  style: {
+                    position: "fixed",
+                    right: 16,
+                    top: 64,
+                    width: 320,
+                    background: "var(--bg-secondary)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 8,
+                    boxShadow: "0 8px 32px rgba(0,0,0,0.5)",
+                    zIndex: 9000,
+                    padding: 16,
+                  },
+                },
+                h(
+                  "div",
+                  { style: { fontWeight: 700, fontSize: 14, marginBottom: 14, color: "var(--text-primary)" } },
+                  "⚡ Quick Dispatch",
+                ),
+                h(
+                  "div",
+                  { style: rowStyle },
+                  h("label", { style: labelStyle }, "Repository"),
+                  h(
+                    "select",
+                    {
+                      style: inputStyle,
+                      value: form.repository,
+                      onChange: function (e) { handleFormChange("repository", e.target.value); },
+                    },
+                    repoList.length === 0
+                      ? h("option", { value: "" }, "Loading…")
+                      : repoList.map(function (repo) {
+                          var name = repo.full_name || repo.name || repo;
+                          return h("option", { key: name, value: name }, name);
+                        }),
+                  ),
+                ),
+                h(
+                  "div",
+                  { style: rowStyle },
+                  h("label", { style: labelStyle }, "Provider"),
+                  h(
+                    "select",
+                    {
+                      style: inputStyle,
+                      value: form.provider,
+                      onChange: function (e) { handleFormChange("provider", e.target.value); },
+                    },
+                    providerList.length === 0
+                      ? h("option", { value: "claude_code_cli" }, "claude_code_cli")
+                      : providerList.map(function (pid) {
+                          return h("option", { key: pid, value: pid }, pid);
+                        }),
+                  ),
+                ),
+                showModel
+                  ? h(
+                      "div",
+                      { style: rowStyle },
+                      h("label", { style: labelStyle }, "Model"),
+                      h("input", {
+                        type: "text",
+                        style: inputStyle,
+                        value: form.model,
+                        placeholder: "claude-opus-4-7",
+                        onChange: function (e) { handleFormChange("model", e.target.value); },
+                      }),
+                    )
+                  : null,
+                h(
+                  "div",
+                  { style: rowStyle },
+                  h("label", { style: labelStyle }, "Branch ref"),
+                  h("input", {
+                    type: "text",
+                    style: inputStyle,
+                    value: form.ref,
+                    placeholder: "main",
+                    onChange: function (e) { handleFormChange("ref", e.target.value); },
+                  }),
+                ),
+                h(
+                  "div",
+                  { style: rowStyle },
+                  h("label", { style: labelStyle }, "Prompt"),
+                  h("textarea", {
+                    rows: 4,
+                    style: Object.assign({}, inputStyle, { resize: "vertical", fontFamily: "inherit" }),
+                    value: form.prompt,
+                    placeholder: "Describe the task for the agent…",
+                    onChange: function (e) { handleFormChange("prompt", e.target.value); },
+                  }),
+                ),
+                error
+                  ? h(
+                      "div",
+                      {
+                        style: {
+                          fontSize: 12,
+                          color: "var(--accent-red)",
+                          marginBottom: 10,
+                          padding: "6px 10px",
+                          background: "rgba(248,81,73,0.1)",
+                          borderRadius: 4,
+                          border: "1px solid rgba(248,81,73,0.3)",
+                        },
+                      },
+                      error,
+                    )
+                  : null,
+                successMsg
+                  ? h(
+                      "div",
+                      {
+                        style: {
+                          fontSize: 12,
+                          color: "var(--accent-green)",
+                          marginBottom: 10,
+                          padding: "6px 10px",
+                          background: "rgba(63,185,80,0.1)",
+                          borderRadius: 4,
+                          border: "1px solid rgba(63,185,80,0.3)",
+                        },
+                      },
+                      successMsg,
+                    )
+                  : null,
+                h(
+                  "div",
+                  { style: { display: "flex", justifyContent: "flex-end", gap: 8 } },
+                  h(
+                    "button",
+                    { className: "btn", onClick: handleCancel, disabled: loading },
+                    "Cancel",
+                  ),
+                  h(
+                    "button",
+                    {
+                      className: "btn btn-blue",
+                      style: { background: "rgba(88,166,255,0.2)", fontWeight: 600 },
+                      onClick: handleDispatch,
+                      disabled: loading,
+                    },
+                    loading ? "Dispatching…" : "⚡ Dispatch",
+                  ),
+                ),
+              )
+            : null,
+        );
+      }
+
       function App() {
         var ts = React.useState("overview");
         var tab = ts[0],
@@ -14803,6 +15148,7 @@
                 },
                 "Build " + shortSha(deployment.git_sha),
               ),
+              h(QuickDispatchPopover, null),
               h(
                 "button",
                 {


### PR DESCRIPTION
## Summary

- Adds a **⚡ Quick Dispatch** button flush-right in the main app header (before the refresh control)
- Clicking toggles a fixed-position popover with repo, provider, model, branch ref, and prompt fields
- Repo list fetched from `GET /api/repos`; provider list from new `GET /api/agents/providers`
- Model field shown only for providers that support model selection (`claude_code_cli`, `codex_cli`)
- Dispatches via new `POST /api/agents/quick-dispatch`, which validates input, applies prompt notes, records history, and delegates to the Jules-Feature-Request workflow
- Inline error display; 429 rate-limit surfaces a human-readable message; success auto-closes after 1.8 s
- Click-outside closes the popover via `useEffect` + `mousedown` listener on `document`
- `SPEC.md` updated with header UX description and Quick Dispatch API catalogue entries

Closes #86.

## Test plan

- [ ] Click **⚡ Quick Dispatch ▾** in the header — popover opens below the button
- [ ] Repo dropdown populates from `/api/repos`
- [ ] Provider dropdown populates from `/api/agents/providers`
- [ ] Model field visible for `claude_code_cli` / `codex_cli`, hidden for `jules_api`
- [ ] Dispatch with empty prompt shows validation error
- [ ] Dispatch with valid inputs shows loading state then success message, popover closes
- [ ] Clicking outside the popover closes it
- [ ] `GET /api/agents/providers` returns providers + availability + `providers_with_model_selection`
- [ ] `POST /api/agents/quick-dispatch` with missing repo or short prompt returns 422
- [ ] `POST /api/agents/quick-dispatch` with unknown provider returns 422
- [ ] CI lint/format passes (`ruff check`, `ruff format --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)