### PR TITLE
fix: Python 3.10 compatibility for StrEnum and datetime.UTC

### DIFF
--- a/backend/dispatch_contract.py
+++ b/backend/dispatch_contract.py
@@ -20,7 +20,7 @@ import hmac
 import json
 import os
 from dataclasses import asdict, dataclass, field
-from enum import StrEnum
+from enum import Enum
 from typing import Any
 from uuid import uuid4
 
@@ -55,7 +55,13 @@ def _load_signing_secret() -> str:
     return secret
 
 
-class TimestampValidationResult(StrEnum):
+class _StrEnum(str, Enum):
+    """Python 3.10 compatible StrEnum."""
+
+    pass
+
+
+class TimestampValidationResult(_StrEnum):
     """Result of timestamp freshness validation."""
 
     VALID = "valid"
@@ -126,7 +132,7 @@ def _verify_envelope_signature(
     return hmac.compare_digest(expected, signature)
 
 
-class DispatchAccess(StrEnum):
+class DispatchAccess(_StrEnum):
     """Access level for an allowlisted dispatch action."""
 
     READ_ONLY = "read_only"

--- a/backend/issue_inventory.py
+++ b/backend/issue_inventory.py
@@ -11,12 +11,15 @@ Taxonomy labels follow the schema in ``docs/issue-taxonomy.md``:
 from __future__ import annotations
 
 import asyncio
+import datetime as _dt_mod
 import json
 import logging
 import re
 import time
-from datetime import UTC, datetime
 from typing import Any
+
+UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
+datetime = _dt_mod.datetime
 
 log = logging.getLogger("dashboard")
 

--- a/backend/pr_inventory.py
+++ b/backend/pr_inventory.py
@@ -9,12 +9,15 @@ the backend) so no extra credentials are required.
 from __future__ import annotations
 
 import asyncio
+import datetime as _dt_mod
 import json
 import logging
 import re
 import time
-from datetime import UTC, datetime
 from typing import Any
+
+UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
+datetime = _dt_mod.datetime
 
 log = logging.getLogger("dashboard")
 

--- a/backend/remote_execution_contract.py
+++ b/backend/remote_execution_contract.py
@@ -6,7 +6,7 @@ import datetime as _dt_mod
 import ipaddress
 import re
 from dataclasses import asdict, dataclass, field
-from enum import StrEnum
+from enum import Enum
 from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -28,7 +28,13 @@ PRIVATE_NETWORKS = (
 )
 
 
-class RemoteExecutionAccess(StrEnum):
+class _StrEnum(str, Enum):
+    """Python 3.10 compatible StrEnum."""
+
+    pass
+
+
+class RemoteExecutionAccess(_StrEnum):
     READ_ONLY = "read_only"
     PRIVILEGED = "privileged"
 


### PR DESCRIPTION
Fixes Python 3.10 compatibility issues that prevented tests from running.\n\n- Replaced `from enum import StrEnum` with a Python 3.10-compatible `class _StrEnum(str, Enum)` mixin in dispatch_contract.py and remote_execution_contract.py\n- Replaced `from datetime import UTC` with a fallback pattern in issue_inventory.py and pr_inventory.py\n\nAll 207 tests pass (3 skipped, 1 xfailed).