### PR TITLE
fix(frontend): restore missing PROVIDERS_WITH_MODEL - fixes black screen

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15100,6 +15100,8 @@
         );
       }
 
+      var PROVIDERS_WITH_MODEL = ["claude_code_cli", "codex_cli", "jules_api"];
+
       // ════════════════════════ QUICK DISPATCH POPOVER ════════════════════════
       function QuickDispatchPopover() {
         var os = React.useState(false);


### PR DESCRIPTION
## Root cause

The variable PROVIDERS_WITH_MODEL was silently dropped during a merge between b65ac31 and current HEAD. It is referenced in two places inside QuickDispatchPopover but was never declared, causing a ReferenceError during React render. React 18 catches this internally and unmounts the entire tree — producing the blank/black screen.

## Fix

Restored as a module-level var before QuickDispatchPopover:
  var PROVIDERS_WITH_MODEL = ["claude_code_cli", "codex_cli", "jules_api"];

## Verification

Node.js React-stub test confirms full App component tree renders without errors after this change.
