### PR TITLE
docs: codify sibling-repos contract (Repo_Mgmt ↔ runner-dashboard ↔ Maxwell-Daemon)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,33 @@
 
 Quick-reference for developers and AI agents working in this repository.
 
+## Sibling repos & boundaries (read first)
+
+`runner-dashboard` is the **operator console** in a three-repo fleet. The
+canonical contract lives in
+[`Repository_Management/docs/sibling-repos.md`](https://github.com/D-sorganization/Repository_Management/blob/main/docs/sibling-repos.md).
+Read it before adding any cross-repo surface.
+
+| Repo                      | Role                                                   |
+| ------------------------- | ------------------------------------------------------ |
+| [`Repository_Management`](https://github.com/D-sorganization/Repository_Management) | Fleet orchestrator (workflows, skills, templates, agent coordination). |
+| `runner-dashboard` (here) | Operator console — backend, frontend, deploy, every dashboard tab and `/api/*` endpoint. |
+| [`Maxwell-Daemon`](https://github.com/D-sorganization/Maxwell-Daemon) | Autonomous local AI control plane consumed by the Maxwell tab over HTTP. |
+
+**Owned here:** every dashboard tab (Fleet, Org, Heavy, Workflows,
+Remediation, Maxwell, Assessments, Feature Requests, Credentials, Reports),
+every `/api/*` endpoint, dispatch envelope/contract, deployment + rollout
+machinery, the frontend bundle, dashboard-only docs.
+
+**Not owned here:** fleet-wide CI workflows (live in `Repository_Management`),
+agent claim/lease protocol (lives in `Repository_Management`), the Maxwell AI
+pipeline (lives in `Maxwell-Daemon`). The dashboard never imports from a
+sibling repo at runtime — all cross-repo traffic is HTTP.
+
+**Routing rule:** issues about the Maxwell pipeline → `Maxwell-Daemon`;
+issues about fleet workflows / templates / skills → `Repository_Management`;
+everything else dashboard-shaped → here.
+
 ## Multi-Agent Coordination
 
 Before starting work on any issue, agents must acquire a coordination lease to
@@ -213,3 +240,28 @@ Agent workflows:
 - Commit messages follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.).
 - Update `SPEC.md` when adding or changing documented behavior.
 - Update `VERSION` (semver) on meaningful releases.
+
+## Engineering principles (mandatory)
+
+Every PR must demonstrably preserve all of these. They are checked at review:
+
+- **TDD** — failing test first; backend route tests in `tests/api/`,
+  frontend behaviour tests in `tests/frontend/`. New feature without a test
+  is reverted, not "followed up".
+- **DbC (Design by Contract)** — pre/postconditions documented as `assert`
+  blocks or pydantic models at every boundary; mandatory on dispatch envelopes
+  and any `POST` route. See `backend/dispatch_contract.py` for the pattern.
+- **DRY** — if a helper would benefit `Repository_Management` or
+  `Maxwell-Daemon`, lift it to `Repository_Management/shared_scripts/` and
+  consume from there. Do not fork.
+- **LoD (Law of Demeter)** — handlers receive flat, typed payloads. No
+  reaching through nested objects across module boundaries.
+- **Orthogonality** — tabs are independent: Maxwell tab failing must not
+  break the Fleet tab; one `/api/*` 5xx must not cascade into others.
+- **Decoupled** — never import from a sibling repo at runtime. All
+  cross-repo traffic is HTTP, with versioned contracts at
+  `GET /api/version`.
+- **Reversible** — every deploy ships a rollback marker. Schema changes are
+  two-step (additive ship → removal in next release).
+- **Reusable** — payload models defined once and reused across handlers,
+  tests, and frontend type generation.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@ runner fleet. Monitor runner health in real-time, control runner lifecycle,
 dispatch AI agents, manage workflows, and orchestrate multi-node deployments —
 all from a single browser tab.
 
+## Sibling repos
+
+This is the **operator console** in a three-repo fleet. The cross-repo
+contract is in
+[`Repository_Management/docs/sibling-repos.md`](https://github.com/D-sorganization/Repository_Management/blob/main/docs/sibling-repos.md).
+
+| Repo | Role |
+| --- | --- |
+| [`Repository_Management`](https://github.com/D-sorganization/Repository_Management) | Fleet orchestrator — CI workflows, skills, templates, agent coordination. |
+| `runner-dashboard` (here) | Operator console — every dashboard tab and `/api/*` endpoint. |
+| [`Maxwell-Daemon`](https://github.com/D-sorganization/Maxwell-Daemon) | Autonomous AI control plane consumed by the Maxwell tab over HTTP. |
+
+The Maxwell tab calls Maxwell-Daemon over HTTP using the contract documented
+in the sibling-repos doc. Maxwell-Daemon never calls back into the dashboard.
+
+---
+
+
 The dashboard is a local FastAPI server that proxies the GitHub API and exposes
 system metrics. The frontend is a self-contained React SPA served directly as
 a static HTML file — no build step, no npm, no node_modules.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,9 +1,34 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.0.0
+**Spec Version:** 2.1.0
 **Application Version:** 4.0.1 (see `VERSION`)
-**Last Updated:** 2026-04-24
+**Last Updated:** 2026-04-25
 **Status:** Active
+
+---
+
+## 0. Sibling repos & boundaries
+
+`runner-dashboard` is one of three repos that together form the
+D-sorganization fleet operating system. The cross-repo contract is
+documented canonically in
+[`Repository_Management/docs/sibling-repos.md`](https://github.com/D-sorganization/Repository_Management/blob/main/docs/sibling-repos.md).
+Quick form:
+
+- **[`Repository_Management`](https://github.com/D-sorganization/Repository_Management)** — fleet orchestrator.
+  Publishes shared CI workflows, skills, templates, agent coordination.
+  *Does not* own dashboard UI, backend, or HTTP API.
+- **`runner-dashboard`** (this repo) — operator console. Owns every dashboard
+  tab, every `/api/*` endpoint, deployment + rollback machinery.
+- **[`Maxwell-Daemon`](https://github.com/D-sorganization/Maxwell-Daemon)** —
+  autonomous local AI control plane. The Maxwell tab here calls the daemon
+  over HTTP; the daemon never calls back.
+
+This SPEC documents only what `runner-dashboard` owns. Fleet-wide workflow
+manifests, agent claim/lease protocol, Project_Template, and skill publishing
+specs live in [`Repository_Management/SPEC.md`](https://github.com/D-sorganization/Repository_Management/blob/main/SPEC.md).
+The Maxwell pipeline state machine and ExecutionSandbox specs live in
+[`Maxwell-Daemon`](https://github.com/D-sorganization/Maxwell-Daemon).
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the boundary between the three fleet repos so issues, PRs, and
code land in the right place. The canonical contract lives in
`Repository_Management/docs/sibling-repos.md`; the other two repos link to
it from CLAUDE.md / README.md / AGENTS.md / SPEC.md (DRY).

- **Repository_Management** — fleet orchestrator (workflows, skills,
  templates, agent coordination). Does not own dashboard or AI pipeline.
- **runner-dashboard** — operator console (every dashboard tab and `/api/*`
  endpoint).
- **Maxwell-Daemon** — autonomous AI control plane with a stable HTTP
  surface consumed by the dashboard's Maxwell tab.

## Companions

This PR ships in lockstep with sibling PRs in the other two repos. All
three should land together so the docs stay consistent.

## Test plan

- [ ] Markdown renders cleanly on GitHub.
- [ ] Spec-Check CI passes (Repository_Management changes are docs-only).
- [ ] No code paths affected; CI quality gates should pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)