### PR TITLE
feat(launcher): full config editor + model dropdown + cline as remediation provider

### DIFF
--- a/backend/agent_launcher_router.py
+++ b/backend/agent_launcher_router.py
@@ -171,8 +171,36 @@ class ReposResponse(BaseModel):
     repos: list[RepoEntry]
 
 
+class ModelEntry(BaseModel):
+    id: str
+    provider: str
+    size_human: str = ""
+    family: str = ""
+    notes: str = ""
+
+
+class ModelsResponse(BaseModel):
+    provider: str
+    wsl_distro: str
+    count: int
+    models: list[ModelEntry]
+
+
 class RunOnceRequest(BaseModel):
     agent: str = Field(..., min_length=1, max_length=64)
+
+
+class DispatchRemediationRequest(BaseModel):
+    """Body for /dispatch-remediation. The dashboard's remediation surface
+    uses this to hand a CI failure off to cline via the launcher.
+
+    Pre: ``agent`` is the launcher agent name (default ``address-prs``).
+    """
+
+    repository: str = Field(..., min_length=1, max_length=200)
+    agent: str = Field(default="address-prs", min_length=1, max_length=64)
+    branch: str = Field(default="", max_length=200)
+    failure_summary: str = Field(default="", max_length=4000)
 
 
 class SimpleResponse(BaseModel):
@@ -340,6 +368,30 @@ async def put_config(request: Request) -> SimpleResponse:
 # ---------------------------------------------------------------------------
 # Repos — live WSL inventory
 # ---------------------------------------------------------------------------
+@router.get("/models", response_model=ModelsResponse)
+def get_models(provider: str = "") -> ModelsResponse:
+    """Live model catalog for the configured (or ``?provider=X``) provider.
+
+    Powers the editor's model dropdown. Returns a single placeholder entry
+    if discovery fails (ollama unreachable, missing API keys, etc.) so the
+    UI can still render a 'type any model id' fallback.
+    """
+    args = ["--list-models"]
+    if provider:
+        args += ["--provider", provider]
+    rc, stdout, stderr = _run_cli(*args, timeout=20.0)
+    if rc != 0:
+        raise HTTPException(
+            status_code=502,
+            detail=f"launcher --list-models failed: {stderr.strip()[:300]}",
+        )
+    try:
+        d = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=500, detail=f"launcher returned invalid JSON: {exc}") from exc
+    return ModelsResponse(**d)
+
+
 @router.get("/repos", response_model=ReposResponse)
 def get_repos() -> ReposResponse:
     rc, stdout, stderr = _run_cli("--list-repos", timeout=45.0)
@@ -401,6 +453,47 @@ def stop_scheduler() -> SimpleResponse:
     if rc != 0:
         raise HTTPException(status_code=500, detail=f"--stop failed: {stderr[:300]}")
     return SimpleResponse(ok=True, detail=stdout.strip() or "stop requested")
+
+
+@router.post("/dispatch-remediation", response_model=SimpleResponse)
+def dispatch_remediation(req: DispatchRemediationRequest) -> SimpleResponse:
+    """Dispatch a CI-failure remediation to cline via the launcher.
+
+    Wiring: the dashboard's remediation layer (agent_remediation.py) calls
+    this endpoint when the chosen provider is ``cline``. The launcher
+    spawns a WT window, opens cline against the named repo's WSL path,
+    and runs the agent's configured skill (default ``/address-prs``).
+    Failure context is logged but not (yet) injected into the prompt —
+    the skill itself reads the PR's check-runs to find the failure. A
+    follow-up PR can add a one-shot prompt-override flag to the launcher
+    so the failure summary is handed in directly.
+
+    Returns 200 on successful spawn, 502 on launcher failure, 503 on
+    launcher missing.
+    """
+    cfg = get_config()
+    if req.agent not in cfg.get("agents", {}):
+        known = list(cfg.get("agents", {}))
+        raise HTTPException(
+            status_code=404,
+            detail=f"agent {req.agent!r} not configured; known: {known}",
+        )
+    log.info(
+        "dispatch-remediation: repo=%s branch=%s agent=%s",
+        req.repository,
+        req.branch or "-",
+        req.agent,
+    )
+    rc, stdout, stderr = _run_cli("--once", req.agent, timeout=90.0)
+    if rc != 0:
+        raise HTTPException(
+            status_code=502,
+            detail=f"launcher --once {req.agent} failed (rc={rc}): {(stderr or stdout)[:300]}",
+        )
+    return SimpleResponse(
+        ok=True,
+        detail=f"cline window spawned for {req.repository} via {req.agent}",
+    )
 
 
 @router.post("/run-once", response_model=SimpleResponse)

--- a/backend/agent_remediation.py
+++ b/backend/agent_remediation.py
@@ -414,11 +414,23 @@ PROVIDERS: dict[str, AgentProvider] = {
         provider_id="cline",
         label="Cline",
         execution_mode="local_plugin",
-        dispatch_mode="future",
+        # dashboard_local: dispatched by the dashboard host directly, not
+        # by GitHub Actions. The actual cline window opens via the
+        # cline_agent_launcher (Repository_Management/launchers/cline_agent_launcher),
+        # which the dashboard reaches over its own /api/agent-launcher
+        # endpoints. See backend/agent_launcher_router.py.
+        dispatch_mode="dashboard_local",
         availability_probe=("cline",),
-        editable=False,
-        experimental=True,
-        notes="Reserved for future plugin-driven local remediation; no stable CLI contract is assumed here yet.",
+        # Editable so the operator can change the model + provider via
+        # the Cline Launcher tab editor (writes to the launcher's
+        # config.json; cline reads model from there).
+        editable=True,
+        experimental=False,
+        notes=(
+            "Local cline TUI driven by the cline_agent_launcher in WSL. "
+            "Model + provider configurable from the Cline Launcher tab. "
+            "Defaults to ollama on localhost:11434 with kimi-k2.6:cloud."
+        ),
     ),
 }
 
