### PR TITLE
feat(remediation): add drill-down links to failed-run rows

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9400,25 +9400,64 @@
                         ),
                       ),
                       h(
-                        "a",
+                        "div",
                         {
-                          href: ghUrl,
-                          target: "_blank",
-                          rel: "noopener noreferrer",
-                          onClick: function (e) {
-                            e.stopPropagation();
-                          },
                           style: {
-                            fontSize: 11,
-                            color: "var(--accent-green)",
-                            textDecoration: "none",
-                            padding: "4px 8px",
-                            border: "1px solid var(--accent-green)",
-                            borderRadius: 4,
-                            whiteSpace: "nowrap",
+                            display: "flex",
+                            gap: 4,
+                            flexWrap: "wrap",
+                            justifyContent: "flex-end",
                           },
                         },
-                        "↗ GitHub",
+                        [
+                          {
+                            label: "Run",
+                            href: ghUrl,
+                          },
+                          {
+                            label: "Repo",
+                            href:
+                              run.repository &&
+                              run.repository.html_url
+                                ? run.repository.html_url
+                                : "https://github.com/D-sorganization/" + repoName,
+                          },
+                          {
+                            label: "Branch",
+                            href:
+                              "https://github.com/D-sorganization/" +
+                              repoName +
+                              "/tree/" +
+                              encodeURIComponent(branch),
+                          },
+                          {
+                            label: "Logs",
+                            href: ghUrl + "/logs",
+                          },
+                        ].map(function (link) {
+                          return h(
+                            "a",
+                            {
+                              key: link.label,
+                              href: link.href,
+                              target: "_blank",
+                              rel: "noopener noreferrer",
+                              onClick: function (e) {
+                                e.stopPropagation();
+                              },
+                              style: {
+                                fontSize: 10,
+                                color: "var(--accent-green)",
+                                textDecoration: "none",
+                                padding: "3px 6px",
+                                border: "1px solid var(--accent-green)",
+                                borderRadius: 4,
+                                whiteSpace: "nowrap",
+                              },
+                            },
+                            "↗ " + link.label,
+                          );
+                        }),
                       ),
                       h(
                         "select",


### PR DESCRIPTION
Closes #109

Replaces the single '↗ GitHub' link in each failed-run row with a compact flex row of actionable deep-links:

- **Run** → the workflow run page
- **Repo** → the repository home
- **Branch** → the branch tree (with `encodeURIComponent` for safety)
- **Logs** → the run logs

This satisfies the acceptance criterion from #109:

> *failed runs are clickable and expose enough context to understand the failure*

### Security / quality notes
- `encodeURIComponent(branch)` prevents injection in the branch URL.
- Each link still calls `e.stopPropagation()` so clicking a pill does not trigger the parent row click.
- `rel="noopener noreferrer"` is preserved on every `<a>`.

### What is NOT in this PR
- Moving Manual dispatch to the top of the page (separate UI refactor)
- Inline editing for provider / loop-guard settings (needs backend contract)
- Fallback provider chain (tracked separately)

Those remain open as follow-ups under #109.