### PR TITLE
feat(panel-review): implement panel opinion summary and tally logic (#116)

### DIFF
--- a/.github/scripts/panel-review.js
+++ b/.github/scripts/panel-review.js
@@ -24,6 +24,208 @@ const SUMMARY_MARKER = "<!-- panel-review:summary:v1 -->";
 const OPINION_MARKER_RE = /<!--\s*panel-opinion:v1\s+([^>]+?)\s*-->/;
 const MIN_OPINIONS_FOR_SUMMARY = 2;
 
+/**
+ * Parse an opinion comment body into structured data.
+ * Handles malformed opinions gracefully by returning null.
+ *
+ * @param {string} body - Comment body
+ * @returns {object|null} Parsed attributes or null if not an opinion
+ */
+function parseOpinion(body) {
+  if (!body) return null;
+  const m = body.match(OPINION_MARKER_RE);
+  if (!m) return null;
+
+  const attrs = {};
+  for (const pair of m[1].split(/\s+/)) {
+    const eq = pair.indexOf("=");
+    if (eq > 0) attrs[pair.slice(0, eq)] = pair.slice(eq + 1);
+  }
+
+  // Extract opinion sections: Opinion, Suggested approach and Risks
+  const opinionMatch = body.match(
+    /##\s+Opinion\s*\n([\s\S]*?)(?=##\s+(Suggested approach|Risks)|$)/i,
+  );
+  const approachMatch = body.match(
+    /##\s+Suggested approach\s*\n([\s\S]*?)(?=##\s+Risks|$)/i,
+  );
+  const risksMatch = body.match(/##\s+Risks\s*\n([\s\S]*?)$/i);
+
+  attrs.opinion = opinionMatch ? opinionMatch[1].trim() : null;
+  attrs.approach = approachMatch ? approachMatch[1].trim() : null;
+  attrs.risks = risksMatch ? risksMatch[1].trim() : null;
+
+  return attrs;
+}
+
+/**
+ * Calculate consensus level from tally and total opinions.
+ *
+ * @param {object} tally - Stance counts {support, oppose, modify, ...}
+ * @param {number} totalOpinions - Total number of opinions
+ * @returns {object} Consensus metadata {level, percent, label, dominantStance}
+ */
+function calculateConsensus(tally, totalOpinions) {
+  if (totalOpinions < MIN_OPINIONS_FOR_SUMMARY) {
+    return {
+      level: "insufficient",
+      percent: 0,
+      label: "Insufficient consensus",
+      dominantStance: "undecided",
+    };
+  }
+
+  const support = tally.support || 0;
+  const oppose = tally.oppose || 0;
+  const modify = tally.modify || 0;
+
+  const max = Math.max(support, oppose, modify);
+  const percent = totalOpinions > 0 ? Math.round((max / totalOpinions) * 100) : 0;
+
+  let level;
+  if (percent === 100) {
+    level = "unanimous";
+  } else if (percent > 75) {
+    level = "strong";
+  } else if (percent >= 50) {
+    level = "moderate";
+  } else {
+    level = "weak";
+  }
+
+  let dominantStance = "undecided";
+  if (support > oppose && support > modify) {
+    dominantStance = "support";
+  } else if (oppose > support && oppose > modify) {
+    dominantStance = "oppose";
+  } else if (modify > support && modify > oppose) {
+    dominantStance = "modify";
+  } else if (support > 0 && oppose > 0 && support === oppose) {
+    dominantStance = "contested";
+  } else if (max > 0) {
+    // Tie resolution: prefer support > oppose > modify
+    if (support === max) dominantStance = "support";
+    else if (oppose === max) dominantStance = "oppose";
+    else dominantStance = "modify";
+  }
+
+  let label;
+  if (support === 0 && oppose === 0 && modify === 0) {
+    label = "No consensus";
+  } else if (level === "unanimous") {
+    label = "Unanimous consensus";
+  } else if (level === "insufficient") {
+    label = "Insufficient consensus";
+  } else {
+    label = `${level.charAt(0).toUpperCase() + level.slice(1)} consensus (${percent}%)`;
+  }
+
+  return { level, percent, label, dominantStance };
+}
+
+/**
+ * Generate a structured summary markdown from panel opinions.
+ *
+ * @param {object} options
+ * @param {Array} options.opinions - Array of {parsed, author} objects
+ * @returns {string} Summary markdown
+ */
+function generateSummary({ opinions }) {
+  const tally = opinions.reduce((acc, o) => {
+    const s = (o.parsed.stance || "unknown").toLowerCase();
+    acc[s] = (acc[s] || 0) + 1;
+    return acc;
+  }, {});
+
+  // Group and rank approaches by number of supporters
+  const approachGroups = {};
+  for (const o of opinions) {
+    if (o.parsed.approach) {
+      const key = o.parsed.approach.trim();
+      if (!approachGroups[key]) approachGroups[key] = [];
+      approachGroups[key].push(o.author || "unknown");
+    }
+  }
+
+  const rankedApproaches = Object.entries(approachGroups)
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([approach, authors]) => ({ approach, authors }));
+
+  // Compile risks with counts (deduplicate by exact text)
+  const riskMap = new Map();
+  for (const o of opinions) {
+    if (o.parsed.risks) {
+      const key = o.parsed.risks.trim();
+      const existing = riskMap.get(key) || [];
+      existing.push(o.author || "unknown");
+      riskMap.set(key, existing);
+    }
+  }
+
+  const compiledRisks = Array.from(riskMap.entries()).map(([text, authors]) => ({
+    text,
+    count: authors.length,
+    authors,
+  }));
+
+  const totalOpinions = opinions.length;
+  const consensus = calculateConsensus(tally, totalOpinions);
+  const timestamp = new Date().toISOString();
+
+  const lines = [
+    `<!-- panel-summary:v1 dominant_stance=${consensus.dominantStance} consensus=${(consensus.percent / 100).toFixed(2)} -->`,
+    `## Panel Review Summary`,
+    "",
+    `**Dominant Stance:** ${consensus.dominantStance.toUpperCase()} (${consensus.label})`,
+    "",
+    "### Tally",
+    `- Support: ${tally.support || 0} agent${(tally.support || 0) !== 1 ? "s" : ""}`,
+    `- Oppose: ${tally.oppose || 0} agent${(tally.oppose || 0) !== 1 ? "s" : ""}`,
+    `- Modify: ${tally.modify || 0} agent${(tally.modify || 0) !== 1 ? "s" : ""}`,
+    "",
+    "### Suggested Approaches",
+  ];
+
+  if (rankedApproaches.length > 0) {
+    for (let i = 0; i < rankedApproaches.length; i++) {
+      const { approach, authors } = rankedApproaches[i];
+      const label = i === 0 ? "Recommended" : "Alternative";
+      lines.push(`${i + 1}. **${label}:** ${approach}`);
+      lines.push(`   - Supported by: ${authors.join(", ")}`);
+    }
+  } else {
+    lines.push("_No approaches suggested._");
+  }
+
+  lines.push("");
+  lines.push("### Risk Consensus");
+
+  if (compiledRisks.length > 0) {
+    for (const risk of compiledRisks) {
+      lines.push(`- ${risk.text}`);
+      lines.push(
+        `  - Identified by ${risk.count} panelist${risk.count !== 1 ? "s" : ""}${risk.count < totalOpinions ? ` (${risk.authors.join(", ")})` : ""}`,
+      );
+    }
+  } else {
+    lines.push("_No risks identified._");
+  }
+
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push(
+    "**Next Step:** Maintainer review and label adjustment. Once consensus is clear, relabel to `judgement:objective` to unblock implementation.",
+  );
+  lines.push("");
+  const panelistList = opinions.map((o) => `@${o.author || "unknown"}`).join(", ");
+  lines.push(
+    `*Panel review completed: ${timestamp} — Panelists responded: ${panelistList}*`,
+  );
+
+  return lines.join("\n");
+}
+
 async function postBrief({ github, context, core, issue }) {
   const { owner, repo } = context.repo;
   const comments = await github.paginate(
@@ -93,28 +295,6 @@ async function postBrief({ github, context, core, issue }) {
   );
 }
 
-function parseOpinion(body) {
-  if (!body) return null;
-  const m = body.match(OPINION_MARKER_RE);
-  if (!m) return null;
-  const attrs = {};
-  for (const pair of m[1].split(/\s+/)) {
-    const eq = pair.indexOf("=");
-    if (eq > 0) attrs[pair.slice(0, eq)] = pair.slice(eq + 1);
-  }
-
-  // Extract opinion sections: Suggested approach and Risks
-  const opinionMatch = body.match(
-    /##\s+Suggested approach\s*\n([\s\S]*?)(?=##\s+Risks|$)/i,
-  );
-  const risksMatch = body.match(/##\s+Risks\s*\n([\s\S]*?)$/i);
-
-  attrs.approach = opinionMatch ? opinionMatch[1].trim() : null;
-  attrs.risks = risksMatch ? risksMatch[1].trim() : null;
-
-  return attrs;
-}
-
 async function summarize({ github, context, core, issue }) {
   const { owner, repo } = context.repo;
   const comments = await github.paginate(
@@ -122,11 +302,18 @@ async function summarize({ github, context, core, issue }) {
     { owner, repo, issue_number: issue.number, per_page: 100 },
   );
 
-  const opinions = [];
+  // Collect opinions, deduplicating by author (most recent wins)
+  const opinionsByAuthor = new Map();
   for (const c of comments) {
     const parsed = parseOpinion(c.body);
-    if (parsed) opinions.push({ parsed, author: c.user && c.user.login });
+    if (!parsed) continue;
+
+    const author = c.user && c.user.login ? c.user.login : "unknown";
+    // Overwrite with most recent opinion from this author
+    opinionsByAuthor.set(author, { parsed, author });
   }
+
+  const opinions = Array.from(opinionsByAuthor.values());
 
   if (opinions.length < MIN_OPINIONS_FOR_SUMMARY) {
     core.info(
@@ -147,87 +334,10 @@ async function summarize({ github, context, core, issue }) {
     }
   }
 
-  const tally = opinions.reduce((acc, o) => {
-    const s = (o.parsed.stance || "unknown").toLowerCase();
-    acc[s] = (acc[s] || 0) + 1;
-    return acc;
-  }, {});
-
-  // Aggregate approaches and risks
-  const approaches = {};
-  const risksList = [];
-
-  for (const o of opinions) {
-    if (o.parsed.approach) {
-      const key = o.parsed.approach.substring(0, 80); // Group similar approaches
-      approaches[key] = (approaches[key] || []).concat(o.author || "unknown");
-    }
-    if (o.parsed.risks) {
-      risksList.push({
-        author: o.author || "unknown",
-        text: o.parsed.risks,
-      });
-    }
-  }
-
-  // Calculate consensus percentage
-  const totalOpinions = opinions.length;
-  const supportCount = tally.support || 0;
-  const consensusPercent = totalOpinions > 0
-    ? Math.round((supportCount / totalOpinions) * 100)
-    : 0;
-
-  const lines = [
-    SUMMARY_MARKER,
-    `## Panel summary (opinions=${opinions.length})`,
-    "",
-    "| Stance | Count |",
-    "|---|---|",
-    ...Object.entries(tally)
-      .sort((a, b) => b[1] - a[1])
-      .map(([stance, n]) => `| \`${stance}\` | ${n} |`),
-    "",
-    supportCount > 0 && totalOpinions > 1
-      ? `**Consensus:** ${consensusPercent}% support`
-      : supportCount === 1 ? "**Consensus:** Single support (pending more opinions)" : "**Consensus:** Undecided",
-    "",
-  ];
-
-  // Add approaches if any were extracted
-  if (Object.keys(approaches).length > 0) {
-    lines.push("### Suggested Approaches");
-    let approachNum = 1;
-    for (const [approach, authors] of Object.entries(approaches)) {
-      lines.push(`${approachNum}. ${approach}`);
-      lines.push(`   - Suggested by: ${authors.join(", ")}`);
-      approachNum++;
-    }
-    lines.push("");
-  }
-
-  // Add risks if any were extracted
-  if (risksList.length > 0) {
-    lines.push("### Identified Risks");
-    for (const risk of risksList) {
-      lines.push(`- **@${risk.author}**: ${risk.text}`);
-    }
-    lines.push("");
-  }
-
-  lines.push(
-    "### Panelists",
-    ...opinions.map(
-      (o) =>
-        `- @${o.author || "unknown"} — \`${o.parsed.agent || "?"}\`, stance \`${o.parsed.stance || "?"}\``,
-    ),
-    "",
-    "Once the team has picked a direction, remove the `panel-review` label",
-    "and set `judgement:objective` / `judgement:preference` to unblock",
-    "implementation.",
-  );
+  const summaryBody = generateSummary({ opinions });
 
   await github.rest.issues.createComment({
-    owner, repo, issue_number: issue.number, body: lines.join("\n"),
+    owner, repo, issue_number: issue.number, body: summaryBody,
   });
   core.info(`Posted summary on #${issue.number}`);
 }
@@ -313,4 +423,14 @@ function getAgentsForTiers(tiers) {
   return Array.from(agents);
 }
 
-module.exports = { postBrief, summarize, sweep, AGENT_ROSTER, selectTiers, getAgentsForTiers };
+module.exports = {
+  postBrief,
+  summarize,
+  sweep,
+  parseOpinion,
+  calculateConsensus,
+  generateSummary,
+  AGENT_ROSTER,
+  selectTiers,
+  getAgentsForTiers,
+};

--- a/.github/scripts/panel-review.test.js
+++ b/.github/scripts/panel-review.test.js
@@ -1,0 +1,306 @@
+// Tests for panel-review.js
+// Run with: node --test .github/scripts/panel-review.test.js
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const {
+  parseOpinion,
+  calculateConsensus,
+  generateSummary,
+  selectTiers,
+  getAgentsForTiers,
+  AGENT_ROSTER,
+} = require("./panel-review");
+
+// ---------------------------------------------------------------------------
+// parseOpinion
+// ---------------------------------------------------------------------------
+describe("parseOpinion", () => {
+  it("parses a well-formed opinion comment", () => {
+    const body = `<!-- panel-opinion:v1 agent=tier-1 stance=support -->
+## Opinion
+This looks good.
+
+## Suggested approach
+Use a standalone script.
+
+## Risks
+Minimal risk.`;
+
+    const result = parseOpinion(body);
+    assert.strictEqual(result.agent, "tier-1");
+    assert.strictEqual(result.stance, "support");
+    assert.strictEqual(result.opinion, "This looks good.");
+    assert.strictEqual(result.approach, "Use a standalone script.");
+    assert.strictEqual(result.risks, "Minimal risk.");
+  });
+
+  it("returns null for non-opinion comments", () => {
+    assert.strictEqual(parseOpinion("Just a regular comment"), null);
+    assert.strictEqual(parseOpinion(null), null);
+    assert.strictEqual(parseOpinion(""), null);
+  });
+
+  it("parses opinion without optional sections", () => {
+    const body = `<!-- panel-opinion:v1 agent=tier-2 stance=oppose -->
+## Opinion
+I disagree with this approach.`;
+
+    const result = parseOpinion(body);
+    assert.strictEqual(result.agent, "tier-2");
+    assert.strictEqual(result.stance, "oppose");
+    assert.strictEqual(result.opinion, "I disagree with this approach.");
+    assert.strictEqual(result.approach, null);
+    assert.strictEqual(result.risks, null);
+  });
+
+  it("handles malformed opinion gracefully", () => {
+    const body = `<!-- panel-opinion:v1 agent=tier-1 -->
+## Opinion
+Missing stance attribute.`;
+
+    const result = parseOpinion(body);
+    assert.strictEqual(result.agent, "tier-1");
+    assert.strictEqual(result.stance, undefined);
+  });
+
+  it("handles opinion with modify stance", () => {
+    const body = `<!-- panel-opinion:v1 agent=tier-3 stance=modify -->
+## Opinion
+Needs changes.
+
+## Suggested approach
+Refactor the API.
+
+## Risks
+Breaking change.`;
+
+    const result = parseOpinion(body);
+    assert.strictEqual(result.stance, "modify");
+    assert.strictEqual(result.approach, "Refactor the API.");
+    assert.strictEqual(result.risks, "Breaking change.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateConsensus
+// ---------------------------------------------------------------------------
+describe("calculateConsensus", () => {
+  it("returns insufficient for fewer than 2 opinions", () => {
+    const result = calculateConsensus({ support: 1 }, 1);
+    assert.strictEqual(result.level, "insufficient");
+    assert.strictEqual(result.dominantStance, "undecided");
+  });
+
+  it("calculates strong consensus (>75%)", () => {
+    const result = calculateConsensus({ support: 4, oppose: 1 }, 5);
+    assert.strictEqual(result.level, "strong");
+    assert.strictEqual(result.percent, 80);
+    assert.strictEqual(result.dominantStance, "support");
+  });
+
+  it("calculates unanimous consensus (100%)", () => {
+    const result = calculateConsensus({ support: 4 }, 4);
+    assert.strictEqual(result.level, "unanimous");
+    assert.strictEqual(result.percent, 100);
+    assert.strictEqual(result.dominantStance, "support");
+  });
+
+  it("calculates moderate consensus (50-75%)", () => {
+    const result = calculateConsensus({ support: 2, oppose: 1, modify: 1 }, 4);
+    assert.strictEqual(result.level, "moderate");
+    assert.strictEqual(result.dominantStance, "support");
+  });
+
+  it("calculates weak consensus (<50%)", () => {
+    const result = calculateConsensus({ support: 1, oppose: 0, modify: 2 }, 5);
+    assert.strictEqual(result.level, "weak");
+    assert.strictEqual(result.percent, 40);
+    assert.strictEqual(result.dominantStance, "modify");
+  });
+
+  it("flags contested when support equals oppose", () => {
+    const result = calculateConsensus({ support: 2, oppose: 2 }, 4);
+    assert.strictEqual(result.dominantStance, "contested");
+  });
+
+  it("handles all zero counts", () => {
+    const result = calculateConsensus({}, 2);
+    assert.strictEqual(result.dominantStance, "undecided");
+    assert.strictEqual(result.label, "No consensus");
+  });
+
+  it("resolves ties with priority support > oppose > modify", () => {
+    // support=2, modify=2, oppose=0: tied max, support !== oppose
+    // tie resolution should pick support (priority: support > oppose > modify)
+    const result = calculateConsensus({ support: 2, oppose: 0, modify: 2 }, 4);
+    assert.strictEqual(result.dominantStance, "support");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateSummary
+// ---------------------------------------------------------------------------
+describe("generateSummary", () => {
+  it("generates a complete summary with all sections", () => {
+    const opinions = [
+      {
+        parsed: {
+          agent: "tier-1",
+          stance: "support",
+          opinion: "Looks good",
+          approach: "Use a standalone script",
+          risks: "Minimal risk",
+        },
+        author: "claude",
+      },
+      {
+        parsed: {
+          agent: "tier-2",
+          stance: "support",
+          opinion: "Agreed",
+          approach: "Use a standalone script",
+          risks: "Needs tests",
+        },
+        author: "codex",
+      },
+      {
+        parsed: {
+          agent: "tier-3",
+          stance: "modify",
+          opinion: "Needs changes",
+          approach: "Inline logic instead",
+          risks: "Minimal risk",
+        },
+        author: "jules",
+      },
+    ];
+
+    const summary = generateSummary({ opinions });
+    assert.ok(summary.includes("<!-- panel-summary:v1"));
+    assert.ok(summary.includes("dominant_stance=support"));
+    assert.ok(summary.includes("consensus=0.67"));
+    assert.ok(summary.includes("## Panel Review Summary"));
+    assert.ok(summary.includes("### Tally"));
+    assert.ok(summary.includes("Support: 2 agents"));
+    assert.ok(summary.includes("Oppose: 0 agents"));
+    assert.ok(summary.includes("Modify: 1 agent"));
+    assert.ok(summary.includes("### Suggested Approaches"));
+    assert.ok(summary.includes("**Recommended:** Use a standalone script"));
+    assert.ok(summary.includes("**Alternative:** Inline logic instead"));
+    assert.ok(summary.includes("### Risk Consensus"));
+    assert.ok(summary.includes("Identified by 2 panelists"));
+    assert.ok(summary.includes("@claude, @codex, @jules"));
+    assert.ok(summary.includes("Panel review completed:"));
+  });
+
+  it("handles no approaches or risks gracefully", () => {
+    const opinions = [
+      {
+        parsed: { agent: "tier-1", stance: "oppose" },
+        author: "claude",
+      },
+      {
+        parsed: { agent: "tier-2", stance: "oppose" },
+        author: "codex",
+      },
+    ];
+
+    const summary = generateSummary({ opinions });
+    assert.ok(summary.includes("_No approaches suggested._"));
+    assert.ok(summary.includes("_No risks identified._"));
+  });
+
+  it("handles single opinion with correct pluralization", () => {
+    const opinions = [
+      {
+        parsed: {
+          agent: "tier-1",
+          stance: "support",
+          approach: "Do it",
+        },
+        author: "claude",
+      },
+    ];
+
+    const summary = generateSummary({ opinions });
+    assert.ok(summary.includes("Support: 1 agent"));
+    assert.ok(summary.includes("Oppose: 0 agents"));
+    assert.ok(!summary.includes("1 agents"));
+  });
+
+  it("includes panelist names in summary", () => {
+    const opinions = [
+      { parsed: { stance: "support" }, author: "agentA" },
+      { parsed: { stance: "oppose" }, author: "agentB" },
+    ];
+    const summary = generateSummary({ opinions });
+    assert.ok(summary.includes("@agentA"));
+    assert.ok(summary.includes("@agentB"));
+  });
+
+  it("uses risk count singular when one panelist identifies", () => {
+    const opinions = [
+      {
+        parsed: { stance: "support", risks: "Security concern" },
+        author: "agentA",
+      },
+      {
+        parsed: { stance: "support" },
+        author: "agentB",
+      },
+    ];
+    const summary = generateSummary({ opinions });
+    assert.ok(summary.includes("Identified by 1 panelist"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectTiers / getAgentsForTiers
+// ---------------------------------------------------------------------------
+describe("selectTiers", () => {
+  it("selects tier-1 for trivial complexity", () => {
+    assert.deepStrictEqual(selectTiers("trivial"), ["tier-1", "tier-2", "tier-3"]);
+  });
+
+  it("selects all tiers for routine complexity", () => {
+    assert.deepStrictEqual(selectTiers("routine"), ["tier-1", "tier-2", "tier-3"]);
+  });
+
+  it("selects tier-2 and tier-3 for complex", () => {
+    assert.deepStrictEqual(selectTiers("complex"), ["tier-2", "tier-3"]);
+  });
+
+  it("selects only tier-3 for deep", () => {
+    assert.deepStrictEqual(selectTiers("deep"), ["tier-3"]);
+  });
+
+  it("selects research for research complexity", () => {
+    assert.deepStrictEqual(selectTiers("research"), ["research"]);
+  });
+
+  it("returns empty array for unknown complexity", () => {
+    assert.deepStrictEqual(selectTiers("unknown"), []);
+  });
+});
+
+describe("getAgentsForTiers", () => {
+  it("returns unique agents for given tiers", () => {
+    const agents = getAgentsForTiers(["tier-1", "tier-2"]);
+    assert.ok(agents.includes("claude"));
+    assert.ok(agents.includes("codex"));
+    assert.ok(agents.includes("maxwell-daemon"));
+  });
+
+  it("returns empty array for unknown tiers", () => {
+    assert.deepStrictEqual(getAgentsForTiers(["nonexistent"]), []);
+  });
+});
+
+describe("AGENT_ROSTER", () => {
+  it("has expected structure", () => {
+    assert.ok(AGENT_ROSTER["tier-1"]);
+    assert.ok(AGENT_ROSTER["tier-2"]);
+    assert.ok(AGENT_ROSTER["tier-3"]);
+    assert.ok(AGENT_ROSTER.research);
+  });
+});


### PR DESCRIPTION
Closes #116.

## Summary

Implements the full panel opinion summary and tally logic as specified in #116.

## Changes

### .github/scripts/panel-review.js
- Refactored parseOpinion() to extract all structured sections (Opinion, Suggested approach, Risks) with graceful handling of malformed or incomplete comments
- Added calculateConsensus() with clear consensus levels: unanimous (100%), strong (>75%), moderate (50-75%), weak (<50%), insufficient (<2 opinions), contested (support == oppose), undecided
- Added generateSummary() producing structured markdown with HTML metadata comment (panel-summary:v1), dominant stance with consensus level, tally with proper pluralization, ranked suggested approaches (Recommended/Alternative), risk consensus with deduplication and per-risk counts, timestamp and full panelist list
- Updated summarize() to deduplicate opinions by author (most recent wins)
- Exported all new pure functions for testability

### .github/scripts/panel-review.test.js
- 27 tests covering parseOpinion, calculateConsensus, generateSummary, selectTiers, getAgentsForTiers, and AGENT_ROSTER
- Uses Node.js built-in test runner (no extra dependencies)
- All tests pass

## Verification
- node --test .github/scripts/panel-review.test.js -> 27/27 pass
- node -e "require('./.github/scripts/panel-review.js')" -> loads without error
- ruff check backend/ -> all checks passed
- PYTHONPATH=backend pytest tests/ -> 207 passed, 3 skipped, 1 xfailed
- No new Python code; no type-check impact
- No TODO/FIXME placeholders introduced