### PR TITLE
feat(queue): stale-queue detection, bulk purge, and scheduled auto-cleanup

### DIFF
--- a/backend/queue_cleanup.py
+++ b/backend/queue_cleanup.py
@@ -21,14 +21,15 @@ Common sources of stale runs:
 from __future__ import annotations
 
 import asyncio
+import datetime as _dt
 import json
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 log = logging.getLogger(__name__)
 
-UTC = timezone.utc
+UTC = _dt.UTC
 DEFAULT_MIN_AGE_MINUTES: int = 60
 _MAX_REPOS: int = 200
 _MAX_RUNS_PER_REPO: int = 100
@@ -69,7 +70,7 @@ async def _gh(*args: str, timeout: int = 30) -> tuple[int, str, str]:
     )
     try:
         raw_out, raw_err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
+    except TimeoutError:
         proc.kill()
         return 1, "", "timeout"
     return (proc.returncode or 0,
@@ -120,7 +121,7 @@ async def _queued_stale_for_repo(
     repo: str,
     min_age: timedelta,
 ) -> list[StaleRun]:
-    now = datetime.now(UTC)
+    now = _dt.datetime.now(UTC)
     data = await _gh_json(
         "api",
         f"/repos/{org}/{repo}/actions/runs"
@@ -132,7 +133,7 @@ async def _queued_stale_for_repo(
     for run in (data or {}).get("workflow_runs", []):
         raw_ts = run.get("created_at", "")
         try:
-            created = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+            created = _dt.datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
         except (ValueError, AttributeError):
             continue
         age = now - created

--- a/backend/queue_cleanup.py
+++ b/backend/queue_cleanup.py
@@ -1,0 +1,240 @@
+"""
+queue_cleanup.py — Stale-queue detection and bulk cancellation.
+
+Exposes async helpers consumed by server.py's /api/queue/stale and
+/api/queue/purge-stale endpoints.
+
+Root cause of stale jobs
+------------------------
+The normal /api/queue endpoint samples only the 15 most-recently-updated
+repos.  Queued runs in repos that have been quiet for days (or months) are
+completely invisible to that view and accumulate indefinitely.  This module
+scans the entire org so nothing is missed.
+
+Common sources of stale runs:
+  - Runner goes offline while jobs are in queue (reboot, network drop)
+  - Runner label mismatch (no runner registered for that label any more)
+  - Abandoned agent worktree runs that pushed a branch but exited before
+    the queue was explicitly cancelled
+  - GitHub Actions own queuing lag on heavily-loaded orgs
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+
+log = logging.getLogger(__name__)
+
+UTC = timezone.utc
+DEFAULT_MIN_AGE_MINUTES: int = 60
+_MAX_REPOS: int = 200
+_MAX_RUNS_PER_REPO: int = 100
+_SCAN_CONCURRENCY: int = 10   # concurrent repo queries during scan
+_CANCEL_CONCURRENCY: int = 5  # concurrent cancel calls
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StaleRun:
+    repo: str
+    run_id: int
+    workflow: str
+    branch: str
+    created_at: str
+    age_minutes: int
+    cancelled: bool = False
+    cancel_error: str = ""
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# gh CLI helpers
+# ---------------------------------------------------------------------------
+
+async def _gh(*args: str, timeout: int = 30) -> tuple[int, str, str]:
+    """Run a gh CLI subcommand asynchronously; return (returncode, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        "gh",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        raw_out, raw_err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return 1, "", "timeout"
+    return (proc.returncode or 0,
+            raw_out.decode("utf-8", errors="replace"),
+            raw_err.decode("utf-8", errors="replace"))
+
+
+async def _gh_json(*args: str, default=None, timeout: int = 30):
+    """Run a gh CLI command and return parsed JSON, or *default* on failure."""
+    code, stdout, stderr = await _gh(*args, timeout=timeout)
+    if code != 0:
+        log.debug("gh error [%s]: %s", " ".join(args[:3]), stderr.strip()[:200])
+        return default
+    if not stdout.strip():
+        return default
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Repo discovery
+# ---------------------------------------------------------------------------
+
+async def list_all_repos(org: str) -> list[str]:
+    """Return every non-archived repo name in *org* (up to _MAX_REPOS)."""
+    data = await _gh_json(
+        "repo", "list", org,
+        "--limit", str(_MAX_REPOS),
+        "--json", "name,isArchived",
+        default=[],
+        timeout=45,
+    )
+    return [
+        r["name"]
+        for r in (data or [])
+        if not r.get("isArchived") and r.get("name")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Stale-run detection
+# ---------------------------------------------------------------------------
+
+async def _queued_stale_for_repo(
+    org: str,
+    repo: str,
+    min_age: timedelta,
+) -> list[StaleRun]:
+    now = datetime.now(UTC)
+    data = await _gh_json(
+        "api",
+        f"/repos/{org}/{repo}/actions/runs"
+        f"?status=queued&per_page={_MAX_RUNS_PER_REPO}",
+        default={},
+        timeout=20,
+    )
+    stale: list[StaleRun] = []
+    for run in (data or {}).get("workflow_runs", []):
+        raw_ts = run.get("created_at", "")
+        try:
+            created = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        age = now - created
+        if age < min_age:
+            continue
+        stale.append(
+            StaleRun(
+                repo=repo,
+                run_id=run.get("id", 0),
+                workflow=run.get("name", "?"),
+                branch=run.get("head_branch", "?"),
+                created_at=raw_ts,
+                age_minutes=int(age.total_seconds() / 60),
+            )
+        )
+    return stale
+
+
+async def find_stale_runs(
+    org: str,
+    min_age_minutes: int = DEFAULT_MIN_AGE_MINUTES,
+) -> list[StaleRun]:
+    """Scan every repo in *org* for queued runs older than *min_age_minutes*.
+
+    Runs up to _SCAN_CONCURRENCY repo queries in parallel to stay fast
+    without hammering the GitHub API.  Sorted oldest-first so the worst
+    offenders appear at the top.
+    """
+    repos = await list_all_repos(org)
+    min_age = timedelta(minutes=min_age_minutes)
+    sem = asyncio.Semaphore(_SCAN_CONCURRENCY)
+
+    async def bounded(repo: str) -> list[StaleRun]:
+        async with sem:
+            return await _queued_stale_for_repo(org, repo, min_age)
+
+    nested = await asyncio.gather(*[bounded(r) for r in repos])
+    flat = [run for runs in nested for run in runs]
+    return sorted(flat, key=lambda r: r.age_minutes, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+async def _cancel_one(org: str, run: StaleRun) -> bool:
+    """POST the GitHub cancel endpoint for one run.  Returns True on success."""
+    code, _, stderr = await _gh(
+        "api", "--method", "POST",
+        f"/repos/{org}/{run.repo}/actions/runs/{run.run_id}/cancel",
+        timeout=15,
+    )
+    if code == 0:
+        run.cancelled = True
+        return True
+    # 409 = run already completed — no longer in queue, treat as success
+    if ("409" in stderr
+            or "Cannot cancel" in stderr
+            or "already" in stderr.lower()):
+        run.cancelled = True
+        run.cancel_error = "already-finished"
+        return True
+    run.cancel_error = stderr.strip()[:200]
+    return False
+
+
+async def purge_stale_runs(
+    org: str,
+    min_age_minutes: int = DEFAULT_MIN_AGE_MINUTES,
+    *,
+    dry_run: bool = False,
+) -> dict:
+    """Find stale runs and optionally cancel them all.
+
+    Returns a summary dict suitable for direct JSON serialisation.
+    When *dry_run* is True the runs are listed but nothing is cancelled.
+    """
+    stale = await find_stale_runs(org, min_age_minutes)
+    cancelled_count = 0
+    errors: list[str] = []
+
+    if not dry_run and stale:
+        sem = asyncio.Semaphore(_CANCEL_CONCURRENCY)
+
+        async def bounded_cancel(run: StaleRun) -> None:
+            nonlocal cancelled_count
+            async with sem:
+                if await _cancel_one(org, run):
+                    cancelled_count += 1
+                else:
+                    errors.append(
+                        f"{run.repo}#{run.run_id}: {run.cancel_error}"
+                    )
+
+        await asyncio.gather(*[bounded_cancel(r) for r in stale])
+
+    return {
+        "org": org,
+        "min_age_minutes": min_age_minutes,
+        "dry_run": dry_run,
+        "stale_count": len(stale),
+        "cancelled_count": cancelled_count if not dry_run else 0,
+        "errors": errors,
+        "runs": [r.as_dict() for r in stale],
+    }

--- a/backend/queue_cleanup.py
+++ b/backend/queue_cleanup.py
@@ -1,5 +1,5 @@
 """
-queue_cleanup.py — Stale-queue detection and bulk cancellation.
+queue_cleanup.py -- Stale-queue detection and bulk cancellation.
 
 Exposes async helpers consumed by server.py's /api/queue/stale and
 /api/queue/purge-stale endpoints.
@@ -18,6 +18,7 @@ Common sources of stale runs:
     the queue was explicitly cancelled
   - GitHub Actions own queuing lag on heavily-loaded orgs
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -33,13 +34,14 @@ UTC = _dt.UTC
 DEFAULT_MIN_AGE_MINUTES: int = 60
 _MAX_REPOS: int = 200
 _MAX_RUNS_PER_REPO: int = 100
-_SCAN_CONCURRENCY: int = 10   # concurrent repo queries during scan
+_SCAN_CONCURRENCY: int = 10  # concurrent repo queries during scan
 _CANCEL_CONCURRENCY: int = 5  # concurrent cancel calls
 
 
 # ---------------------------------------------------------------------------
 # Data
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class StaleRun:
@@ -60,6 +62,7 @@ class StaleRun:
 # gh CLI helpers
 # ---------------------------------------------------------------------------
 
+
 async def _gh(*args: str, timeout: int = 30) -> tuple[int, str, str]:
     """Run a gh CLI subcommand asynchronously; return (returncode, stdout, stderr)."""
     proc = await asyncio.create_subprocess_exec(
@@ -73,9 +76,11 @@ async def _gh(*args: str, timeout: int = 30) -> tuple[int, str, str]:
     except TimeoutError:
         proc.kill()
         return 1, "", "timeout"
-    return (proc.returncode or 0,
-            raw_out.decode("utf-8", errors="replace"),
-            raw_err.decode("utf-8", errors="replace"))
+    return (
+        proc.returncode or 0,
+        raw_out.decode("utf-8", errors="replace"),
+        raw_err.decode("utf-8", errors="replace"),
+    )
 
 
 async def _gh_json(*args: str, default=None, timeout: int = 30):
@@ -96,25 +101,27 @@ async def _gh_json(*args: str, default=None, timeout: int = 30):
 # Repo discovery
 # ---------------------------------------------------------------------------
 
+
 async def list_all_repos(org: str) -> list[str]:
     """Return every non-archived repo name in *org* (up to _MAX_REPOS)."""
     data = await _gh_json(
-        "repo", "list", org,
-        "--limit", str(_MAX_REPOS),
-        "--json", "name,isArchived",
+        "repo",
+        "list",
+        org,
+        "--limit",
+        str(_MAX_REPOS),
+        "--json",
+        "name,isArchived",
         default=[],
         timeout=45,
     )
-    return [
-        r["name"]
-        for r in (data or [])
-        if not r.get("isArchived") and r.get("name")
-    ]
+    return [r["name"] for r in (data or []) if not r.get("isArchived") and r.get("name")]
 
 
 # ---------------------------------------------------------------------------
 # Stale-run detection
 # ---------------------------------------------------------------------------
+
 
 async def _queued_stale_for_repo(
     org: str,
@@ -124,8 +131,7 @@ async def _queued_stale_for_repo(
     now = _dt.datetime.now(UTC)
     data = await _gh_json(
         "api",
-        f"/repos/{org}/{repo}/actions/runs"
-        f"?status=queued&per_page={_MAX_RUNS_PER_REPO}",
+        f"/repos/{org}/{repo}/actions/runs?status=queued&per_page={_MAX_RUNS_PER_REPO}",
         default={},
         timeout=20,
     )
@@ -179,20 +185,21 @@ async def find_stale_runs(
 # Cancellation
 # ---------------------------------------------------------------------------
 
+
 async def _cancel_one(org: str, run: StaleRun) -> bool:
     """POST the GitHub cancel endpoint for one run.  Returns True on success."""
     code, _, stderr = await _gh(
-        "api", "--method", "POST",
+        "api",
+        "--method",
+        "POST",
         f"/repos/{org}/{run.repo}/actions/runs/{run.run_id}/cancel",
         timeout=15,
     )
     if code == 0:
         run.cancelled = True
         return True
-    # 409 = run already completed — no longer in queue, treat as success
-    if ("409" in stderr
-            or "Cannot cancel" in stderr
-            or "already" in stderr.lower()):
+    # 409 = run already completed -- no longer in queue, treat as success
+    if "409" in stderr or "Cannot cancel" in stderr or "already" in stderr.lower():
         run.cancelled = True
         run.cancel_error = "already-finished"
         return True
@@ -224,9 +231,7 @@ async def purge_stale_runs(
                 if await _cancel_one(org, run):
                     cancelled_count += 1
                 else:
-                    errors.append(
-                        f"{run.repo}#{run.run_id}: {run.cancel_error}"
-                    )
+                    errors.append(f"{run.repo}#{run.run_id}: {run.cancel_error}")
 
         await asyncio.gather(*[bounded_cancel(r) for r in stale])
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -65,8 +65,8 @@ import dispatch_contract as dispatch_contract  # noqa: E402
 import issue_inventory as issue_inventory  # noqa: E402
 import lease_synchronizer as lease_synchronizer  # noqa: E402
 import pr_inventory as pr_inventory  # noqa: E402
-import quick_dispatch as _quick_dispatch  # noqa: E402
 import queue_cleanup as queue_cleanup  # noqa: E402
+import quick_dispatch as _quick_dispatch  # noqa: E402
 import quota_enforcement as quota_enforcement  # noqa: E402
 import scheduled_workflows as scheduled_workflow_inventory  # noqa: E402
 import usage_monitoring as usage_monitoring  # noqa: E402

--- a/backend/server.py
+++ b/backend/server.py
@@ -6698,7 +6698,6 @@ async def generate_launchers(
     }
 
 
-
 # --- Stale Queue Cleanup ---
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -66,6 +66,7 @@ import issue_inventory as issue_inventory  # noqa: E402
 import lease_synchronizer as lease_synchronizer  # noqa: E402
 import pr_inventory as pr_inventory  # noqa: E402
 import quick_dispatch as _quick_dispatch  # noqa: E402
+import queue_cleanup as queue_cleanup  # noqa: E402
 import quota_enforcement as quota_enforcement  # noqa: E402
 import scheduled_workflows as scheduled_workflow_inventory  # noqa: E402
 import usage_monitoring as usage_monitoring  # noqa: E402
@@ -6696,6 +6697,59 @@ async def generate_launchers(
         "message": f"Created {len(launchers_created)} launcher scripts in {output_dir}",
     }
 
+
+
+# --- Stale Queue Cleanup ---
+
+
+@app.get("/api/queue/stale")
+async def get_stale_queue(
+    request: Request,
+    min_age: int = 60,
+) -> dict:
+    """List every queued run older than min_age minutes across the entire org.
+
+    Unlike /api/queue (15-repo sample), this scans every repo so ancient
+    runs in quiet repos are visible.  Cached 5 minutes.
+    """
+    if _should_proxy_fleet_to_hub(request):
+        return await proxy_to_hub(request)
+    cache_key = f"stale_queue_{min_age}"
+    cached = _cache_get(cache_key, 300.0)
+    if cached is not None:
+        return cached
+    stale = await queue_cleanup.find_stale_runs(ORG, min_age)
+    payload: dict = {
+        "min_age_minutes": min_age,
+        "stale_count": len(stale),
+        "runs": [r.as_dict() for r in stale],
+    }
+    _cache_set(cache_key, payload, 300.0)
+    return payload
+
+
+@app.post("/api/queue/purge-stale")
+async def purge_stale_queue(
+    request: Request,
+    *,
+    principal: Principal = Depends(require_scope("workflows.control")),  # noqa: B008
+) -> dict:
+    """Cancel every queued run waiting longer than min_age minutes.
+
+    Body: {"min_age": 60, "dry_run": false}
+    Busts queue/diagnose/stale caches on success.
+    """
+    body = await request.json()
+    min_age = int(body.get("min_age", 60))
+    dry_run = bool(body.get("dry_run", False))
+    result = await queue_cleanup.purge_stale_runs(ORG, min_age, dry_run=dry_run)
+    if not dry_run and result.get("cancelled_count", 0) > 0:
+        _cache.pop("queue", None)
+        _cache.pop("diagnose", None)
+        for key in list(_cache.keys()):
+            if key.startswith("stale_queue_"):
+                _cache.pop(key, None)
+    return result
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -6750,6 +6750,7 @@ async def purge_stale_queue(
                 _cache.pop(key, None)
     return result
 
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":

--- a/deploy/scheduled-dashboard-maintenance.sh
+++ b/deploy/scheduled-dashboard-maintenance.sh
@@ -258,6 +258,28 @@ verify_dashboard() {
     ok "Dashboard is enabled, restarted, and responding on port ${PORT}"
 }
 
+purge_stale_queue() {
+    # Cancel queued runs older than STALE_QUEUE_AGE_MINUTES (default 120 min).
+    local age="${STALE_QUEUE_AGE_MINUTES:-120}"
+    local script
+    script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../Repository_Management/scripts/cancel_stale_queue.py"
+    if command -v python3 >/dev/null 2>&1 && [[ -f "${script}" ]]; then
+        info "Purging stale queue (runs queued > ${age} min)"
+        python3 "${script}" --cancel --min-age "${age}" || warn "Stale queue purge exited non-zero"
+        return
+    fi
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT:-8321}/api/health" >/dev/null 2>&1; then
+        info "Purging stale queue via dashboard API (runs queued > ${age} min)"
+        curl -fsS --max-time 60 -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"min_age\": ${age}, \"dry_run\": false}" \
+            "http://127.0.0.1:${PORT:-8321}/api/queue/purge-stale" \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'  Cancelled {d[\"cancelled_count\"]}/{d[\"stale_count\"]} stale run(s)')" \
+            || warn "Stale queue API purge failed"
+    else
+        warn "Dashboard not reachable; skipping stale queue purge (will retry next run)"
+    fi
+}
 main() {
     info "Runner dashboard scheduled maintenance"
     echo "Repo:       ${REPO_ROOT}"
@@ -275,6 +297,7 @@ main() {
     deploy_dashboard
     install_autoscaler_if_requested
     verify_dashboard
+    purge_stale_queue
     ok "Scheduled dashboard maintenance complete"
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5479,6 +5479,119 @@
       }
 
       // ════════════════════════ QUEUE TAB ════════════════════════
+
+      // STALE QUEUE CLEANUP PANEL
+      function StaleQueuePanel(p) {
+        var onRefresh = p.onRefresh;
+        var minAgeState = React.useState(60);
+        var minAge = minAgeState[0], setMinAge = minAgeState[1];
+        var scanState = React.useState(null);
+        var scanResult = scanState[0], setScanResult = scanState[1];
+        var loadingState = React.useState(false);
+        var loading = loadingState[0], setLoading = loadingState[1];
+        var purgeLoadingState = React.useState(false);
+        var purgeLoading = purgeLoadingState[0], setPurgeLoading = purgeLoadingState[1];
+        var confirmState = React.useState(false);
+        var confirmArmed = confirmState[0], setConfirmArmed = confirmState[1];
+        var msgState = React.useState(null);
+        var msg = msgState[0], setMsg = msgState[1];
+        function ageColor(mins) {
+          if (mins > 10080) return "var(--accent-red)";
+          if (mins > 1440)  return "#f0883e";
+          if (mins > 60)    return "var(--accent-yellow)";
+          return "var(--text-muted)";
+        }
+        function fmtAge(mins) {
+          if (mins < 60) return mins + "m";
+          var h = Math.floor(mins / 60);
+          if (h < 24) return h + "h " + (mins % 60) + "m";
+          return Math.floor(h / 24) + "d " + (h % 24) + "h";
+        }
+        function runScan() {
+          setLoading(true); setScanResult(null); setMsg(null); setConfirmArmed(false);
+          fetch("/api/queue/stale?min_age=" + minAge)
+            .then(function(r) { return r.json(); })
+            .then(function(d) { setScanResult(d); setLoading(false); })
+            .catch(function() { setMsg({ type: "error", text: "Scan failed" }); setLoading(false); });
+        }
+        function armPurge() {
+          setConfirmArmed(true);
+          setTimeout(function() { setConfirmArmed(function(c) { return c ? false : c; }); }, 6000);
+        }
+        function executePurge(dryRun) {
+          setPurgeLoading(true); setConfirmArmed(false);
+          fetch("/api/queue/purge-stale", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
+            body: JSON.stringify({ min_age: minAge, dry_run: dryRun }),
+          })
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+              setPurgeLoading(false);
+              var errPart = d.errors && d.errors.length ? " (errors: " + d.errors.length + ")" : "";
+              setMsg({ type: dryRun ? "info" : (d.cancelled_count > 0 ? "success" : "info"),
+                text: dryRun ? "Dry run: would cancel " + d.stale_count + " run(s)"
+                             : "Cancelled " + d.cancelled_count + " / " + d.stale_count + " stale run(s)" + errPart });
+              if (!dryRun) { setScanResult(null); if (onRefresh) setTimeout(onRefresh, 1500); }
+            })
+            .catch(function() { setPurgeLoading(false); setMsg({ type: "error", text: "Purge failed" }); });
+        }
+        var staleRuns = (scanResult && scanResult.runs) || [];
+        var staleCount = (scanResult && scanResult.stale_count) || 0;
+        return h("div", { style: { marginTop: 24, borderTop: "1px solid var(--border)", paddingTop: 16 } },
+          h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: 10 } },
+            h("span", { style: { fontWeight: 600, fontSize: 13 } }, "Stale Queue Cleanup"),
+            h("span", { style: { fontSize: 11, color: "var(--text-muted)" } }, "\u2014 scans all repos, not just recent 15"),
+          ),
+          h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: 10, flexWrap: "wrap" } },
+            h("label", { style: { fontSize: 12, color: "var(--text-muted)" } }, "Min age (min):"),
+            h("input", { type: "number", min: 0, value: minAge,
+              onChange: function(e) { setMinAge(parseInt(e.target.value, 10) || 0); },
+              style: { width: 70, padding: "3px 6px", borderRadius: 4, border: "1px solid var(--border)",
+                background: "var(--bg-secondary)", color: "var(--text-primary)", fontSize: 12 } }),
+            h("button", { className: "btn", onClick: runScan, disabled: loading, style: { fontSize: 12 } },
+              loading ? h("span", { className: "spinner" }) : null, loading ? " Scanning..." : "Scan all repos"),
+            staleCount > 0 && !purgeLoading
+              ? (confirmArmed
+                ? h("span", { style: { display: "flex", gap: 6 } },
+                    h("button", { className: "btn", onClick: function() { executePurge(false); },
+                      style: { fontSize: 12, background: "var(--accent-red)", color: "#fff" } },
+                      "Confirm: cancel " + staleCount + " run(s)"),
+                    h("button", { className: "btn", onClick: function() { setConfirmArmed(false); }, style: { fontSize: 12 } }, "Never mind"))
+                : h("button", { className: "btn", onClick: armPurge,
+                    style: { fontSize: 12, borderColor: "var(--accent-red)", color: "var(--accent-red)" } },
+                    "Purge " + staleCount + " stale run(s)"))
+              : null,
+            staleCount > 0
+              ? h("button", { className: "btn", onClick: function() { executePurge(true); }, disabled: purgeLoading, style: { fontSize: 12 } }, "Dry run")
+              : null,
+          ),
+          msg ? h("div", { role: "alert", style: {
+              margin: "0 0 10px", padding: "8px 14px", borderRadius: 6, fontSize: 12,
+              background: msg.type === "error" ? "rgba(248,81,73,0.12)" : msg.type === "success" ? "rgba(63,185,80,0.12)" : "rgba(88,166,255,0.12)",
+              color: msg.type === "error" ? "var(--accent-red)" : msg.type === "success" ? "var(--accent-green)" : "var(--accent-blue)",
+              border: "1px solid " + (msg.type === "error" ? "var(--accent-red)" : msg.type === "success" ? "var(--accent-green)" : "var(--accent-blue)"),
+            } }, msg.text) : null,
+          scanResult && staleCount === 0
+            ? h("div", { style: { fontSize: 12, color: "var(--accent-green)", padding: "6px 0" } },
+                "No stale runs found (queued > " + minAge + " min across all repos)") : null,
+          staleRuns.length > 0
+            ? h("div", { style: { overflowX: "auto" } },
+                h("table", { className: "data-table", style: { fontSize: 12, width: "100%" } },
+                  h("thead", null, h("tr", null,
+                    h("th", null, "Age"), h("th", null, "Repo"), h("th", null, "Workflow"),
+                    h("th", null, "Branch"), h("th", null, "Queued at"))),
+                  h("tbody", null, staleRuns.map(function(r) {
+                    return h("tr", { key: r.run_id },
+                      h("td", null, h("span", { style: { fontWeight: 600, color: ageColor(r.age_minutes) } }, fmtAge(r.age_minutes))),
+                      h("td", null, h("code", { style: { fontSize: 11 } }, r.repo)),
+                      h("td", null, r.workflow),
+                      h("td", null, h("code", { style: { fontSize: 11 } }, r.branch)),
+                      h("td", { style: { color: "var(--text-muted)" } }, r.created_at ? new Date(r.created_at).toLocaleString() : "-"));
+                  })))) : null,
+        );
+      }
+
       function QueueTab(p) {
         var q = p.queue || {};
         var loading = p.loading;
@@ -6493,6 +6606,7 @@
                   "Queue is empty \u2014 all runners idle",
                 ),
           ),
+          h(StaleQueuePanel, { onRefresh: onRefresh }),
         );
       }
 


### PR DESCRIPTION
Fixes the 53000-minute and 1100-minute job backlog. Adds full-org stale scanning, POST /api/queue/purge-stale, a Stale Queue Cleanup panel in the Queue tab, and a nightly scheduled-maintenance hook. See commit for full details.