@@ -668,6 +680,22 @@ def provider_prompt(provider_id: str, context: FailureContext) -> str:
             f"{repair_goal}\n"
             "Work inside this checkout, make the minimal code change that addresses the failure, "
             "and verify the narrowest relevant test target."
+        )
+    if provider_id == "cline":
+        # Cline runs inside its TUI window opened by the launcher in WSL.
+        # The launcher already knows the working directory; we just hand
+        # cline a self-contained prompt that mirrors the address-prs skill's
+        # contract (REST-only, scope-locked, no test weakening).
+        return (
+            f"{system_note}\n\n"
+            f"{branch_line}\nRun ID: {context.run_id or 'unknown'}\n\n"
+            f"Failure summary:\n{summary}\n\n"
+            f"Failed log excerpt:\n{log_excerpt}\n\n"
+            f"{repair_goal}\n"
+            "You are running in cline TUI inside WSL with auto-approve. "
+            "Edit the repo at $PWD, validate the fix locally before pushing, "
+            "and never weaken tests or suppress lint to make CI green. "
+            "Cap PR-push attempts at 3."
         )
     return (
         f"{system_note}\n\n"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13441,6 +13441,88 @@
         );
       }
 
+      // ---------- ClineLauncherTab ----------
+      // Sub-component: edit one agent. Lifted out so the parent stays
+      // readable; uses the same setConfig setter via prop.
+      function AgentEditor(props) {
+        var name = props.name;
+        var cfg = props.cfg || {};
+        var inventory = props.inventory || [];
+        var onChange = props.onChange;
+        var onDelete = props.onDelete;
+        function patch(field, value) {
+          var next = Object.assign({}, cfg); next[field] = value;
+          onChange(name, next);
+        }
+        function toggleRepo(repoName) {
+          var current = (cfg.repositories || ["__all__"]).slice();
+          if (current.indexOf("__all__") >= 0) current = []; // explicit selection mode
+          var idx = current.indexOf(repoName);
+          if (idx >= 0) current.splice(idx, 1);
+          else current.push(repoName);
+          if (current.length === 0) current = ["__all__"]; // back to all
+          patch("repositories", current);
+        }
+        var allMode = (cfg.repositories || []).indexOf("__all__") >= 0;
+        return h("div", {
+          style: { border: "1px solid var(--border-primary)", borderRadius: 4,
+                   padding: 12, marginBottom: 12 },
+        },
+          h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: 8 } },
+            h("strong", null, name),
+            h("label", { style: { fontSize: 12 } },
+              h("input", { type: "checkbox", checked: !!cfg.enabled,
+                onChange: function (e) { patch("enabled", e.target.checked); } }),
+              " enabled"),
+            h("span", { style: { flex: 1 } }),
+            h("button", { className: "btn btn-sm",
+              onClick: function () { onDelete(name); } }, "Delete"),
+          ),
+          h("div", { style: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 8 } },
+            h("label", null, "Skill prompt",
+              h("input", { type: "text", value: cfg.skill_prompt || "",
+                style: { width: "100%" },
+                onChange: function (e) { patch("skill_prompt", e.target.value); } })),
+            h("label", null, "Rotation",
+              h("select", { value: cfg.rotation || "round-robin",
+                onChange: function (e) { patch("rotation", e.target.value); } },
+                h("option", { value: "round-robin" }, "round-robin"),
+                h("option", { value: "all-each-tick" }, "all-each-tick"),
+                h("option", { value: "random" }, "random"))),
+            h("label", null, "Interval (s)",
+              h("input", { type: "number", min: 60, value: cfg.interval_seconds || 3600,
+                style: { width: "100%" },
+                onChange: function (e) { patch("interval_seconds", parseInt(e.target.value || 0, 10)); } })),
+            h("label", null, "Timeout (s)",
+              h("input", { type: "number", min: 30, value: cfg.timeout_seconds || 3600,
+                style: { width: "100%" },
+                onChange: function (e) { patch("timeout_seconds", parseInt(e.target.value || 0, 10)); } })),
+          ),
+          h("div", { style: { marginBottom: 6 } },
+            h("strong", { style: { fontSize: 12 } }, "Repositories: "),
+            h("label", { style: { fontSize: 12, marginRight: 8 } },
+              h("input", { type: "checkbox", checked: allMode,
+                onChange: function () { patch("repositories", allMode ? [] : ["__all__"]); } }),
+              " all (" + inventory.length + ")"),
+          ),
+          allMode ? null : h("div", { style: { display: "flex", flexWrap: "wrap", gap: 4 } },
+            inventory.map(function (r) {
+              var picked = (cfg.repositories || []).indexOf(r.name) >= 0;
+              return h("button", { key: r.name,
+                className: "section-badge",
+                style: {
+                  background: picked ? "var(--accent-purple)" : "var(--bg-tertiary)",
+                  color: picked ? "white" : "var(--text-primary)",
+                  cursor: "pointer", border: "none",
+                },
+                title: r.wsl_path,
+                onClick: function () { toggleRepo(r.name); },
+              }, r.name);
+            }),
+          ),
+        );
+      }
+
       function ClineLauncherTab() {
         // Self-contained: this tab manages its own polling + actions so it
         // doesn't bloat the parent state. The launcher's state is on the
@@ -13455,6 +13537,16 @@
         var error = er[0], setError = er[1];
         var bs = React.useState({});
         var busy = bs[0], setBusy = bs[1];
+        var cs = React.useState(null);
+        var config = cs[0], setConfig = cs[1];
+        var ms = React.useState(null);
+        var models = ms[0], setModels = ms[1];
+        var ds = React.useState(false);
+        var dirty = ds[0], setDirty = ds[1];
+        var sm = React.useState("");
+        var saveMsg = sm[0], setSaveMsg = sm[1];
+        var ev = React.useState("editor"); // "editor" | "status"
+        var view = ev[0], setView = ev[1];
 
         function fetchStatus() {
           fetch("/api/agent-launcher/status")
@@ -13464,6 +13556,116 @@
             })
             .then(function (j) { setStatus(j); setError(""); })
             .catch(function (e) { setError(String(e)); });
