### PR TITLE
feat: implement Wave 4 identity propagation and admin API

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1659,3 +1659,15 @@ New principals can be added by editing this file; the dashboard reloads it
 automatically. Service tokens for bot principals can be minted via the
 Identity Manager (`identity_manager.mint_service_token`).
 <!-- spec-trigger-144 -->
+
+### 18.5 Cross-Fleet Coherence & Admin API (Wave 4)
+
+To ensure identity and quotas are respected across the entire fleet:
+- **Cross-Node Principal Propagation**: The \CommandEnvelope\ in \dispatch_contract.py\ includes \principal\, \on_behalf_of\, and \correlation_id\. These fields are now included in the canonical JSON payload used to generate the HMAC-SHA256 signature, ensuring that malicious actors cannot forge identities during cross-node dispatch.
+- **Hub-Side Merged Audit View**: A new endpoint \/api/fleet/audit\ aggregates orchestration audit logs from all nodes in the \FLEET_NODES\ configuration. It supports filtering by \principal\ and merges entries sorted by timestamp. Local audit logs can be retrieved via \/api/audit\.
+- **Admin API**: The \/api/admin/*\ router provides endpoints for managing the identity system:
+  - \GET /api/admin/principals\: List all registered principals and their quotas.
+  - \GET /api/admin/tokens\: List all active service token hashes.
+  - \POST /api/admin/principals/{id}/token\: Mint a new service token for a bot principal.
+  - \DELETE /api/admin/tokens/{token_hash}\: Revoke a service token.
+  - \PATCH /api/admin/principals/{id}/quota\: Update quotas (\max_runners\, \gent_spend_usd_day\, \local_app_slots\) for a specific principal.

--- a/backend/assistant_contract.py
+++ b/backend/assistant_contract.py
@@ -110,7 +110,7 @@ class AuditHistoryResponse(BaseModel):
 # Retained for backwards-compatibility with existing callers.
 
 
-class ActionRiskLevel(str, enum.Enum):
+class ActionRiskLevel(enum.StrEnum):
     """Risk assessment for proposed actions."""
 
     LOW = "low"  # Informational, no impact

--- a/backend/dispatch_contract.py
+++ b/backend/dispatch_contract.py
@@ -138,8 +138,16 @@ def _verify_envelope_signature(
 ) -> bool:
     """Verify HMAC-SHA256 signature over envelope payload."""
     expected = _sign_envelope_payload(
-        action, source, target, requested_by, issued_at, envelope_version, secret,
-        principal, on_behalf_of, correlation_id
+        action,
+        source,
+        target,
+        requested_by,
+        issued_at,
+        envelope_version,
+        secret,
+        principal,
+        on_behalf_of,
+        correlation_id,
     )
     return hmac.compare_digest(expected, signature)
 

--- a/backend/dispatch_contract.py
+++ b/backend/dispatch_contract.py
@@ -55,7 +55,7 @@ def _load_signing_secret() -> str:
     return secret
 
 
-class _StrEnum(str, enum.Enum):
+class _StrEnum(enum.StrEnum):
     """Python 3.10 compatible StrEnum."""
 
     pass
@@ -99,6 +99,9 @@ def _sign_envelope_payload(
     issued_at: str,
     envelope_version: int,
     secret: str,
+    principal: str = "",
+    on_behalf_of: str = "",
+    correlation_id: str = "",
 ) -> str:
     """Generate HMAC-SHA256 signature over envelope payload."""
     canonical = json.dumps(
@@ -109,6 +112,9 @@ def _sign_envelope_payload(
             "requested_by": requested_by,
             "issued_at": issued_at,
             "envelope_version": envelope_version,
+            "principal": principal,
+            "on_behalf_of": on_behalf_of,
+            "correlation_id": correlation_id,
         },
         separators=(",", ":"),
         sort_keys=True,
@@ -126,9 +132,15 @@ def _verify_envelope_signature(
     envelope_version: int,
     signature: str,
     secret: str,
+    principal: str = "",
+    on_behalf_of: str = "",
+    correlation_id: str = "",
 ) -> bool:
     """Verify HMAC-SHA256 signature over envelope payload."""
-    expected = _sign_envelope_payload(action, source, target, requested_by, issued_at, envelope_version, secret)
+    expected = _sign_envelope_payload(
+        action, source, target, requested_by, issued_at, envelope_version, secret,
+        principal, on_behalf_of, correlation_id
+    )
     return hmac.compare_digest(expected, signature)
 
 
@@ -244,6 +256,9 @@ class CommandEnvelope:
                 self.issued_at,
                 self.envelope_version,
                 secret,
+                self.principal,
+                self.on_behalf_of,
+                self.correlation_id,
             )
             object.__setattr__(self, "signature", sig)
 
@@ -291,6 +306,9 @@ class CommandEnvelope:
                 self.envelope_version,
                 self.signature,
                 secret,
+                self.principal,
+                self.on_behalf_of,
+                self.correlation_id,
             )
         except Exception:
             return False

--- a/backend/remote_execution_contract.py
+++ b/backend/remote_execution_contract.py
@@ -28,7 +28,7 @@ PRIVATE_NETWORKS = (
 )
 
 
-class _StrEnum(str, enum.Enum):
+class _StrEnum(enum.StrEnum):
     """Python 3.10 compatible StrEnum."""
 
     pass

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, Depends, HTTPException
+from identity import Principal, identity_manager, require_scope
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+class TokenCreateRequest(BaseModel):
+    name: str
+    expires_in_days: int | None = None
+
+
+class QuotaUpdateRequest(BaseModel):
+    max_runners: int | None = None
+    agent_spend_usd_day: float | None = None
+    local_app_slots: int | None = None
+
+
+@router.get("/principals")
+def list_principals(_auth: Principal = Depends(require_scope("admin"))):  # noqa: B008
+    """List all registered principals and their quotas."""
+    return {"principals": [p.model_dump() for p in identity_manager.principals.values()]}
+
+
+@router.get("/tokens")
+def list_tokens(_auth: Principal = Depends(require_scope("admin"))):  # noqa: B008
+    """List all active service tokens (hashes only)."""
+    return {"tokens": [t.model_dump() for t in identity_manager.tokens]}
+
+
+@router.post("/principals/{principal_id}/token")
+def create_service_token(
+    principal_id: str,
+    req: TokenCreateRequest,
+    _auth: Principal = Depends(require_scope("admin")),  # noqa: B008
+):
+    """Mint a new service token for a bot principal."""
+    try:
+        raw_token = identity_manager.mint_service_token(
+            principal_id,
+            name=req.name,
+            expires_in_days=req.expires_in_days,
+        )
+        return {"principal_id": principal_id, "token": raw_token}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.delete("/tokens/{token_hash}")
+def revoke_service_token(token_hash: str, _auth: Principal = Depends(require_scope("admin"))):  # noqa: B008
+    """Revoke a service token by its hash."""
+    identity_manager.revoke_token(token_hash)
+    return {"success": True}
+
+
+@router.patch("/principals/{principal_id}/quota")
+def update_principal_quota(
+    principal_id: str,
+    req: QuotaUpdateRequest,
+    _auth: Principal = Depends(require_scope("admin")),  # noqa: B008
+):
+    """Update quotas for a specific principal."""
+    prin = identity_manager.get_principal(principal_id)
+    if not prin:
+        raise HTTPException(status_code=404, detail="Principal not found")
+
+    if req.max_runners is not None:
+        prin.quotas.max_runners = req.max_runners
+    if req.agent_spend_usd_day is not None:
+        prin.quotas.agent_spend_usd_day = req.agent_spend_usd_day
+    if req.local_app_slots is not None:
+        prin.quotas.local_app_slots = req.local_app_slots
+
+    # Save to principals.yml
+    import yaml
+    with open(identity_manager.principals_path, "w") as f:
+        yaml.dump(
+            {"principals": [p.model_dump() for p in identity_manager.principals.values()]},
+            f,
+        )
+
+    return prin.model_dump()

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -73,6 +73,7 @@ def update_principal_quota(
 
     # Save to principals.yml
     import yaml
+
     with open(identity_manager.principals_path, "w") as f:
         yaml.dump(
             {"principals": [p.model_dump() for p in identity_manager.principals.values()]},

--- a/backend/server.py
+++ b/backend/server.py
@@ -45,8 +45,9 @@ import psutil
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
-from identity import Principal, require_scope  # noqa: B008
+from identity import Principal, require_principal, require_scope  # noqa: B008
 from pydantic import BaseModel, Field
+from routers import admin as admin_router
 from routers import auth as auth_router
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -430,6 +431,7 @@ async def _record_processed_envelope(envelope_id: str, ttl_seconds: int = 86400)
 app.include_router(_dispatch_router.router)
 _dispatch_router.set_replay_functions(_is_envelope_replay, _record_processed_envelope)
 app.include_router(_credentials_router.router)
+app.include_router(admin_router.router)
 app.include_router(auth_router.router)
 
 # Agent-launcher control surface (sibling: Repository_Management/launchers/cline_agent_launcher).
@@ -6136,7 +6138,7 @@ _ORCHESTRATION_AUDIT_PATH = Path.home() / "actions-runners" / "dashboard" / "orc
 _DEPLOY_ACTIONS = {"sync_workflows", "restart_runner", "update_config"}
 
 
-def _load_orchestration_audit(limit: int = 50) -> list[dict]:
+def _load_orchestration_audit(limit: int = 50, principal: str | None = None) -> list[dict]:
     """Load recent orchestration audit entries from disk."""
     if not _ORCHESTRATION_AUDIT_PATH.exists():
         return []
@@ -6146,6 +6148,8 @@ def _load_orchestration_audit(limit: int = 50) -> list[dict]:
             return []
         entries = json.loads(raw)
         if isinstance(entries, list):
+            if principal:
+                entries = [e for e in entries if e.get("principal") == principal]
             return entries[-limit:]
         return []
     except (OSError, json.JSONDecodeError):
@@ -6161,6 +6165,68 @@ async def _append_orchestration_audit(entry: dict) -> None:
             config_schema.atomic_write_json(_ORCHESTRATION_AUDIT_PATH, existing)
         except OSError as exc:
             log.warning("orchestration audit write failed: %s", exc)
+
+
+@app.get("/api/audit", tags=["fleet"])
+async def get_node_audit_log(
+    request: Request,
+    limit: int = 50,
+    principal: str | None = None,
+    _auth: Principal = Depends(require_principal),
+) -> list[dict]:
+    """Return this node's orchestration audit log."""
+    return _load_orchestration_audit(limit=limit, principal=principal)
+
+
+@app.get("/api/fleet/audit", tags=["fleet"])
+async def get_fleet_audit_log(
+    request: Request,
+    limit: int = 50,
+    principal: str | None = None,
+    _auth: Principal = Depends(require_principal),
+) -> dict:
+    """Return a merged view of orchestration audit logs across the fleet."""
+    local_entries = _load_orchestration_audit(limit=limit, principal=principal)
+    all_entries = list(local_entries)
+
+    async def fetch_remote_audit(name: str, url: str) -> list[dict]:
+        try:
+            params: dict[str, Any] = {"limit": limit}
+            if principal:
+                params["principal"] = principal
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                headers = {}
+                if auth_header := request.headers.get("Authorization"):
+                    headers["Authorization"] = auth_header
+                r = await client.get(f"{url}/api/audit", params=params, headers=headers)
+            if r.status_code == 200:
+                data = r.json()
+                if isinstance(data, list):
+                    return data
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Failed to fetch audit from %s (%s): %s", name, url, exc)
+        return []
+
+    if FLEET_NODES:
+        remotes = await asyncio.gather(
+            *[fetch_remote_audit(n, u) for n, u in FLEET_NODES.items()]
+        )
+        for r_entries in remotes:
+            all_entries.extend(r_entries)
+
+    def _parse_ts(entry: dict) -> _dt_mod.datetime:
+        ts_str = entry.get("timestamp") or entry.get("ts") or ""
+        try:
+            return _dt_mod.datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        except ValueError:
+            return _dt_mod.datetime.min.replace(tzinfo=UTC)
+
+    all_entries.sort(key=_parse_ts, reverse=True)
+
+    return {
+        "entries": all_entries[:limit],
+        "count": len(all_entries[:limit]),
+    }
 
 
 @app.get("/api/fleet/orchestration")

--- a/backend/server.py
+++ b/backend/server.py
@@ -6208,9 +6208,7 @@ async def get_fleet_audit_log(
         return []
 
     if FLEET_NODES:
-        remotes = await asyncio.gather(
-            *[fetch_remote_audit(n, u) for n, u in FLEET_NODES.items()]
-        )
+        remotes = await asyncio.gather(*[fetch_remote_audit(n, u) for n, u in FLEET_NODES.items()])
         for r_entries in remotes:
             all_entries.extend(r_entries)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,7 @@ def mock_auth():
     from server import app
 
     def mock_principal():
-        return Principal(
-            id="test-admin", type="bot", name="Test Admin", roles=["admin"]
-        )
+        return Principal(id="test-admin", type="bot", name="Test Admin", roles=["admin"])
 
     app.dependency_overrides[require_principal] = mock_principal
     yield

--- a/tests/test_agent_dispatch_router.py
+++ b/tests/test_agent_dispatch_router.py
@@ -24,9 +24,7 @@ from agent_dispatch_router import (  # noqa: E402
 
 
 def _make_run_cmd(returncode: int = 0, stdout: str = "", stderr: str = "") -> AsyncMock:
-    async def _run(
-        cmd: list[str], timeout: int = 30, cwd: Path | None = None
-    ) -> tuple[int, str, str]:
+    async def _run(cmd: list[str], timeout: int = 30, cwd: Path | None = None) -> tuple[int, str, str]:
         return returncode, stdout, stderr
 
     return AsyncMock(side_effect=_run)
@@ -67,9 +65,7 @@ async def _dispatch_prs(req: PRDispatchRequest, run_cmd_fn=None):
         )
 
 
-async def _dispatch_issues(
-    req: IssueDispatchRequest, run_cmd_fn=None, available: bool = True
-):
+async def _dispatch_issues(req: IssueDispatchRequest, run_cmd_fn=None, available: bool = True):
     if run_cmd_fn is None:
         run_cmd_fn = _make_run_cmd(0)
     with _avail_patch(available):
@@ -108,10 +104,7 @@ async def test_dispatch_to_prs_single_happy_path() -> None:
 @pytest.mark.asyncio
 async def test_dispatch_to_prs_all_past_cap_returns_error() -> None:
     """dispatch_to_prs mode=all with >100 items → error dict with status_code=400."""
-    items = [
-        DispatchItem(repository="D-sorganization/runner-dashboard", number=i)
-        for i in range(1, 102)
-    ]
+    items = [DispatchItem(repository="D-sorganization/runner-dashboard", number=i) for i in range(1, 102)]
     req = PRDispatchRequest(
         selection=DispatchSelection(mode="all", items=items),
         provider="claude_code_cli",

--- a/tests/test_agent_launcher_router.py
+++ b/tests/test_agent_launcher_router.py
@@ -11,10 +11,9 @@ from __future__ import annotations  # noqa: E402
 import json  # noqa: E402
 from pathlib import Path  # noqa: E402
 
+import agent_launcher_router as alr  # noqa: E402
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-
-from backend import agent_launcher_router as alr  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_launcher_router.py
+++ b/tests/test_agent_launcher_router.py
@@ -59,9 +59,7 @@ def test_status_no_state_no_config_returns_empty_agents(runtime, client, monkeyp
 
 def test_status_with_running_scheduler_and_one_agent(runtime, client, monkeypatch):
     (runtime / "config.json").write_text(
-        json.dumps(
-            {"agents": {"address-issues": {"enabled": True, "interval_seconds": 3600}}}
-        ),
+        json.dumps({"agents": {"address-issues": {"enabled": True, "interval_seconds": 3600}}}),
         encoding="utf-8",
     )
     (runtime / "scheduler.pid").write_text(
@@ -104,9 +102,7 @@ def test_status_with_running_scheduler_and_one_agent(runtime, client, monkeypatc
 
 def test_status_lock_alive_when_pid_alive(runtime, client, monkeypatch):
     (runtime / "config.json").write_text(
-        json.dumps(
-            {"agents": {"address-prs": {"enabled": True, "interval_seconds": 3600}}}
-        ),
+        json.dumps({"agents": {"address-prs": {"enabled": True, "interval_seconds": 3600}}}),
         encoding="utf-8",
     )
     (runtime / "locks").mkdir()
@@ -130,9 +126,7 @@ def test_status_corrupt_state_does_not_500(runtime, client, monkeypatch):
     """Status must degrade gracefully — a half-written JSON shouldn't blank
     the dashboard."""
     (runtime / "state.json").write_text("{ this is not json", encoding="utf-8")
-    (runtime / "config.json").write_text(
-        json.dumps({"agents": {"a": {}}}), encoding="utf-8"
-    )
+    (runtime / "config.json").write_text(json.dumps({"agents": {"a": {}}}), encoding="utf-8")
     monkeypatch.setattr(alr, "_is_pid_alive", lambda pid: False)
     r = client.get("/api/agent-launcher/status")
     assert r.status_code == 200
@@ -164,9 +158,7 @@ def test_get_config_503_when_launcher_missing(client, monkeypatch):
 def test_put_config_validates_before_promoting(runtime, client, monkeypatch):
     """A bad config must NOT overwrite the existing config.json."""
     (runtime / "config.json").write_text('{"version": 2}', encoding="utf-8")
-    monkeypatch.setattr(
-        alr, "_run_cli", lambda *a, **kw: (2, "", "model.provider must be one of [...]")
-    )
+    monkeypatch.setattr(alr, "_run_cli", lambda *a, **kw: (2, "", "model.provider must be one of [...]"))
     r = client.put("/api/agent-launcher/config", json={"bad": "config"})
     assert r.status_code == 422
     assert "rejected" in r.json()["detail"].lower()

--- a/tests/test_agent_remediation.py
+++ b/tests/test_agent_remediation.py
@@ -21,9 +21,7 @@ from agent_remediation import (  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-def classify_failure(
-    context: FailureContext, policy: RemediationPolicy | None = None
-) -> WorkflowTypeRule:
+def classify_failure(context: FailureContext, policy: RemediationPolicy | None = None) -> WorkflowTypeRule:
     """Thin wrapper so tests can call classify_failure(ctx) as described in the issue."""
     if policy is None:
         policy = load_policy()
@@ -61,9 +59,7 @@ def test_classify_failure_ci_standard_returns_test_type() -> None:
 
 
 def test_classify_failure_ruff_lint_returns_lint_type() -> None:
-    ctx = FailureContext(
-        repository="Foo", workflow_name="ruff lint check", branch="main"
-    )
+    ctx = FailureContext(repository="Foo", workflow_name="ruff lint check", branch="main")
     rule = classify_failure(ctx)
     assert isinstance(rule, WorkflowTypeRule)
     assert rule.workflow_type == "lint"
@@ -106,9 +102,7 @@ def test_failure_context_protected_branch_flag() -> None:
 def _make_availability(*provider_ids: str) -> dict[str, ProviderAvailability]:
     """Helper to create availability map with all requested providers available."""
     return {
-        pid: ProviderAvailability(
-            provider_id=pid, available=True, status="available", detail="ready"
-        )
+        pid: ProviderAvailability(provider_id=pid, available=True, status="available", detail="ready")
         for pid in provider_ids
     }
 
@@ -152,9 +146,7 @@ def test_fallback_provider_chain_uses_fallback_when_primary_exhausted() -> None:
         enabled_providers=("codex_cli", "claude_code_cli", "jules_api"),
         default_provider="codex_cli",  # primary is codex_cli
     )
-    context = FailureContext(
-        repository="foo/bar", workflow_name="CI", branch="main", failure_reason="lint"
-    )
+    context = FailureContext(repository="foo/bar", workflow_name="CI", branch="main", failure_reason="lint")
     availability = _make_availability("codex_cli", "claude_code_cli", "jules_api")
 
     decision = plan_dispatch(
@@ -223,9 +215,7 @@ def test_fallback_provider_chain_exhausted_all_providers() -> None:
         enabled_providers=("codex_cli", "claude_code_cli", "jules_api"),
         default_provider="codex_cli",
     )
-    context = FailureContext(
-        repository="foo/bar", workflow_name="CI", branch="main", failure_reason="lint"
-    )
+    context = FailureContext(repository="foo/bar", workflow_name="CI", branch="main", failure_reason="lint")
     availability = _make_availability("codex_cli", "claude_code_cli", "jules_api")
 
     decision = plan_dispatch(
@@ -370,9 +360,7 @@ def test_per_provider_attempt_count_separate_from_global() -> None:
         enabled_providers=("codex_cli", "claude_code_cli"),
         default_provider="codex_cli",
     )
-    context = FailureContext(
-        repository="foo/bar", workflow_name="CI", branch="main", failure_reason="lint"
-    )
+    context = FailureContext(repository="foo/bar", workflow_name="CI", branch="main", failure_reason="lint")
     availability = _make_availability("codex_cli", "claude_code_cli")
 
     decision = plan_dispatch(

--- a/tests/test_backend_routers.py
+++ b/tests/test_backend_routers.py
@@ -14,9 +14,7 @@ import pytest  # noqa: E402
 _BACKEND_DIR = Path(__file__).parent.parent / "backend"
 sys.path.insert(0, str(_BACKEND_DIR))
 
-_py311 = pytest.mark.skipif(
-    sys.version_info < (3, 11), reason="dispatch_contract requires Python 3.11+"
-)
+_py311 = pytest.mark.skipif(sys.version_info < (3, 11), reason="dispatch_contract requires Python 3.11+")
 
 
 # ---------------------------------------------------------------------------
@@ -44,9 +42,7 @@ def test_dispatch_router_has_expected_routes() -> None:
 def test_dispatch_router_uses_dispatch_contract() -> None:
     """The dispatch router module must reference dispatch_contract — its core dependency."""
     source = (_BACKEND_DIR / "routers" / "dispatch.py").read_text(encoding="utf-8")
-    assert (
-        "import dispatch_contract" in source
-    ), "dispatch router must import dispatch_contract"
+    assert "import dispatch_contract" in source, "dispatch router must import dispatch_contract"
 
 
 # ---------------------------------------------------------------------------
@@ -83,19 +79,14 @@ def test_credentials_router_no_secret_exposure() -> None:
 def test_server_registers_dispatch_router() -> None:
     """server.py must include the dispatch router (not re-implement it inline)."""
     server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
-    assert (
-        "from routers import dispatch" in server_src or "routers.dispatch" in server_src
-    )
+    assert "from routers import dispatch" in server_src or "routers.dispatch" in server_src
     assert "include_router(_dispatch_router.router)" in server_src
 
 
 def test_server_registers_credentials_router() -> None:
     """server.py must include the credentials router (not re-implement it inline)."""
     server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
-    assert (
-        "from routers import credentials" in server_src
-        or "routers.credentials" in server_src
-    )
+    assert "from routers import credentials" in server_src or "routers.credentials" in server_src
     assert "include_router(_credentials_router.router)" in server_src
 
 

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -24,9 +24,7 @@ def test_agent_remediation_valid_policy() -> None:
 
 def test_agent_remediation_max_attempts_out_of_range() -> None:
     with pytest.raises(ValueError, match="max_attempts_per_fingerprint"):
-        config_schema.validate_agent_remediation_config(
-            {"policy": {"max_attempts_per_fingerprint": 999}}
-        )
+        config_schema.validate_agent_remediation_config({"policy": {"max_attempts_per_fingerprint": 999}})
 
 
 def test_agent_remediation_secret_key_rejected() -> None:
@@ -74,9 +72,7 @@ def test_atomic_write_json(tmp_path: Path) -> None:
 
 
 def test_safe_read_json_nonexistent(tmp_path: Path) -> None:
-    result = config_schema.safe_read_json(
-        tmp_path / "nonexistent.json", {"default": True}
-    )
+    result = config_schema.safe_read_json(tmp_path / "nonexistent.json", {"default": True})
     assert result == {"default": True}
 
 

--- a/tests/test_deploy_hardening.py
+++ b/tests/test_deploy_hardening.py
@@ -19,9 +19,7 @@ def test_shared_deploy_lib_enables_strict_mode() -> None:
 
 def test_update_deployed_requires_successful_backup() -> None:
     content = _read(_DEPLOY / "update-deployed.sh")
-    assert (
-        'backup_dir "$DEPLOY_DIR") || fail "Backup failed; aborting update"' in content
-    )
+    assert 'backup_dir "$DEPLOY_DIR") || fail "Backup failed; aborting update"' in content
     assert 'fail "Backup returned empty path; aborting update"' in content
 
 

--- a/tests/test_dispatch_contract.py
+++ b/tests/test_dispatch_contract.py
@@ -17,15 +17,11 @@ _PRIVILEGED_ACTION = "runner.restart"
 _READ_ONLY_ACTION = "dashboard.status"
 
 
-def _make_confirmation(
-    approved_by: str = "alice", approved_at: str = "2026-04-23T00:00:00Z"
-) -> DispatchConfirmation:
+def _make_confirmation(approved_by: str = "alice", approved_at: str = "2026-04-23T00:00:00Z") -> DispatchConfirmation:
     return DispatchConfirmation(approved_by=approved_by, approved_at=approved_at)
 
 
-def _base_envelope(
-    action: str, confirmation: DispatchConfirmation | None = None
-) -> CommandEnvelope:
+def _base_envelope(action: str, confirmation: DispatchConfirmation | None = None) -> CommandEnvelope:
     return build_envelope(
         action=action,
         source="hub",

--- a/tests/test_envelope_signing.py
+++ b/tests/test_envelope_signing.py
@@ -11,8 +11,9 @@ from __future__ import annotations  # noqa: E402
 import json  # noqa: E402
 import os  # noqa: E402
 import sys  # noqa: E402
-from datetime import datetime, timedelta, timezone  # noqa: E402
-UTC = timezone.utc
+from datetime import UTC, datetime, timedelta  # noqa: E402
+
+UTC = UTC
 from pathlib import Path  # noqa: E402
 from unittest.mock import patch  # noqa: E402
 
@@ -33,6 +34,7 @@ from dispatch_contract import (  # noqa: E402  # noqa: E402
     _verify_envelope_signature,
     validate_envelope_crypto,
 )
+
 
 class TestEnvelopeSigningAndVerification:
     """Test HMAC-SHA256 envelope signing infrastructure."""

--- a/tests/test_envelope_signing.py
+++ b/tests/test_envelope_signing.py
@@ -180,9 +180,7 @@ class TestEnvelopeSigningAndVerification:
         )
         sig = _sign_envelope_payload(**payload_args, secret="secret-1")
 
-        result = _verify_envelope_signature(
-            **payload_args, secret="secret-2", signature=sig
-        )
+        result = _verify_envelope_signature(**payload_args, secret="secret-2", signature=sig)
         assert result is False
 
 
@@ -252,41 +250,25 @@ class TestTimestampValidation:
 
     def test_timestamp_validation_accepts_older_within_ttl(self):
         """Timestamp 1 minute ago within 5-minute TTL is VALID."""
-        one_min_ago = (
-            (datetime.now(UTC) - timedelta(minutes=1))
-            .isoformat()
-            .replace("+00:00", "Z")
-        )
+        one_min_ago = (datetime.now(UTC) - timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
         result = _validate_timestamp_freshness(one_min_ago, ttl_seconds=300)
         assert result == TimestampValidationResult.VALID
 
     def test_timestamp_validation_accepts_future_within_ttl(self):
         """Timestamp 1 minute in future within 5-minute TTL is VALID."""
-        one_min_future = (
-            (datetime.now(UTC) + timedelta(minutes=1))
-            .isoformat()
-            .replace("+00:00", "Z")
-        )
+        one_min_future = (datetime.now(UTC) + timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
         result = _validate_timestamp_freshness(one_min_future, ttl_seconds=300)
         assert result == TimestampValidationResult.VALID
 
     def test_timestamp_validation_rejects_too_old(self):
         """Timestamp 10 minutes ago outside 5-minute TTL is TOO_OLD."""
-        ten_min_ago = (
-            (datetime.now(UTC) - timedelta(minutes=10))
-            .isoformat()
-            .replace("+00:00", "Z")
-        )
+        ten_min_ago = (datetime.now(UTC) - timedelta(minutes=10)).isoformat().replace("+00:00", "Z")
         result = _validate_timestamp_freshness(ten_min_ago, ttl_seconds=300)
         assert result == TimestampValidationResult.TOO_OLD
 
     def test_timestamp_validation_rejects_too_new(self):
         """Timestamp 10 minutes in future outside 5-minute TTL is TOO_NEW."""
-        ten_min_future = (
-            (datetime.now(UTC) + timedelta(minutes=10))
-            .isoformat()
-            .replace("+00:00", "Z")
-        )
+        ten_min_future = (datetime.now(UTC) + timedelta(minutes=10)).isoformat().replace("+00:00", "Z")
         result = _validate_timestamp_freshness(ten_min_future, ttl_seconds=300)
         assert result == TimestampValidationResult.TOO_NEW
 
@@ -358,11 +340,7 @@ class TestCryptoValidation:
     def test_crypto_validation_rejects_old_issued_at(self):
         """validate_envelope_crypto rejects timestamp > TTL seconds old."""
         with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
-            old_time = (
-                (datetime.now(UTC) - timedelta(minutes=10))
-                .isoformat()
-                .replace("+00:00", "Z")
-            )
+            old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat().replace("+00:00", "Z")
             envelope = CommandEnvelope(
                 action="test.action",
                 source="hub",
@@ -405,19 +383,13 @@ class TestCryptoValidation:
             result = validate_envelope_crypto(envelope)
             assert result.valid is True
 
-    @pytest.mark.skip(
-        reason="Implementation doesn't validate old confirmation timestamps on post-creation assignment"
-    )
+    @pytest.mark.skip(reason="Implementation doesn't validate old confirmation timestamps on post-creation assignment")
     def test_crypto_validation_rejects_confirmation_with_old_timestamp(self):
         """validate_envelope_crypto rejects confirmation timestamp > TTL."""
         with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
             # This test checks that old confirmation timestamps are rejected
             # Note: current implementation only validates timestamps at envelope creation
-            old_time = (
-                (datetime.now(UTC) - timedelta(minutes=10))
-                .isoformat()
-                .replace("+00:00", "Z")
-            )
+            old_time = (datetime.now(UTC) - timedelta(minutes=10)).isoformat().replace("+00:00", "Z")
             confirmation = DispatchConfirmation(
                 approved_by="bob",
                 approved_at=old_time,

--- a/tests/test_frontend_integrity.py
+++ b/tests/test_frontend_integrity.py
@@ -60,9 +60,7 @@ def test_required_function_present(marker: str) -> None:
     assert marker in content, f"Expected '{marker}' in frontend/index.html"
 
 
-@pytest.mark.xfail(
-    reason="RunnerPlanTab not yet implemented in frontend/index.html", strict=True
-)
+@pytest.mark.xfail(reason="RunnerPlanTab not yet implemented in frontend/index.html", strict=True)
 def test_runner_plan_tab_present() -> None:
     content = _read_index()
     assert "function RunnerPlanTab" in content
@@ -75,9 +73,7 @@ def test_runner_plan_tab_present() -> None:
 
 def test_heavy_tests_tab_absent() -> None:
     content = _read_index()
-    assert (
-        "HeavyTestsTab" not in content
-    ), "HeavyTestsTab was found — use TestsTab instead"
+    assert "HeavyTestsTab" not in content, "HeavyTestsTab was found — use TestsTab instead"
 
 
 # ---------------------------------------------------------------------------
@@ -128,13 +124,8 @@ def test_dangerous_set_inner_html_sanitized() -> None:
         window_end = min(len(lines), lineno + 6)
         window = "\n".join(lines[window_start:window_end])
         has_sanitize = "DOMPurify.sanitize" in window
-        has_safe_wrapper = (
-            "renderMarkdown" in window
-        )  # renderMarkdown internally calls DOMPurify
-        has_safe_comment = (
-            re.search(r"//.*safe|//.*sanitize|//.*trusted", window, re.IGNORECASE)
-            is not None
-        )
+        has_safe_wrapper = "renderMarkdown" in window  # renderMarkdown internally calls DOMPurify
+        has_safe_comment = re.search(r"//.*safe|//.*sanitize|//.*trusted", window, re.IGNORECASE) is not None
         if not (has_sanitize or has_safe_wrapper or has_safe_comment):
             violations.append(lineno + 1)
     assert not violations, (
@@ -190,11 +181,7 @@ def test_jsx_archive_removed() -> None:
 
 def test_index_html_is_only_frontend_source() -> None:
     """No other .jsx or .tsx files should exist in frontend/ at runtime."""
-    unexpected = [
-        p
-        for p in _FRONTEND_DIR.iterdir()
-        if p.suffix in {".jsx", ".tsx"} and p.is_file()
-    ]
+    unexpected = [p for p in _FRONTEND_DIR.iterdir() if p.suffix in {".jsx", ".tsx"} and p.is_file()]
     assert not unexpected, (
         f"Unexpected transpilable source files in frontend/: {[p.name for p in unexpected]}. "
         "frontend/index.html is the only runtime source — no build step exists."

--- a/tests/test_issue_inventory.py
+++ b/tests/test_issue_inventory.py
@@ -261,9 +261,7 @@ class TestFetchRepoIssues:
 
     @pytest.mark.asyncio
     async def test_json_error_returns_error(self) -> None:
-        with patch.object(
-            issue_inventory, "_run_gh", new=AsyncMock(return_value=(0, "oops", ""))
-        ):
+        with patch.object(issue_inventory, "_run_gh", new=AsyncMock(return_value=(0, "oops", ""))):
             items, err = await issue_inventory.fetch_repo_issues("org/repo")
         assert items == []
         assert err is not None
@@ -275,9 +273,7 @@ class TestFetchRepoIssues:
 class TestFetchAllIssues:
     @pytest.mark.asyncio
     async def test_per_repo_error_captured(self) -> None:
-        async def fake_fetch(
-            full_name: str, state: str = "open"
-        ) -> tuple[list, str | None]:
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
             if full_name == "org/bad":
                 return [], "org/bad: gh exit 1: not found"
             raw = _make_issue(1, "Good issue")
@@ -291,23 +287,17 @@ class TestFetchAllIssues:
 
     @pytest.mark.asyncio
     async def test_pickable_only_filter(self) -> None:
-        raw_pickable = _make_issue(
-            1, "Pickable", labels=["type:task", "judgement:objective"]
-        )
+        raw_pickable = _make_issue(1, "Pickable", labels=["type:task", "judgement:objective"])
         raw_blocked = _make_issue(2, "Contested", labels=["judgement:contested"])
 
-        async def fake_fetch(
-            full_name: str, state: str = "open"
-        ) -> tuple[list, str | None]:
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
             return [
                 issue_inventory._normalise_issue(raw_pickable, full_name),
                 issue_inventory._normalise_issue(raw_blocked, full_name),
             ], None
 
         with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
-            result = await issue_inventory.fetch_all_issues(
-                ["org/repo"], pickable_only=True
-            )
+            result = await issue_inventory.fetch_all_issues(["org/repo"], pickable_only=True)
 
         assert all(i["pickable"] for i in result["items"])
 
@@ -318,17 +308,11 @@ class TestFetchAllIssues:
             _make_issue(2, "Routine", labels=["complexity:routine"]),
         ]
 
-        async def fake_fetch(
-            full_name: str, state: str = "open"
-        ) -> tuple[list, str | None]:
-            return [
-                issue_inventory._normalise_issue(i, full_name) for i in issues
-            ], None
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            return [issue_inventory._normalise_issue(i, full_name) for i in issues], None
 
         with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
-            result = await issue_inventory.fetch_all_issues(
-                ["org/repo"], complexity=["trivial"]
-            )
+            result = await issue_inventory.fetch_all_issues(["org/repo"], complexity=["trivial"])
 
         assert result["items"][0]["taxonomy"]["complexity"] == "trivial"
         assert len(result["items"]) == 1
@@ -337,12 +321,8 @@ class TestFetchAllIssues:
     async def test_limit_respected(self) -> None:
         issues = [_make_issue(i, f"Issue {i}") for i in range(20)]
 
-        async def fake_fetch(
-            full_name: str, state: str = "open"
-        ) -> tuple[list, str | None]:
-            return [
-                issue_inventory._normalise_issue(i, full_name) for i in issues
-            ], None
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            return [issue_inventory._normalise_issue(i, full_name) for i in issues], None
 
         with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
             result = await issue_inventory.fetch_all_issues(["org/repo"], limit=5)
@@ -356,17 +336,11 @@ class TestFetchAllIssues:
             _make_issue(2, "Bob issue", assignees=["bob"]),
         ]
 
-        async def fake_fetch(
-            full_name: str, state: str = "open"
-        ) -> tuple[list, str | None]:
-            return [
-                issue_inventory._normalise_issue(i, full_name) for i in issues
-            ], None
+        async def fake_fetch(full_name: str, state: str = "open") -> tuple[list, str | None]:
+            return [issue_inventory._normalise_issue(i, full_name) for i in issues], None
 
         with patch.object(issue_inventory, "fetch_repo_issues", side_effect=fake_fetch):
-            result = await issue_inventory.fetch_all_issues(
-                ["org/repo"], assignee="alice"
-            )
+            result = await issue_inventory.fetch_all_issues(["org/repo"], assignee="alice")
 
         assert len(result["items"]) == 1
         assert "alice" in result["items"][0]["assignees"]

--- a/tests/test_keepalive_diagnostics.py
+++ b/tests/test_keepalive_diagnostics.py
@@ -23,9 +23,7 @@ def _patch_server_windows_os(monkeypatch) -> None:
     monkeypatch.setattr(server, "os", WindowsOs())
 
 
-def test_windows_wslconfig_path_is_checked_directly(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_windows_wslconfig_path_is_checked_directly(monkeypatch, tmp_path: Path) -> None:
     _patch_server_windows_os(monkeypatch)
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.delenv("HOMEDRIVE", raising=False)

--- a/tests/test_maxwell_proxy.py
+++ b/tests/test_maxwell_proxy.py
@@ -52,9 +52,7 @@ def _mock_httpx_response(json_data: dict, status_code: int = 200) -> MagicMock:
     return mock_resp
 
 
-def _make_mock_client(
-    get_return=None, post_return=None, get_side_effect=None, post_side_effect=None
-):
+def _make_mock_client(get_return=None, post_return=None, get_side_effect=None, post_side_effect=None):
     """Build a mock AsyncClient context manager that yields a mock client."""
     mock_client = MagicMock()
     if get_side_effect is not None:
@@ -91,9 +89,7 @@ async def test_get_maxwell_version_returns_200_with_contract(client) -> None:
 @pytest.mark.asyncio
 async def test_get_maxwell_version_daemon_unreachable_returns_200(client) -> None:
     """When daemon is unreachable, version endpoint returns 200 with daemon_available=False."""
-    mock_cm = _make_mock_client(
-        get_side_effect=httpx.ConnectError("connection refused")
-    )
+    mock_cm = _make_mock_client(get_side_effect=httpx.ConnectError("connection refused"))
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.get("/api/maxwell/version")
     assert resp.status_code == 200
@@ -120,9 +116,7 @@ async def test_get_maxwell_tasks_returns_200_with_tasks_key(client) -> None:
 @pytest.mark.asyncio
 async def test_get_maxwell_tasks_daemon_unreachable_returns_200(client) -> None:
     """When daemon is unreachable, tasks endpoint returns 200 with daemon_available=False."""
-    mock_cm = _make_mock_client(
-        get_side_effect=httpx.ConnectError("connection refused")
-    )
+    mock_cm = _make_mock_client(get_side_effect=httpx.ConnectError("connection refused"))
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.get("/api/maxwell/tasks")
     assert resp.status_code == 200
@@ -148,9 +142,7 @@ async def test_get_maxwell_task_detail_returns_200(client) -> None:
 @pytest.mark.asyncio
 async def test_get_maxwell_task_detail_daemon_unreachable_returns_200(client) -> None:
     """When daemon is unreachable, task detail returns 200 with daemon_available=False."""
-    mock_cm = _make_mock_client(
-        get_side_effect=httpx.ConnectError("connection refused")
-    )
+    mock_cm = _make_mock_client(get_side_effect=httpx.ConnectError("connection refused"))
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.get("/api/maxwell/tasks/abc123")
     assert resp.status_code == 200
@@ -176,9 +168,7 @@ async def test_get_maxwell_daemon_status_returns_200(client) -> None:
 @pytest.mark.asyncio
 async def test_get_maxwell_daemon_status_unreachable_returns_200(client) -> None:
     """When daemon is unreachable, daemon-status returns 200 with daemon_available=False."""
-    mock_cm = _make_mock_client(
-        get_side_effect=httpx.ConnectError("connection refused")
-    )
+    mock_cm = _make_mock_client(get_side_effect=httpx.ConnectError("connection refused"))
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.get("/api/maxwell/daemon-status")
     assert resp.status_code == 200
@@ -219,9 +209,7 @@ async def test_maxwell_pipeline_control_badaction_returns_422(client) -> None:
 @pytest.mark.asyncio
 async def test_maxwell_pipeline_control_daemon_unreachable_returns_200(client) -> None:
     """When daemon is unreachable, pipeline-control returns 200 with daemon_available=False."""
-    mock_cm = _make_mock_client(
-        post_side_effect=httpx.ConnectError("connection refused")
-    )
+    mock_cm = _make_mock_client(post_side_effect=httpx.ConnectError("connection refused"))
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.post("/api/maxwell/pipeline-control/abort", json={})
     assert resp.status_code == 200
@@ -235,9 +223,7 @@ async def test_maxwell_pipeline_control_daemon_unreachable_returns_200(client) -
 @pytest.mark.asyncio
 async def test_maxwell_dispatch_daemon_unreachable_returns_200(client) -> None:
     """When daemon is unreachable, dispatch returns 200 with daemon_available=False (not 5xx)."""
-    mock_cm = _make_mock_client(
-        post_side_effect=httpx.ConnectError("connection refused")
-    )
+    mock_cm = _make_mock_client(post_side_effect=httpx.ConnectError("connection refused"))
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.post("/api/maxwell/dispatch", json={"repo": "test-repo"})
     assert resp.status_code == 200

--- a/tests/test_pr_inventory.py
+++ b/tests/test_pr_inventory.py
@@ -3,8 +3,9 @@
 from __future__ import annotations  # noqa: E402
 
 import sys  # noqa: E402
-from datetime import datetime, timedelta, timezone  # noqa: E402
-UTC = timezone.utc
+from datetime import UTC, datetime, timedelta  # noqa: E402
+
+UTC = UTC
 from pathlib import Path  # noqa: E402
 from unittest.mock import AsyncMock, patch  # noqa: E402
 

--- a/tests/test_pr_inventory.py
+++ b/tests/test_pr_inventory.py
@@ -179,9 +179,7 @@ class TestParseAgentClaim:
 class TestFetchRepoPrs:
     @pytest.mark.asyncio
     async def test_gh_failure_returns_error(self) -> None:
-        with patch.object(
-            pr_inventory, "_run_gh", new=AsyncMock(return_value=(1, "", "auth error"))
-        ):
+        with patch.object(pr_inventory, "_run_gh", new=AsyncMock(return_value=(1, "", "auth error"))):
             items, err = await pr_inventory.fetch_repo_prs("org/repo")
         assert items == []
         assert err is not None
@@ -189,9 +187,7 @@ class TestFetchRepoPrs:
 
     @pytest.mark.asyncio
     async def test_json_decode_error_returns_error(self) -> None:
-        with patch.object(
-            pr_inventory, "_run_gh", new=AsyncMock(return_value=(0, "not json", ""))
-        ):
+        with patch.object(pr_inventory, "_run_gh", new=AsyncMock(return_value=(0, "not json", ""))):
             items, err = await pr_inventory.fetch_repo_prs("org/repo")
         assert items == []
         assert err is not None
@@ -247,9 +243,7 @@ class TestFetchAllPrs:
             return [pr_inventory._normalise_pr(p, full_name) for p in prs], None
 
         with patch.object(pr_inventory, "fetch_repo_prs", side_effect=fake_fetch):
-            result = await pr_inventory.fetch_all_prs(
-                ["org/repo"], include_drafts=False
-            )
+            result = await pr_inventory.fetch_all_prs(["org/repo"], include_drafts=False)
 
         assert result["total"] == 1
         assert result["items"][0]["draft"] is False

--- a/tests/test_quick_dispatch.py
+++ b/tests/test_quick_dispatch.py
@@ -20,9 +20,7 @@ from quick_dispatch import (  # noqa: E402
 
 
 def _make_run_cmd(returncode: int = 0, stdout: str = "", stderr: str = "") -> AsyncMock:
-    async def _run(
-        cmd: list[str], timeout: int = 30, cwd: Path | None = None
-    ) -> tuple[int, str, str]:
+    async def _run(cmd: list[str], timeout: int = 30, cwd: Path | None = None) -> tuple[int, str, str]:
         return returncode, stdout, stderr
 
     return AsyncMock(side_effect=_run)
@@ -35,14 +33,10 @@ def _normalize(value: str) -> tuple[str, str]:
     return value, f"D-sorganization/{value}"
 
 
-async def _call(
-    req: QuickDispatchRequest, run_cmd_fn=None, extra_patches: dict | None = None
-):
+async def _call(req: QuickDispatchRequest, run_cmd_fn=None, extra_patches: dict | None = None):
     if run_cmd_fn is None:
         run_cmd_fn = _make_run_cmd(0)
-    with patch(
-        "quick_dispatch.agent_remediation.probe_provider_availability"
-    ) as mock_avail:
+    with patch("quick_dispatch.agent_remediation.probe_provider_availability") as mock_avail:
         mock_avail.return_value = {
             "claude_code_cli": type(
                 "A",
@@ -87,9 +81,7 @@ async def test_provider_unavailable_rejected() -> None:
         prompt="Fix the failing test in test_api.py",
         provider="nonexistent_provider",
     )
-    with patch(
-        "quick_dispatch.agent_remediation.probe_provider_availability"
-    ) as mock_avail:
+    with patch("quick_dispatch.agent_remediation.probe_provider_availability") as mock_avail:
         mock_avail.return_value = {}
         resp = await quick_dispatch(
             req,


### PR DESCRIPTION
Implements Wave 4 of the Identity Epic (#63):
- Hub-side merged audit view (\/api/fleet/audit\) with principal filter
- Cross-node principal propagation in signed envelopes (updated \dispatch_contract\)
- Admin endpoints (\/api/admin/*\) for principals list, token management, quota overrides