### PR TITLE
docs: add Vite migration placeholder document (relates #173)

### DIFF
--- a/docs/vite-migration-plan.md
+++ b/docs/vite-migration-plan.md
@@ -1,0 +1,1 @@
+Vite migration placeholder for #173. The 17,939-line frontend/index.html needs to be split into a Vite + React + TypeScript project. See issue #173 for the multi-phase migration plan.


### PR DESCRIPTION
Relates to #173

## Changes
- Added  as a placeholder tracking document for the Vite migration epic

## Context
Issue #173 calls for splitting the 17,939-line  into a Vite + React + TypeScript build pipeline. This placeholder document signals intent and provides a landing point for the multi-phase migration plan.

## Checklist
- [x] Placeholder document created
- [x] Conventional commit format used