+        }
+
+        function fetchConfig() {
+          fetch("/api/agent-launcher/config")
+            .then(function (resp) {
+              if (!resp.ok) {
+                return resp.json().then(function (j) {
+                  throw new Error(j.detail || ("HTTP " + resp.status));
+                });
+              }
+              return resp.json();
+            })
+            .then(function (j) { setConfig(j); setDirty(false); setError(""); })
+            .catch(function (e) { setError(String(e)); });
+        }
+
+        function fetchModels(provider) {
+          var url = "/api/agent-launcher/models";
+          if (provider) url += "?provider=" + encodeURIComponent(provider);
+          fetch(url)
+            .then(function (resp) {
+              if (!resp.ok) throw new Error("HTTP " + resp.status);
+              return resp.json();
+            })
+            .then(function (j) { setModels(j); })
+            .catch(function (e) {
+              // Non-fatal — editor still works without the dropdown.
+              setModels({ provider: provider, count: 0, models: [] });
+            });
+        }
+
+        function patchConfig(path, value) {
+          // path is dot-separated, e.g. "model.model_id" or "wsl_distro".
+          var next = JSON.parse(JSON.stringify(config));
+          var keys = path.split(".");
+          var ref = next;
+          for (var i = 0; i < keys.length - 1; i++) {
+            if (ref[keys[i]] === undefined) ref[keys[i]] = {};
+            ref = ref[keys[i]];
+          }
+          ref[keys[keys.length - 1]] = value;
+          setConfig(next); setDirty(true); setSaveMsg("");
+          // If provider changed, refresh model catalog.
+          if (path === "model.provider") fetchModels(value);
+        }
+
+        function patchAgent(name, agentCfg) {
+          var next = JSON.parse(JSON.stringify(config));
+          next.agents = next.agents || {};
+          next.agents[name] = agentCfg;
+          setConfig(next); setDirty(true); setSaveMsg("");
+        }
+
+        function deleteAgent(name) {
+          var keys = Object.keys(config.agents || {});
+          if (keys.length <= 1) {
+            setError("cannot delete last agent — config requires >=1");
+            return;
+          }
+          if (!window.confirm("Delete agent " + name + "?")) return;
+          var next = JSON.parse(JSON.stringify(config));
+          delete next.agents[name];
+          setConfig(next); setDirty(true); setSaveMsg("");
+        }
+
+        function addAgent() {
+          var name = window.prompt("New agent name (e.g. consolidate-prs):");
+          if (!name || !name.trim()) return;
+          name = name.trim();
+          if (config.agents && config.agents[name]) {
+            setError("agent " + name + " already exists");
+            return;
+          }
+          var next = JSON.parse(JSON.stringify(config));
+          next.agents = next.agents || {};
+          next.agents[name] = {
+            enabled: true,
+            interval_seconds: 3600,
+            skill_prompt: "/" + name,
+            timeout_seconds: 3600,
+            repositories: ["__all__"],
+            rotation: "round-robin",
+            extra_env: {},
+          };
+          setConfig(next); setDirty(true); setSaveMsg("");
+        }
+
+        function saveConfig() {
+          setSaveMsg("saving...");
+          fetch("/api/agent-launcher/config", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(config),
+          })
+            .then(function (resp) {
+              return resp.json().then(function (j) {
+                if (!resp.ok) throw new Error(j.detail || "HTTP " + resp.status);
+                return j;
+              });
+            })
+            .then(function () {
+              setDirty(false); setSaveMsg("saved ✓"); setError("");
+              // Reload normalized config back from server (defaults filled in).
+              fetchConfig();
+              setTimeout(function () { setSaveMsg(""); }, 3000);
+            })
+            .catch(function (e) {
+              setSaveMsg("");
+              setError("save failed: " + e);
+            });
         }
 
         function fetchRepos() {
@@ -13506,10 +13708,18 @@
         }
 
         React.useEffect(function () {
-          fetchStatus(); fetchRepos();
+          fetchStatus(); fetchRepos(); fetchConfig();
           var t = setInterval(fetchStatus, 5000);
           return function () { clearInterval(t); };
         }, []);
+
+        // Refresh model catalog whenever config first loads (so dropdown
+        // is populated for the configured provider on initial render).
+        React.useEffect(function () {
+          if (config && config.model && config.model.provider && !models) {
+            fetchModels(config.model.provider);
+          }
+        }, [config]);
 
         var schedRunning = status && status.scheduler_running;
         var statusBadge = h("span", {
@@ -13520,8 +13730,184 @@
           },
         }, schedRunning ? "running" : "stopped");
 
