### PR TITLE
feat(#131): Identity Wave 1 — Foundation and Principal Model

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,8 +1,8 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.2.0
+**Spec Version:** 2.3.0
 **Application Version:** 4.0.1 (see `VERSION`)
-**Last Updated:** 2026-04-25
+**Last Updated:** 2026-04-26
 **Status:** Active
 
 ---
@@ -846,6 +846,48 @@ The function:
 Every generated prompt also includes the constant
 `PROMPT_UNTRUSTED_SYSTEM_INSTRUCTION` as a preamble, instructing the model
 not to follow any instructions found inside the delimiters.
+
+### 9.8 Identity and Principal Model (Issue #131)
+The dashboard supports a configurable identity and authorization layer via
+`config/principals.yml` and the `backend/principal.py` module.
+
+**Principal types:**
+- `human` — authenticated via GitHub OAuth (future)
+- `bot` — authenticated via service token (future)
+- `service` — internal service accounts (e.g. Maxwell-Daemon, autoscaler)
+
+**`config/principals.yml` schema:**
+```yaml
+principals:
+  - id: alice
+    name: Alice
+    type: human
+    email: alice@example.com
+    roles: [operator, admin]
+    permissions: [fleet:read, fleet:write, agents:dispatch]
+```
+
+**Built-in permissions:** `fleet:read`, `fleet:write`, `agents:dispatch`,
+`agents:read`, `workflows:dispatch`, `workflows:read`, `config:read`,
+`config:write`, `credentials:read`, `system:read`, `system:write`.
+
+**Fail-closed behavior:**
+When `principals.yml` contains more than the two anonymous fallback entries,
+requests without a recognized principal are rejected with HTTP 401 by the
+`require_principal()` FastAPI dependency.
+
+**FastAPI integration:**
+- `_principal_middleware` attaches the current principal to `request.state`
+  by reading the `X-Principal-Id` header
+- `require_principal()` dependency raises 401 for anonymous when real
+  principals are configured
+- `require_role(role)` and `require_permission(perm)` dependency factories
+  raise 403 when the principal lacks the required grant
+
+**No hardcoded identities:**
+All previous hardcoded `"dashboard-user"` / `"dashboard-operator"` strings
+have been removed.  Fallback defaults are `"unknown"` (anonymous human) and
+`"anonymous-bot"` (anonymous bot).
 
 ---
 

--- a/backend/assistant_contract.py
+++ b/backend/assistant_contract.py
@@ -108,7 +108,7 @@ class AuditHistoryResponse(BaseModel):
 # Retained for backwards-compatibility with existing callers.
 
 
-class ActionRiskLevel(enum.StrEnum):
+class ActionRiskLevel(str, enum.Enum):
     """Risk assessment for proposed actions."""
 
     LOW = "low"  # Informational, no impact

--- a/backend/principal.py
+++ b/backend/principal.py
@@ -1,0 +1,297 @@
+"""Principal model — identity and authorization foundation.
+
+Issue #131: Foundation and Principal Model
+Provides the ``Principal`` dataclass and ``require_principal()`` FastAPI
+dependency so every state-changing request carries a verifiable identity.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+log = logging.getLogger("dashboard.principal")
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+_UNKNOWN_PRINCIPAL_ID = "unknown"
+_DEFAULT_HUMAN = "anonymous-human"
+_DEFAULT_BOT = "anonymous-bot"
+
+# ─── Enums ────────────────────────────────────────────────────────────────────
+
+
+class PrincipalType(str, Enum):
+    """Class of principal."""
+
+    HUMAN = "human"
+    BOT = "bot"
+    SERVICE = "service"
+
+
+# ─── Dataclass ──────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class Principal:
+    """Verified identity attached to every authenticated request.
+
+    Attributes
+    ----------
+    id:
+        Stable identifier (GitHub login for humans, service name for bots).
+    name:
+        Human-readable display name.
+    type:
+        ``human``, ``bot``, or ``service``.
+    email:
+        Optional contact address.
+    roles:
+        Set of role strings (e.g. ``{"operator", "viewer"}``).
+    permissions:
+        Set of explicit permission strings (e.g. ``{"fleet:write", "agents:dispatch"}``).
+    """
+
+    id: str
+    name: str
+    type: PrincipalType
+    email: str | None = None
+    roles: frozenset[str] = frozenset()
+    permissions: frozenset[str] = frozenset()
+
+    def has_role(self, role: str) -> bool:
+        """Return True when the principal carries *role* (case-insensitive)."""
+        return role.lower() in {r.lower() for r in self.roles}
+
+    def has_permission(self, permission: str) -> bool:
+        """Return True when the principal carries *permission* (case-insensitive)."""
+        return permission.lower() in {p.lower() for p in self.permissions}
+
+
+# ─── Anonymous sentinel instances ─────────────────────────────────────────────
+
+_ANONYMOUS_HUMAN = Principal(
+    id=_UNKNOWN_PRINCIPAL_ID,
+    name=_DEFAULT_HUMAN,
+    type=PrincipalType.HUMAN,
+    roles=frozenset(),
+    permissions=frozenset(),
+)
+
+_ANONYMOUS_BOT = Principal(
+    id=_UNKNOWN_PRINCIPAL_ID,
+    name=_DEFAULT_BOT,
+    type=PrincipalType.BOT,
+    roles=frozenset(),
+    permissions=frozenset(),
+)
+
+
+# ─── YAML Loader ────────────────────────────────────────────────────────────────
+
+
+class PrincipalConfigError(Exception):
+    """Raised when principals.yml is missing, malformed, or contains duplicate IDs."""
+
+
+def _default_principals() -> dict[str, Principal]:
+    """Return the built-in anonymous principals for backward compatibility."""
+    return {
+        _UNKNOWN_PRINCIPAL_ID: _ANONYMOUS_HUMAN,
+        "anonymous-bot": _ANONYMOUS_BOT,
+    }
+
+
+def load_principals(path: Path | None = None) -> dict[str, Principal]:
+    """Load principals from *path* (YAML).
+
+    The file is optional; if missing the function returns built-in anonymous
+    principals and logs an informational message.
+
+    Parameters
+    ----------
+    path:
+        Absolute path to ``principals.yml``.  Defaults to
+        ``config/principals.yml`` under the repository root.
+    """
+    if path is None:
+        repo_root = Path(
+            os.environ.get("RUNNER_DASHBOARD_REPO_ROOT", Path(__file__).resolve().parents[1])
+        )
+        path = repo_root / "config" / "principals.yml"
+
+    if not path.exists():
+        log.info("principals.yml not found at %s; using anonymous principals", path)
+        return _default_principals()
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise PrincipalConfigError(f"Failed to load principals.yml: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise PrincipalConfigError("principals.yml root must be a mapping")
+
+    principals_list = raw.get("principals")
+    if principals_list is None:
+        log.info("principals.yml has no 'principals' key; using anonymous principals")
+        return _default_principals()
+
+    if not isinstance(principals_list, list):
+        raise PrincipalConfigError("'principals' must be a list")
+
+    principals: dict[str, Principal] = {}
+    for idx, entry in enumerate(principals_list, start=1):
+        if not isinstance(entry, dict):
+            raise PrincipalConfigError(f"Entry {idx} is not a mapping")
+        pid = str(entry.get("id") or entry.get("name") or "").strip()
+        if not pid:
+            raise PrincipalConfigError(f"Entry {idx} is missing 'id' or 'name'")
+        if pid in principals:
+            raise PrincipalConfigError(f"Duplicate principal id: {pid}")
+
+        ptype_str = str(entry.get("type") or "service").strip().lower()
+        try:
+            ptype = PrincipalType(ptype_str)
+        except ValueError as exc:
+            raise PrincipalConfigError(
+                f"Entry {idx} ({pid}) has invalid type: {ptype_str}"
+            ) from exc
+
+        roles = frozenset(str(r).strip().lower() for r in entry.get("roles", []) if str(r).strip())
+        permissions = frozenset(
+            str(p).strip().lower() for p in entry.get("permissions", []) if str(p).strip()
+        )
+
+        principals[pid] = Principal(
+            id=pid,
+            name=str(entry.get("name") or pid).strip(),
+            type=ptype,
+            email=str(entry.get("email") or "").strip() or None,
+            roles=roles,
+            permissions=permissions,
+        )
+
+    # Always ensure the anonymous fallback exists
+    if _UNKNOWN_PRINCIPAL_ID not in principals:
+        principals[_UNKNOWN_PRINCIPAL_ID] = _ANONYMOUS_HUMAN
+
+    log.info("Loaded %d principal(s) from %s", len(principals), path)
+    return principals
+
+
+# ─── Pydantic model for request bodies ──────────────────────────────────────────
+
+
+class PrincipalRef(BaseModel):
+    """Lightweight principal reference used in request payloads."""
+
+    id: str = Field(..., max_length=200)
+    name: str = Field(default="", max_length=200)
+    type: str = Field(default="human", max_length=20)
+
+    def to_principal(self) -> Principal:
+        """Return a full Principal from this reference."""
+        try:
+            ptype = PrincipalType(self.type.lower())
+        except ValueError:
+            ptype = PrincipalType.HUMAN
+        return Principal(
+            id=self.id,
+            name=self.name or self.id,
+            type=ptype,
+        )
+
+
+# ─── FastAPI dependency ─────────────────────────────────────────────────────────
+
+_PRINCIPALS: dict[str, Principal] | None = None
+
+
+def init_principals(principals: dict[str, Principal] | None = None) -> None:
+    """Populate the global principal registry (called once at server boot)."""
+    global _PRINCIPALS  # noqa: PLW0603
+    if principals is not None:
+        _PRINCIPALS = dict(principals)
+    else:
+        _PRINCIPALS = load_principals()
+
+
+def get_principal_registry() -> dict[str, Principal]:
+    """Return the loaded principal registry."""
+    if _PRINCIPALS is None:
+        init_principals()
+    return _PRINCIPALS  # type: ignore[return-value]
+
+
+def _lookup_principal(pid: str) -> Principal:
+    """Return the principal with id *pid*, falling back to anonymous."""
+    registry = get_principal_registry()
+    return registry.get(pid, _ANONYMOUS_HUMAN)
+
+
+def get_current_principal(request: Request) -> Principal:
+    """Extract the current principal from request.state (set by auth middleware)."""
+    principal = getattr(request.state, "principal", None)
+    if isinstance(principal, Principal):
+        return principal
+    # Fallback to header for API-key-authenticated clients (bots / service tokens)
+    header_pid = request.headers.get("X-Principal-Id", "").strip()
+    if header_pid:
+        return _lookup_principal(header_pid)
+    return _ANONYMOUS_HUMAN
+
+
+def require_principal(request: Request = None) -> Principal:  # type: ignore[assignment]
+    """FastAPI dependency: attach the current principal to the request.
+
+    Raises ``HTTPException(401)`` when no principal is attached and the
+    configuration requires authentication (fail-closed).
+    """
+    # FastAPI injects the Request automatically when used as Depends()
+    if request is None:  # pragma: no cover
+        raise HTTPException(status_code=401, detail="Authentication required")
+    principal = get_current_principal(request)
+    # Fail closed: anonymous principals with the unknown ID are rejected
+    # when the server is configured with real principals.
+    if principal.id == _UNKNOWN_PRINCIPAL_ID and len(get_principal_registry()) > 2:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return principal
+
+
+def require_role(role: str):
+    """Return a FastAPI dependency that enforces *role* on the current principal."""
+
+    def _checker(request: Request = None) -> Principal:  # type: ignore[assignment]
+        principal = require_principal(request)
+        if not principal.has_role(role):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Role '{role}' required",
+            )
+        return principal
+
+    return _checker
+
+
+def require_permission(permission: str):
+    """Return a FastAPI dependency that enforces *permission* on the current principal."""
+
+    def _checker(request: Request = None) -> Principal:  # type: ignore[assignment]
+        principal = require_principal(request)
+        if not principal.has_permission(permission):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Permission '{permission}' required",
+            )
+        return principal
+
+    return _checker

--- a/backend/quick_dispatch.py
+++ b/backend/quick_dispatch.py
@@ -127,7 +127,7 @@ def _make_audit_entry(
         "access": DispatchAccess.PRIVILEGED.value,
         "source": "dashboard",
         "target": repository,
-        "requested_by": "dashboard-operator",
+        "requested_by": "unknown",
         "decision": decision,
         "detail": detail,
         "fingerprint": fingerprint,

--- a/backend/server.py
+++ b/backend/server.py
@@ -67,6 +67,7 @@ from machine_registry import (  # noqa: E402
     load_machine_registry,
     merge_registry_with_live_nodes,
 )
+from principal import init_principals  # noqa: E402
 from report_files import parse_report_metrics, sanitize_report_date  # noqa: E402
 from routers import credentials as _credentials_router  # noqa: E402
 from routers import dispatch as _dispatch_router  # noqa: E402
@@ -209,7 +210,7 @@ class WorkflowDispatchBody(BaseModel):
     workflow_id: Any = None
     ref: str = Field(default="main", max_length=200)
     inputs: dict[str, Any] = Field(default_factory=dict)
-    approved_by: str = Field(default="dashboard-operator", max_length=200)
+    approved_by: str = Field(default="unknown", max_length=200)
 
 
 class HeavyTestDispatchBody(BaseModel):
@@ -470,6 +471,20 @@ async def get_setup_key(request: Request) -> dict:
 
 
 @app.middleware("http")
+async def _principal_middleware(request: Request, call_next: Any) -> Any:
+    """Attach the current principal to request.state (issue #131).
+
+    Reads the X-Principal-Id header and looks up the principal in the loaded
+    registry. Falls back to anonymous when no header is present.
+    """
+    from principal import get_current_principal  # noqa: PLC0415
+
+    request.state.principal = get_current_principal(request)
+    response = await call_next(request)
+    return response
+
+
+@app.middleware("http")
 async def _csrf_check(request: Request, call_next: Any) -> Any:
     """Reject state-changing requests that lack the CSRF sentinel header (issue #30).
 
@@ -518,6 +533,7 @@ async def _add_security_headers(request: Request, call_next: Any) -> Any:
 # ─── Startup timestamp ───────────────────────────────────────────────────────
 BOOT_TIME = time.time()
 _setup_api_key()
+init_principals()
 
 # ─── Response cache ───────────────────────────────────────────────────────────
 # The frontend polls every 10-15 s; without caching, each poll spawns dozens of
@@ -732,9 +748,6 @@ async def proxy_to_hub(request: Request):
                 return {}
             return resp.json()
         except Exception as e:  # noqa: BLE001
-            log.warning("Hub proxy error for %s: %s", request.url.path, e)
-            raise HTTPException(status_code=502, detail="Hub proxy error") from e
-
             log.warning("Hub proxy error for %s: %s", request.url.path, e)
             raise HTTPException(status_code=502, detail="Hub proxy error") from e
 
@@ -2901,7 +2914,7 @@ async def dispatch_workflow(request: Request) -> dict:
     workflow_id = body.get("workflow_id")
     ref = str(body.get("ref", "main")).strip()
     inputs = body.get("inputs", {}) or {}
-    approved_by = str(body.get("approved_by", "dashboard-operator")).strip()
+    approved_by = str(body.get("approved_by", "")).strip()
 
     if not repo or not workflow_id:
         raise HTTPException(status_code=422, detail="repository and workflow_id required")
@@ -6072,7 +6085,7 @@ async def fleet_orchestration_dispatch(request: Request) -> dict:
     ref = str(body.get("ref", "main")).strip() or "main"
     machine_target = str(body.get("machine_target", "")).strip()
     inputs = body.get("inputs") or {}
-    approved_by = str(body.get("approved_by", "dashboard-user")).strip() or "dashboard-user"
+    approved_by = str(body.get("approved_by", "")).strip() or "unknown"
 
     if not repo or not workflow:
         raise HTTPException(status_code=422, detail="repo and workflow are required")
@@ -6183,7 +6196,7 @@ async def fleet_orchestration_deploy(request: Request) -> dict:
     machine = str(body.get("machine", "")).strip()
     action = str(body.get("action", "")).strip()
     confirmed = bool(body.get("confirmed", False))
-    requested_by = str(body.get("requested_by", "dashboard-user")).strip() or "dashboard-user"
+    requested_by = str(body.get("requested_by", "")).strip() or "unknown"
 
     if not machine:
         raise HTTPException(status_code=422, detail="machine is required")
@@ -6402,9 +6415,6 @@ async def restart_dashboard_service(request: Request) -> dict:
             "output": (result.stdout + result.stderr).strip(),
         }
     except Exception as exc:  # noqa: BLE001
-        log.exception("Failed to restart runner-dashboard service")
-        raise HTTPException(status_code=500, detail="Restart failed") from exc
-
         log.exception("Failed to restart runner-dashboard service")
         raise HTTPException(status_code=500, detail="Restart failed") from exc
 

--- a/config/principals.yml
+++ b/config/principals.yml
@@ -1,0 +1,94 @@
+# Principals configuration — identity and authorization for the runner dashboard.
+#
+# Issue #131: Identity: Wave 1 - Foundation and Principal Model
+#
+# Each entry defines a verified identity that can be attached to requests.
+# The dashboard supports three principal types:
+#
+#   human   — authenticated via GitHub OAuth (login flow)
+#   bot     — authenticated via service token (minted/rotated by the dashboard)
+#   service — internal service accounts (e.g. Maxwell-Daemon, autoscaler)
+#
+# Fields
+# ------
+# id          : Stable unique identifier (required).  GitHub login for humans.
+# name        : Human-readable display name (defaults to id).
+# type        : One of human, bot, service (defaults to service).
+# email       : Optional contact address.
+# roles       : List of role strings.  Built-in roles: operator, viewer, admin.
+# permissions : List of explicit permission strings.
+#
+# Built-in permissions
+# --------------------
+#   fleet:read          — view runners, machines, fleet status
+#   fleet:write         — start/stop runners, fleet control
+#   agents:dispatch     — dispatch AI agent tasks
+#   agents:read         — view agent history, plans
+#   workflows:dispatch  — trigger GitHub Actions workflows
+#   workflows:read      — view workflow runs, queue
+#   config:read         — view configuration
+#   config:write        — modify configuration
+#   credentials:read    — view credential inventory (names only)
+#   system:read         — view system metrics
+#   system:write        — restart services, run diagnostics
+#
+# Fail-closed behaviour
+# ---------------------
+# When principals.yml is present and contains more than the two anonymous
+# fallbacks, requests without a recognised principal are rejected with 401.
+# This is enforced by the ``require_principal()`` FastAPI dependency.
+
+principals:
+  # ── Anonymous fallbacks (always present, used when no auth is configured) ──
+  - id: unknown
+    name: Anonymous Human
+    type: human
+    roles: [viewer]
+    permissions: [fleet:read, agents:read, workflows:read, system:read]
+
+  - id: anonymous-bot
+    name: Anonymous Bot
+    type: bot
+    roles: []
+    permissions: []
+
+  # ── Example human operator (replace with real GitHub logins) ────────────────
+  # - id: dieterolson
+  #   name: Dieter Olson
+  #   type: human
+  #   email: dieter@example.com
+  #   roles: [operator, admin]
+  #   permissions:
+  #     - fleet:read
+  #     - fleet:write
+  #     - agents:dispatch
+  #     - agents:read
+  #     - workflows:dispatch
+  #     - workflows:read
+  #     - config:read
+  #     - config:write
+  #     - credentials:read
+  #     - system:read
+  #     - system:write
+
+  # ── Example service account (e.g. Maxwell-Daemon) ─────────────────────────
+  # - id: maxwell-daemon
+  #   name: Maxwell Daemon
+  #   type: service
+  #   roles: [operator]
+  #   permissions:
+  #     - fleet:read
+  #     - fleet:write
+  #     - agents:dispatch
+  #     - system:read
+  #     - system:write
+
+  # ── Example bot principal (e.g. CI agent) ───────────────────────────────────
+  # - id: ci-agent
+  #   name: CI Agent
+  #   type: bot
+  #   roles: [viewer]
+  #   permissions:
+  #     - fleet:read
+  #     - workflows:read
+  #     - system:read

--- a/tests/test_keepalive_diagnostics.py
+++ b/tests/test_keepalive_diagnostics.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
 
 import server  # noqa: E402
 

--- a/tests/test_principal.py
+++ b/tests/test_principal.py
@@ -1,0 +1,352 @@
+"""Tests for the principal identity and authorization module (issue #131)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+import principal as principal_mod  # noqa: E402
+from principal import (  # noqa: E402
+    Principal,
+    PrincipalConfigError,
+    PrincipalRef,
+    PrincipalType,
+    get_current_principal,
+    get_principal_registry,
+    init_principals,
+    load_principals,
+    require_permission,
+    require_principal,
+    require_role,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_principals():
+    """Reset the global principal registry before every test."""
+    principal_mod._PRINCIPALS = None
+    yield
+    principal_mod._PRINCIPALS = None
+
+
+# ─── Principal dataclass ────────────────────────────────────────────────────────
+
+
+class TestPrincipalDataclass:
+    def test_principal_equality(self) -> None:
+        p1 = Principal(id="alice", name="Alice", type=PrincipalType.HUMAN, roles=frozenset({"operator"}))
+        p2 = Principal(id="alice", name="Alice", type=PrincipalType.HUMAN, roles=frozenset({"operator"}))
+        assert p1 == p2
+
+    def test_has_role_case_insensitive(self) -> None:
+        p = Principal(id="alice", name="Alice", type=PrincipalType.HUMAN, roles=frozenset({"Operator"}))
+        assert p.has_role("operator")
+        assert p.has_role("OPERATOR")
+
+    def test_has_role_missing(self) -> None:
+        p = Principal(id="alice", name="Alice", type=PrincipalType.HUMAN)
+        assert not p.has_role("admin")
+
+    def test_has_permission_case_insensitive(self) -> None:
+        p = Principal(
+            id="alice",
+            name="Alice",
+            type=PrincipalType.HUMAN,
+            permissions=frozenset({"Fleet:Write"}),
+        )
+        assert p.has_permission("fleet:write")
+        assert p.has_permission("FLEET:WRITE")
+
+    def test_frozen_dataclass_cannot_mutate(self) -> None:
+        p = Principal(id="alice", name="Alice", type=PrincipalType.HUMAN)
+        with pytest.raises(AttributeError):
+            p.name = "Bob"  # type: ignore[misc]
+
+
+# ─── PrincipalType enum ─────────────────────────────────────────────────────────
+
+
+class TestPrincipalType:
+    def test_from_string_valid(self) -> None:
+        assert PrincipalType("human") == PrincipalType.HUMAN
+        assert PrincipalType("bot") == PrincipalType.BOT
+        assert PrincipalType("service") == PrincipalType.SERVICE
+
+    def test_from_string_invalid_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PrincipalType("alien")
+
+
+# ─── YAML loader ────────────────────────────────────────────────────────────────
+
+
+class TestLoadPrincipals:
+    def test_missing_file_returns_anonymous(self, tmp_path: Path) -> None:
+        result = load_principals(tmp_path / "nonexistent.yml")
+        assert "unknown" in result
+        assert result["unknown"].type == PrincipalType.HUMAN
+
+    def test_empty_principals_key_returns_anonymous(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        path.write_text("principals:\n")
+        result = load_principals(path)
+        assert "unknown" in result
+
+    def test_loads_single_principal(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        data = {
+            "principals": [
+                {
+                    "id": "alice",
+                    "name": "Alice",
+                    "type": "human",
+                    "email": "alice@example.com",
+                    "roles": ["operator", "viewer"],
+                    "permissions": ["fleet:read", "fleet:write"],
+                }
+            ]
+        }
+        path.write_text(yaml.dump(data))
+        result = load_principals(path)
+        assert "alice" in result
+        alice = result["alice"]
+        assert alice.name == "Alice"
+        assert alice.email == "alice@example.com"
+        assert alice.type == PrincipalType.HUMAN
+        assert alice.has_role("operator")
+        assert alice.has_role("viewer")
+        assert alice.has_permission("fleet:read")
+
+    def test_duplicate_id_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        data = {"principals": [{"id": "alice"}, {"id": "alice"}]}
+        path.write_text(yaml.dump(data))
+        with pytest.raises(PrincipalConfigError, match="Duplicate principal id"):
+            load_principals(path)
+
+    def test_invalid_type_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        data = {"principals": [{"id": "alice", "type": "alien"}]}
+        path.write_text(yaml.dump(data))
+        with pytest.raises(PrincipalConfigError, match="invalid type"):
+            load_principals(path)
+
+    def test_missing_id_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        data = {"principals": [{"name": ""}]}
+        path.write_text(yaml.dump(data))
+        with pytest.raises(PrincipalConfigError, match="missing"):
+            load_principals(path)
+
+    def test_root_not_dict_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        path.write_text("- not a dict")
+        with pytest.raises(PrincipalConfigError, match="root must be a mapping"):
+            load_principals(path)
+
+    def test_principals_not_list_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        data = {"principals": "notalist"}
+        path.write_text(yaml.dump(data))
+        with pytest.raises(PrincipalConfigError, match="'principals' must be a list"):
+            load_principals(path)
+
+    def test_ensures_unknown_fallback(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        data = {"principals": [{"id": "alice", "name": "Alice"}]}
+        path.write_text(yaml.dump(data))
+        result = load_principals(path)
+        assert "unknown" in result
+        assert result["unknown"].id == "unknown"
+
+    def test_roles_permissions_normalised_to_lower(self, tmp_path: Path) -> None:
+        path = tmp_path / "principals.yml"
+        data = {
+            "principals": [
+                {
+                    "id": "alice",
+                    "roles": ["Operator"],
+                    "permissions": ["Fleet:Write"],
+                }
+            ]
+        }
+        path.write_text(yaml.dump(data))
+        result = load_principals(path)
+        alice = result["alice"]
+        assert alice.has_role("operator")
+        assert alice.has_permission("fleet:write")
+
+
+# ─── FastAPI dependency helpers ─────────────────────────────────────────────────
+
+
+class FakeRequest:
+    """Minimal ASGI request stand-in for testing."""
+
+    def __init__(self, headers: dict[str, str] | None = None, state_principal: Principal | None = None) -> None:
+        self.headers = headers or {}
+        self.state = type("State", (), {})()
+        if state_principal:
+            self.state.principal = state_principal
+
+
+class TestGetCurrentPrincipal:
+    def test_from_request_state(self) -> None:
+        p = Principal(id="alice", name="Alice", type=PrincipalType.HUMAN)
+        req = FakeRequest(state_principal=p)
+        assert get_current_principal(req) == p  # type: ignore[arg-type]
+
+    def test_from_header(self) -> None:
+        init_principals(
+            {
+                "alice": Principal(id="alice", name="Alice", type=PrincipalType.HUMAN),
+                "unknown": Principal(id="unknown", name="Unknown", type=PrincipalType.HUMAN),
+            }
+        )
+        req = FakeRequest(headers={"X-Principal-Id": "alice"})
+        result = get_current_principal(req)  # type: ignore[arg-type]
+        assert result.id == "alice"
+
+    def test_unknown_header_returns_anonymous(self) -> None:
+        init_principals(
+            {
+                "unknown": Principal(id="unknown", name="Unknown", type=PrincipalType.HUMAN),
+            }
+        )
+        req = FakeRequest(headers={"X-Principal-Id": "nobody"})
+        result = get_current_principal(req)  # type: ignore[arg-type]
+        assert result.id == "unknown"
+
+    def test_no_header_no_state_returns_anonymous(self) -> None:
+        req = FakeRequest()
+        result = get_current_principal(req)  # type: ignore[arg-type]
+        assert result.id == "unknown"
+
+
+class TestRequirePrincipal:
+    def test_no_request_raises_401(self) -> None:
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_principal(None)  # type: ignore[arg-type]
+        assert exc_info.value.status_code == 401
+
+    def test_anonymous_with_only_defaults_allowed(self) -> None:
+        """When only anonymous principals exist, anonymous is allowed."""
+        init_principals()
+        req = FakeRequest()
+        result = require_principal(req)  # type: ignore[arg-type]
+        assert result.id == "unknown"
+
+    def test_anonymous_with_real_principals_rejected(self) -> None:
+        """Fail-closed: anonymous rejected when real principals configured."""
+        from fastapi import HTTPException
+
+        init_principals(
+            {
+                "unknown": Principal(id="unknown", name="Unknown", type=PrincipalType.HUMAN),
+                "anonymous-bot": Principal(id="anonymous-bot", name="Anonymous Bot", type=PrincipalType.BOT),
+                "alice": Principal(id="alice", name="Alice", type=PrincipalType.HUMAN),
+            }
+        )
+        req = FakeRequest()
+        with pytest.raises(HTTPException) as exc_info:
+            require_principal(req)  # type: ignore[arg-type]
+        assert exc_info.value.status_code == 401
+
+
+class TestRequireRole:
+    def test_has_role_returns_principal(self) -> None:
+        init_principals(
+            {
+                "unknown": Principal(id="unknown", name="Unknown", type=PrincipalType.HUMAN),
+                "alice": Principal(id="alice", name="Alice", type=PrincipalType.HUMAN, roles=frozenset({"operator"})),
+            }
+        )
+        req = FakeRequest(headers={"X-Principal-Id": "alice"})
+        dep = require_role("operator")
+        result = dep(req)  # type: ignore[arg-type]
+        assert result.id == "alice"
+
+    def test_missing_role_raises_403(self) -> None:
+        from fastapi import HTTPException
+
+        init_principals(
+            {
+                "unknown": Principal(id="unknown", name="Unknown", type=PrincipalType.HUMAN),
+                "alice": Principal(id="alice", name="Alice", type=PrincipalType.HUMAN),
+            }
+        )
+        req = FakeRequest(headers={"X-Principal-Id": "alice"})
+        dep = require_role("operator")
+        with pytest.raises(HTTPException) as exc_info:
+            dep(req)  # type: ignore[arg-type]
+        assert exc_info.value.status_code == 403
+
+
+class TestRequirePermission:
+    def test_has_permission_returns_principal(self) -> None:
+        init_principals(
+            {
+                "unknown": Principal(id="unknown", name="Unknown", type=PrincipalType.HUMAN),
+                "alice": Principal(
+                    id="alice", name="Alice", type=PrincipalType.HUMAN, permissions=frozenset({"fleet:write"})
+                ),
+            }
+        )
+        req = FakeRequest(headers={"X-Principal-Id": "alice"})
+        dep = require_permission("fleet:write")
+        result = dep(req)  # type: ignore[arg-type]
+        assert result.id == "alice"
+
+    def test_missing_permission_raises_403(self) -> None:
+        from fastapi import HTTPException
+
+        init_principals(
+            {
+                "unknown": Principal(id="unknown", name="Unknown", type=PrincipalType.HUMAN),
+                "alice": Principal(id="alice", name="Alice", type=PrincipalType.HUMAN),
+            }
+        )
+        req = FakeRequest(headers={"X-Principal-Id": "alice"})
+        dep = require_permission("fleet:write")
+        with pytest.raises(HTTPException) as exc_info:
+            dep(req)  # type: ignore[arg-type]
+        assert exc_info.value.status_code == 403
+
+
+# ─── PrincipalRef Pydantic model ────────────────────────────────────────────────
+
+
+class TestPrincipalRef:
+    def test_to_principal_full(self) -> None:
+        ref = PrincipalRef(id="alice", name="Alice", type="human")
+        p = ref.to_principal()
+        assert p.id == "alice"
+        assert p.name == "Alice"
+        assert p.type == PrincipalType.HUMAN
+
+    def test_to_principal_defaults_name_to_id(self) -> None:
+        ref = PrincipalRef(id="alice")
+        p = ref.to_principal()
+        assert p.name == "alice"
+
+    def test_to_principal_invalid_type_fallbacks_to_human(self) -> None:
+        ref = PrincipalRef(id="alice", type="alien")
+        p = ref.to_principal()
+        assert p.type == PrincipalType.HUMAN
+
+
+# ─── get_principal_registry ─────────────────────────────────────────────────────
+
+
+class TestGetPrincipalRegistry:
+    def test_auto_initialises(self) -> None:
+        principal_mod._PRINCIPALS = None
+        registry = get_principal_registry()
+        assert "unknown" in registry


### PR DESCRIPTION
## Summary

Closes #131 (child of Epic #63).

Implements the foundation for Identity and Authorization in the runner dashboard.

## Changes

- **Principal model** ():
  -  dataclass with uid=1000(dieterolson) gid=1000(dieterolson) groups=1000(dieterolson),4(adm),20(dialout),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev),117(netdev),999(ollama),1001(docker), , , , , 
  -  enum: , , 
  -  YAML loader for 
  -  FastAPI dependency with fail-closed behavior
  -  and  dependency factories
  -  attaches principal to 

- **Config schema** ():
  - Documented YAML schema with anonymous fallbacks and example principals
  - Built-in permission vocabulary for fleet, agents, workflows, config, credentials, system

- **Removed hardcoded strings**:
  - Replaced all  /  defaults with  fallback

- **Python 3.10 compatibility**:
  - Fixed  →  in  and 

- **Tests** (, 32 tests):
  - Principal dataclass equality, role/permission checks, immutability
  - YAML loader: missing file, empty config, valid principals, duplicates, invalid types
  - FastAPI dependencies: , , 
  -  Pydantic model conversion

- **Test isolation fix**:
  -  now sets  before importing 

## Verification

All 248 tests pass:
```
248 passed, 3 skipped, 1 xfailed
```

## Standards Impact

security · DbC · TDD · least privilege · operator clarity