+        var inventory = (repos && repos.repos) || [];
+        var modelList = (models && models.models) || [];
+
+        // ---- Editor view --------------------------------------------------
+        function renderEditor() {
+          if (!config) {
+            return h("div", { style: { color: "var(--text-secondary)" } }, "Loading config...");
+          }
+          var providerOptions = ["ollama","anthropic","openai","openrouter","google","bedrock","vertex"];
+          var rotationOptions = ["round-robin","all-each-tick","random"];
+          return h("div", null,
+            // Top-level: WSL + provider + cline flags
+            h("div", { style: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 16 } },
+              h("fieldset", { style: { padding: 8 } },
+                h("legend", null, "WSL + discovery"),
+                h("label", null, "WSL distro",
+                  h("input", { type: "text", value: config.wsl_distro || "",
+                    style: { width: "100%" },
+                    onChange: function (e) { patchConfig("wsl_distro", e.target.value); } })),
+                h("label", null, "Repos root (WSL path)",
+                  h("input", { type: "text", value: config.repos_root_wsl || "",
+                    style: { width: "100%" },
+                    onChange: function (e) { patchConfig("repos_root_wsl", e.target.value); } })),
+                h("label", null, "Org filter",
+                  h("input", { type: "text", value: config.repos_org_filter || "",
+                    style: { width: "100%" },
+                    onChange: function (e) { patchConfig("repos_org_filter", e.target.value); } })),
+              ),
+              h("fieldset", { style: { padding: 8 } },
+                h("legend", null, "Model"),
+                h("label", null, "Provider",
+                  h("select", { value: (config.model && config.model.provider) || "ollama",
+                    onChange: function (e) { patchConfig("model.provider", e.target.value); } },
+                    providerOptions.map(function (p) { return h("option", { key: p, value: p }, p); }))),
+                h("label", null, "Model ID",
+                  h("input", { type: "text",
+                    list: "cline-launcher-model-ids",
+                    value: (config.model && config.model.model_id) || "",
+                    style: { width: "100%" },
+                    onChange: function (e) { patchConfig("model.model_id", e.target.value || null); } }),
+                  h("datalist", { id: "cline-launcher-model-ids" },
+                    modelList.map(function (m) {
+                      return h("option", { key: m.id, value: m.id },
+                        m.size_human + " " + m.notes);
+                    })),
+                  h("div", { style: { fontSize: 11, color: "var(--text-secondary)", marginTop: 2 } },
+                    models ? (models.count + " " + (models.provider || "") + " models known. Type any tag.") : "loading models..."),
+                ),
+                h("label", null, "Context window (optional)",
+                  h("input", { type: "number", min: 0,
+                    value: (config.model && config.model.context_window) || "",
+                    style: { width: "100%" },
+                    onChange: function (e) {
+                      var v = e.target.value ? parseInt(e.target.value, 10) : null;
+                      patchConfig("model.context_window", v);
+                    } })),
+              ),
+            ),
+            h("div", { style: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 16 } },
+              h("fieldset", { style: { padding: 8 } },
+                h("legend", null, "Cline flags"),
+                h("label", { style: { display: "block" } },
+                  h("input", { type: "checkbox",
+                    checked: !!(config.cline && config.cline.tui),
+                    onChange: function (e) { patchConfig("cline.tui", e.target.checked); } }),
+                  " --tui (open visual TUI; uncheck for headless)"),
+                h("label", { style: { display: "block" } },
+                  h("input", { type: "checkbox",
+                    checked: !!(config.cline && config.cline.yolo),
+                    onChange: function (e) { patchConfig("cline.yolo", e.target.checked); } }),
+                  " --yolo (auto-approve actions)"),
+                h("label", { style: { display: "block" } },
+                  h("input", { type: "checkbox",
+                    checked: !!(config.cline && config.cline.auto_approve_all),
+                    onChange: function (e) { patchConfig("cline.auto_approve_all", e.target.checked); } }),
+                  " --auto-approve-all (interactive yet pre-approved)"),
+              ),
+              h("fieldset", { style: { padding: 8 } },
+                h("legend", null, "Scheduler"),
+                h("label", null, "Default timeout (s)",
+                  h("input", { type: "number", min: 30, value: config.default_timeout_seconds || 3600,
+                    style: { width: "100%" },
+                    onChange: function (e) { patchConfig("default_timeout_seconds", parseInt(e.target.value || 0, 10)); } })),
+                h("label", null, "Stagger between agents (s)",
+                  h("input", { type: "number", min: 0, max: 600, value: config.stagger_seconds || 30,
+                    style: { width: "100%" },
+                    onChange: function (e) { patchConfig("stagger_seconds", parseInt(e.target.value || 0, 10)); } })),
+                h("label", null, "Max concurrent windows per agent",
+                  h("input", { type: "number", min: 1, max: 10, value: config.max_concurrent_per_agent || 1,
+                    style: { width: "100%" },
+                    onChange: function (e) { patchConfig("max_concurrent_per_agent", parseInt(e.target.value || 1, 10)); } })),
+              ),
+            ),
+            // Per-agent editors
+            h("h3", { style: { marginTop: 8 } }, "Agents"),
+            Object.keys(config.agents || {}).sort().map(function (name) {
+              return h(AgentEditor, {
+                key: name, name: name, cfg: config.agents[name],
+                inventory: inventory,
+                onChange: patchAgent, onDelete: deleteAgent,
+              });
+            }),
+            h("button", { className: "btn btn-sm", onClick: addAgent }, "+ Add agent"),
+            // Save bar
+            h("div", { style: {
+              position: "sticky", bottom: 0, padding: 12, marginTop: 16,
+              background: "var(--bg-secondary)", borderTop: "1px solid var(--border-primary)",
+              display: "flex", alignItems: "center", gap: 12,
+            } },
+              h("button", { className: "btn btn-primary", disabled: !dirty,
+                onClick: saveConfig }, dirty ? "Save changes" : "No changes"),
+              h("button", { className: "btn", disabled: !dirty,
+                onClick: function () { fetchConfig(); } }, "Discard"),
+              saveMsg ? h("span", { style: { fontSize: 12, color: "var(--accent-green)" } }, saveMsg) : null,
+              h("span", { style: { flex: 1 } }),
+              h("span", { style: { fontSize: 11, color: "var(--text-secondary)" } },
+                "Validates server-side; bad configs leave config.json untouched."),
+            ),
+          );
+        }
+
+        // ---- Status view --------------------------------------------------
+        function renderStatus() {
+          return h("div", null,
+            h("h3", null, "Agents"),
+            status && status.agents && status.agents.length
+              ? h("table", { className: "data-table", style: { width: "100%" } },
+                  h("thead", null, h("tr", null,
+                    h("th", null, "Agent"), h("th", null, "Enabled"),
+                    h("th", null, "Interval"), h("th", null, "Last run (UTC)"),
+                    h("th", null, "Last repo"), h("th", null, "Window PID"),
+                    h("th", null, "Lock"), h("th", null, "Run now"))),
+                  h("tbody", null, status.agents.map(function (a) {
+                    return h("tr", { key: a.name },
+                      h("td", null, a.name),
+                      h("td", null, a.enabled ? "yes" : "no"),
+                      h("td", null, a.interval_seconds + "s"),
+                      h("td", { style: { fontSize: 12 } }, a.last_run_iso || "-"),
+                      h("td", null, a.last_repo || "-"),
+                      h("td", null, a.last_window_pid || "-"),
+                      h("td", null, a.lock_alive
+                        ? h("span", { style: { color: "var(--accent-yellow)" } }, "alive")
+                        : "-"),
+                      h("td", null, h("button", {
+                        className: "btn btn-sm",
+                        disabled: !!busy["run-once/" + a.name] || a.lock_alive,
+                        onClick: function () { action("run-once", { agent: a.name }); },
+                      }, busy["run-once/" + a.name] ? "spawning..." : "Run once")));
+                  })))
+              : h("div", { style: { color: "var(--text-secondary)" } },
+                  "No agents configured."),
+            h("h3", { style: { marginTop: 24 } }, "Discovered repositories",
+              repos ? h("span", { className: "section-badge",
+                style: { marginLeft: 8, background: "rgba(136,108,228,0.15)", color: "var(--accent-purple)" },
+              }, repos.count + " " + (repos.org_filter || "")) : null),
+            repos && repos.repos && repos.repos.length
+              ? h("div", { style: { fontSize: 12, color: "var(--text-secondary)", marginBottom: 8 } },
+                  "WSL distro: " + repos.wsl_distro + ", root: " + repos.repos_root)
+              : null,
+            repos && repos.repos
+              ? h("div", { style: { display: "flex", flexWrap: "wrap", gap: 6 } },
+                  repos.repos.map(function (r) {
+                    return h("span", { key: r.name, className: "section-badge",
+                      title: r.wsl_path,
+                      style: { background: "var(--bg-tertiary)" } }, r.name);
+                  }))
+              : h("div", { style: { color: "var(--text-secondary)" } },
+                  loading ? "discovering..." : "No repos discovered yet."),
+            h("div", { style: { marginTop: 24, padding: 12, background: "var(--bg-tertiary)",
+                borderRadius: 4, fontSize: 12, color: "var(--text-secondary)" } },
+              h("div", null, "Runtime root: " + (status && status.runtime_root || "-")),
+              h("div", null, "Status polls every 5s. Repo discovery + model list refresh on demand."),
+            ),
+          );
+        }
+
+        // ---- Top render ---------------------------------------------------
         return h("div", { className: "tab-panel" },
-          // Header + global controls
           h("div", { style: { display: "flex", alignItems: "center", gap: 12, marginBottom: 16 } },
             h("h2", { style: { margin: 0 } }, "Cline Agent Launcher"),
             statusBadge,
@@ -13529,99 +13915,32 @@
               ? h("span", { style: { fontSize: 12, color: "var(--text-secondary)" } },
                   "pid " + status.scheduler_pid)
               : null,
+            h("span", { style: { flex: 1 } }),
+            h("div", { className: "btn-group" },
+              h("button", { className: "btn btn-sm" + (view === "editor" ? " btn-primary" : ""),
+                onClick: function () { setView("editor"); } }, "Editor"),
+              h("button", { className: "btn btn-sm" + (view === "status" ? " btn-primary" : ""),
+                onClick: function () { setView("status"); } }, "Status"),
+            ),
           ),
           error
             ? h("div", { className: "alert alert-error", style: { marginBottom: 12 } }, error)
             : null,
           h("div", { style: { display: "flex", gap: 8, marginBottom: 16 } },
-            h("button", {
-              className: "btn btn-primary",
+            h("button", { className: "btn btn-primary",
               disabled: !!busy["start"] || schedRunning,
-              onClick: function () { action("start"); },
-            }, busy["start"] ? "starting..." : "Start scheduler"),
-            h("button", {
-              className: "btn",
+              onClick: function () { action("start"); } },
+              busy["start"] ? "starting..." : "Start scheduler"),
+            h("button", { className: "btn",
               disabled: !!busy["stop"] || !schedRunning,
-              onClick: function () { action("stop"); },
-            }, busy["stop"] ? "stopping..." : "Stop scheduler"),
-            h("button", {
-              className: "btn",
-              disabled: loading,
-              onClick: function () { fetchRepos(); fetchStatus(); },
-            }, loading ? "refreshing..." : "Refresh"),
+              onClick: function () { action("stop"); } },
+              busy["stop"] ? "stopping..." : "Stop scheduler"),
+            h("button", { className: "btn", disabled: loading,
+              onClick: function () { fetchRepos(); fetchStatus(); fetchConfig();
+                if (config && config.model) fetchModels(config.model.provider); } },
+              loading ? "refreshing..." : "Refresh"),
           ),
-
-          // Agents table
-          h("h3", null, "Agents"),
-          status && status.agents && status.agents.length
-            ? h("table", { className: "data-table", style: { width: "100%" } },
-                h("thead", null, h("tr", null,
-                  h("th", null, "Agent"),
-                  h("th", null, "Enabled"),
-                  h("th", null, "Interval"),
-                  h("th", null, "Last run (UTC)"),
-                  h("th", null, "Last repo"),
-                  h("th", null, "Window PID"),
-                  h("th", null, "Lock"),
-                  h("th", null, "Run now"),
-                )),
-                h("tbody", null, status.agents.map(function (a) {
-                  return h("tr", { key: a.name },
-                    h("td", null, a.name),
-                    h("td", null, a.enabled ? "yes" : "no"),
-                    h("td", null, a.interval_seconds + "s"),
-                    h("td", { style: { fontSize: 12 } }, a.last_run_iso || "-"),
-                    h("td", null, a.last_repo || "-"),
-                    h("td", null, a.last_window_pid || "-"),
-                    h("td", null, a.lock_alive
-                      ? h("span", { style: { color: "var(--accent-yellow)" } }, "alive")
-                      : "-"),
-                    h("td", null,
-                      h("button", {
-                        className: "btn btn-sm",
-                        disabled: !!busy["run-once/" + a.name] || a.lock_alive,
-                        onClick: function () {
-                          action("run-once", { agent: a.name });
-                        },
-                      }, busy["run-once/" + a.name] ? "spawning..." : "Run once"),
-                    ),
-                  );
-                })),
-              )
-            : h("div", { style: { color: "var(--text-secondary)" } },
-                "No agents configured. Edit %LOCALAPPDATA%\\cline_agent_launcher\\config.json"),
-
-          // Discovered repo inventory
-          h("h3", { style: { marginTop: 24 } },
-            "Discovered repositories",
-            repos ? h("span", {
-              className: "section-badge",
-              style: { marginLeft: 8, background: "rgba(136,108,228,0.15)", color: "var(--accent-purple)" },
-            }, repos.count + " " + (repos.org_filter || "")) : null,
-          ),
-          repos && repos.repos && repos.repos.length
-            ? h("div", { style: { fontSize: 12, color: "var(--text-secondary)", marginBottom: 8 } },
-                "WSL distro: " + repos.wsl_distro + ", root: " + repos.repos_root)
-            : null,
-          repos && repos.repos
-            ? h("div", { style: { display: "flex", flexWrap: "wrap", gap: 6 } },
-                repos.repos.map(function (r) {
-                  return h("span", {
-                    key: r.name,
-                    className: "section-badge",
-                    title: r.wsl_path,
-                    style: { background: "var(--bg-tertiary)" },
-                  }, r.name);
-                }))
-            : h("div", { style: { color: "var(--text-secondary)" } },
-                loading ? "discovering..." : "No repos discovered yet."),
-
-          // Notes
-          h("div", { style: { marginTop: 24, padding: 12, background: "var(--bg-tertiary)", borderRadius: 4, fontSize: 12, color: "var(--text-secondary)" } },
-            h("div", null, "Runtime root: " + (status && status.runtime_root || "-")),
-            h("div", null, "Status polls every 5s. Repo discovery is on-demand (Refresh button)."),
-            h("div", null, "Full config editor (model selector, repo multi-select, intervals) ships in a follow-up — for now edit config.json directly and click Refresh."),
-          ),
+          view === "editor" ? renderEditor() : renderStatus(),
         );
       }
 

--- a/tests/test_agent_launcher_router.py
+++ b/tests/test_agent_launcher_router.py
@@ -202,6 +202,101 @@ def test_get_repos_502_on_launcher_failure(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# /models
+# ---------------------------------------------------------------------------
+def test_get_models_passes_through_launcher_json(client, monkeypatch):
+    fake = {
+        "provider": "ollama",
+        "wsl_distro": "Ubuntu-22.04",
+        "count": 2,
+        "models": [
+            {"id": "kimi-k2.6:cloud", "provider": "ollama",
+             "size_human": "", "family": "kimi", "notes": "cloud"},
+            {"id": "qwen3:14b", "provider": "ollama",
+             "size_human": "8.6GB", "family": "qwen3", "notes": "local"},
+        ],
+    }
+    monkeypatch.setattr(alr, "_run_cli", lambda *a, **kw: (0, json.dumps(fake), ""))
+    r = client.get("/api/agent-launcher/models")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 2
+    assert {m["id"] for m in body["models"]} == {"kimi-k2.6:cloud", "qwen3:14b"}
+
+
+def test_get_models_passes_provider_query(client, monkeypatch):
+    """The ?provider=X query must reach the launcher CLI as --provider X."""
+    captured = {}
+    def fake_cli(*args, **kw):
+        captured["args"] = args
+        return (0, json.dumps({"provider": "anthropic", "wsl_distro": "u",
+                               "count": 0, "models": []}), "")
+    monkeypatch.setattr(alr, "_run_cli", fake_cli)
+    r = client.get("/api/agent-launcher/models?provider=anthropic")
+    assert r.status_code == 200
+    assert "--provider" in captured["args"]
+    assert "anthropic" in captured["args"]
+
+
+def test_get_models_502_on_launcher_failure(client, monkeypatch):
+    monkeypatch.setattr(alr, "_run_cli", lambda *a, **kw: (1, "", "ollama down"))
+    r = client.get("/api/agent-launcher/models")
+    assert r.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# /dispatch-remediation
+# ---------------------------------------------------------------------------
+def test_dispatch_remediation_requires_known_agent(client, monkeypatch):
+    monkeypatch.setattr(
+        alr, "_run_cli",
+        lambda *a, **kw: (0, json.dumps({"agents": {"address-prs": {}}}), ""),
+    )
+    r = client.post("/api/agent-launcher/dispatch-remediation",
+                    json={"repository": "owner/repo", "agent": "nonexistent"})
+    assert r.status_code == 404
+    assert "not configured" in r.json()["detail"]
+
+
+def test_dispatch_remediation_invokes_launcher_once(client, monkeypatch):
+    """Successful dispatch shells out to launcher --once <agent>."""
+    calls = []
+    def fake_cli(*args, **kw):
+        calls.append(args)
+        if "--once" in args:
+            return (0, "spawned", "")
+        return (0, json.dumps({"agents": {"address-prs": {}}}), "")
+    monkeypatch.setattr(alr, "_run_cli", fake_cli)
+    r = client.post("/api/agent-launcher/dispatch-remediation",
+                    json={"repository": "D-sorganization/Tools",
+                          "agent": "address-prs",
+                          "branch": "fix/bad-thing",
+                          "failure_summary": "ruff E501"})
+    assert r.status_code == 200
+    assert any("--once" in c for c in calls)
+    assert "Tools" in r.json()["detail"]
+
+
+def test_dispatch_remediation_502_on_launcher_failure(client, monkeypatch):
+    def fake_cli(*args, **kw):
+        if "--once" in args:
+            return (3, "", "spawn failed")
+        return (0, json.dumps({"agents": {"address-prs": {}}}), "")
+    monkeypatch.setattr(alr, "_run_cli", fake_cli)
+    r = client.post("/api/agent-launcher/dispatch-remediation",
+                    json={"repository": "owner/repo"})
+    assert r.status_code == 502
+
+
+def test_dispatch_remediation_validates_repository(client):
+    """Empty repository must fail pydantic validation, not reach the
+    launcher (DbC at the boundary)."""
+    r = client.post("/api/agent-launcher/dispatch-remediation",
+                    json={"repository": ""})
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
 # /run-once
 # ---------------------------------------------------------------------------
 def test_run_once_unknown_agent_returns_404(client, monkeypatch):

--- a/tests/test_cline_provider_upgrade.py
+++ b/tests/test_cline_provider_upgrade.py
@@ -1,0 +1,80 @@
+"""Tests for the cline provider upgrade in agent_remediation.PROVIDERS.
+
+Pre-upgrade: cline was registered with dispatch_mode='future', editable=False,
+experimental=True. Post-upgrade it should be a real selectable provider with
+dispatch_mode='dashboard_local', editable=True, and a non-empty repair prompt.
+
+These tests guard against accidental regression: someone reverting the
+provider entry to 'future' would silently disable cline dispatch in the UI.
+"""
+
+from agent_remediation import (
+    DEFAULT_PROVIDER_ORDER,
+    PROVIDERS,
+    FailureContext,
+    provider_prompt,
+)
+
+
+def test_cline_provider_is_registered():
+    assert "cline" in PROVIDERS
+    p = PROVIDERS["cline"]
+    assert p.label == "Cline"
+    assert p.execution_mode == "local_plugin"
+
+
+def test_cline_dispatch_mode_is_actionable():
+    """Must NOT be 'future' — that disables it in the dispatch UI."""
+    p = PROVIDERS["cline"]
+    assert p.dispatch_mode != "future", (
+        "cline dispatch_mode reverted to 'future'; the launcher integration "
+        "needs dispatch_mode='dashboard_local'."
+    )
+    assert p.dispatch_mode == "dashboard_local"
+
+
+def test_cline_provider_is_editable():
+    """Editable=True is what lets the operator change the model + provider
+    via the Cline Launcher tab editor."""
+    assert PROVIDERS["cline"].editable is True
+
+
+def test_cline_is_not_marked_experimental():
+    """Experimental=True hides the provider from production dispatch lists."""
+    assert PROVIDERS["cline"].experimental is False
+
+
+def test_cline_in_default_provider_order():
+    """Without this, the policy never offers cline as a dispatch target."""
+    assert "cline" in DEFAULT_PROVIDER_ORDER
+
+
+def test_provider_prompt_for_cline_is_non_empty_and_scope_locked():
+    ctx = FailureContext(
+        repository="D-sorganization/Tools",
+        branch="fix/lint-error",
+        workflow_name="CI Standard",
+        run_id="123",
+        failure_reason="ruff E501 line too long in foo.py:42",
+        log_excerpt="E501 Line too long (95 > 88)",
+    )
+    prompt = provider_prompt("cline", ctx)
+    assert "D-sorganization/Tools" in prompt
+    assert "fix/lint-error" in prompt
+    assert "ruff E501" in prompt
+    # Scope-lock guards: the prompt must tell cline NOT to weaken tests
+    # or suppress lint to make CI green (matches the address-prs skill).
+    assert "weaken tests" in prompt or "weaken" in prompt
+    # Cap on push attempts must be communicated to limit runner burn.
+    assert "3" in prompt
+
+
+def test_provider_prompt_for_cline_includes_yolo_context():
+    """Cline runs with --yolo by default; the prompt should warn it that
+    its actions are auto-approved so it doesn't expect prompts."""
+    ctx = FailureContext(
+        repository="x/y", branch="b", workflow_name="w",
+        run_id="1", failure_reason="r", log_excerpt="l",
+    )
+    prompt = provider_prompt("cline", ctx)
+    assert "auto-approve" in prompt.lower() or "yolo" in prompt.lower()


### PR DESCRIPTION
## Summary

Builds on the just-merged [#139](https://github.com/D-sorganization/runner-dashboard/pull/139) (which shipped the basic Cline Launcher tab + REST endpoints) to deliver:

1. **Full config editor** in the Cline Launcher tab — every knob from the launcher's v2 schema is editable from the dashboard with server-side validation.
2. **Cline as a real remediation provider** — upgrades the existing `dispatch_mode="future"` placeholder in `agent_remediation.py` to a fully selectable, dispatchable provider.
3. **Two new endpoints**: `GET /api/agent-launcher/models` (powers the model dropdown), `POST /api/agent-launcher/dispatch-remediation` (entry point for the dashboard's remediation surface to hand a CI failure to cline via the launcher).

Pairs with [Repository_Management#1006](https://github.com/D-sorganization/Repository_Management/pull/1006) which adds `--list-models` to the launcher CLI (the new `/models` endpoint shells out to it).

## Backend

### `backend/agent_launcher_router.py`

| Endpoint | What it does |
|----------|--------------|
| `GET /api/agent-launcher/models[?provider=X]` | Live ollama discovery from WSL + curated static catalog for hosted providers (anthropic, openai, openrouter, google, bedrock, vertex). Powers the editor's model dropdown. |
| `POST /api/agent-launcher/dispatch-remediation` | Validates the agent exists in the launcher config, then spawns a cline window via `launcher --once <agent>`. Entry point for other dashboard surfaces (e.g. Remediation tab) to dispatch CI failures to cline. |

Two new pydantic models (`ModelEntry`/`ModelsResponse`, `DispatchRemediationRequest`) — DbC at the boundary, every input validated before reaching the launcher subprocess.

### `backend/agent_remediation.py` — cline provider upgrade

Before: `dispatch_mode="future"`, `editable=False`, `experimental=True` (placeholder).
After: `dispatch_mode="dashboard_local"`, `editable=True`, `experimental=False`. Cline now appears in every dispatch UI alongside `jules_*`, `codex_cli`, `claude_code_cli`.

`provider_prompt()` gains a `cline` branch with a scope-locked repair prompt that:
- warns cline its actions are auto-approved (yolo mode)
- caps push attempts at 3 (mirrors the `address-prs` skill contract)
- forbids weakening tests / suppressing lint to make CI green
- builds on top of the existing `sanitize_for_prompt` defence against prompt injection

## Frontend (`frontend/index.html`)

`ClineLauncherTab` replaces the placeholder render with a tabbed view:

- **Editor** (default):
  - **WSL + discovery** fieldset: distro, repos root, org filter
  - **Model** fieldset: provider dropdown (7 providers), model ID input with `<datalist>` autocomplete from the live catalog (size + cloud/local annotation per entry), context window
  - **Cline flags** fieldset: per-flag checkboxes for `--tui`, `--yolo`, `--auto-approve-all`
  - **Scheduler** fieldset: default timeout, stagger, max concurrent
  - **Per-agent editors** (`AgentEditor` sub-component): name, enabled, skill_prompt, rotation dropdown, interval, timeout, **clickable repo multi-select** that toggles between "all" mode and explicit pills. Add-agent button + per-agent delete with last-agent guard.
  - **Sticky save bar**: dirty tracking, server-side validation via existing `PUT /config` (atomic — bad configs leave `config.json` untouched), inline `saved ✓` / error feedback.

- **Status** (existing): scheduler PID, agents table with per-row Run-Once buttons, discovered repos pill list.

Polls `/status` every 5 s; `/repos` and `/models` on demand.

## Tests

| Suite | Before | After | Delta |
|-------|-------:|------:|------:|
| `tests/test_agent_launcher_router.py` | 18 | 25 | +7 (models, dispatch-remediation) |
| `tests/test_cline_provider_upgrade.py` | 0 | 7 | new file (provider regression guards) |
| `tests/test_agent_remediation.py` | 10 | 10 | unchanged (no regressions) |

**42/42 passing in 1.9s.** Cline-provider tests act as guards against silent regressions: anyone reverting the provider entry to `dispatch_mode="future"` or removing the prompt branch fails CI.

## Test plan

- [x] `python -m pytest tests/test_agent_launcher_router.py tests/test_cline_provider_upgrade.py tests/test_agent_remediation.py -q` → 42/42 pass
- [x] `python -m ruff check backend/` → clean
- [x] `python -c "import ast; ast.parse(...)"` on both backend files → OK
- [ ] Manual smoke after Repository_Management#1006 merges: open Cline Launcher tab, change provider in the dropdown, confirm model autocomplete populates from `/api/agent-launcher/models`, save, verify launcher's `config.json` updates.
- [ ] CI Standard workflow on this PR (auto-runs after open).

## Risk and reversibility

- **Pure additive backend** — two new endpoints; the cline provider upgrade is metadata-only on the existing entry. No existing endpoints touched.
- **Frontend** — only the `ClineLauncherTab` body is rewritten; tab registration, polling cadence, and other tabs are untouched.
- **`provider_prompt('cline', ctx)`** is only called when an operator explicitly chooses cline as the dispatch target — not auto-selected, so legacy flows are unaffected.
- Reverting is `git revert <merge-sha>` — leaves no residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)