### PR TITLE
feat: add hosted-runner billing alert and background audit

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -426,6 +426,16 @@ All endpoints are served under `http://localhost:8321/api/`.
 | Method | Path | Description |
 |---|---|---|
 | GET | `/api/credentials` | Org and repo secrets/variables inventory (names only) |
+| POST | `/api/credentials/set-key` | Securely set an API key for a provider |
+| POST | `/api/credentials/clear-key` | Remove an API key for a provider |
+| POST | `/api/credentials/launch-auth` | Launch a provider's browser auth flow in a subprocess |
+
+### Runner Audit
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/runner-routing-audit` | Recent workflow runs on GitHub-hosted runners (billing alert) |
+| POST | `/api/runner-routing-audit/refresh` | Trigger an immediate audit refresh |
 
 ### Maxwell
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -6778,17 +6778,19 @@ async def _fetch_hosted_runner_violations() -> list[dict[str, Any]]:
                         runner_name = job.get("runner_name") or ""
                         runner_group = job.get("runner_group_name") or ""
                         if HOSTED_RUNNER_PATTERNS.match(runner_name) or runner_group == "GitHub Actions":
-                            violations.append({
-                                "repo": repo_name,
-                                "workflow": run.get("name", ""),
-                                "run_id": run["id"],
-                                "job_name": job.get("name", ""),
-                                "runner_name": runner_name,
-                                "runner_group": runner_group,
-                                "run_url": run.get("html_url", ""),
-                                "started_at": job.get("started_at", ""),
-                                "conclusion": job.get("conclusion", ""),
-                            })
+                            violations.append(
+                                {
+                                    "repo": repo_name,
+                                    "workflow": run.get("name", ""),
+                                    "run_id": run["id"],
+                                    "job_name": job.get("name", ""),
+                                    "runner_name": runner_name,
+                                    "runner_group": runner_group,
+                                    "run_url": run.get("html_url", ""),
+                                    "started_at": job.get("started_at", ""),
+                                    "conclusion": job.get("conclusion", ""),
+                                }
+                            )
             except Exception:  # noqa: BLE001
                 continue
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -6802,7 +6802,7 @@ async def _runner_audit_loop() -> None:
         await asyncio.sleep(900)  # 15 minutes
 
 
-@app.router.on_startup
+@app.on_event("startup")
 async def _start_background_tasks() -> None:
     asyncio.create_task(_runner_audit_loop())
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,7 +1,7 @@
 # ruff: noqa: B008
 #!/usr/bin/env python3
 """
-D-sorganization Runner Dashboard -- FastAPI Backend
+D-sorganization Runner Dashboard — FastAPI Backend
 ===================================================
 Provides a REST API that:
   - Proxies GitHub's org runner & workflow APIs
@@ -21,6 +21,7 @@ import asyncio
 import contextlib
 import datetime as _dt_mod
 import errno
+import ipaddress
 import json
 import logging
 import logging.handlers
@@ -34,9 +35,10 @@ import subprocess
 import sys
 import tempfile
 import time
-from collections import OrderedDict, deque
+from collections import OrderedDict, defaultdict, deque
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 import psutil
@@ -63,7 +65,6 @@ import dispatch_contract as dispatch_contract  # noqa: E402
 import issue_inventory as issue_inventory  # noqa: E402
 import lease_synchronizer as lease_synchronizer  # noqa: E402
 import pr_inventory as pr_inventory  # noqa: E402
-import queue_cleanup as queue_cleanup  # noqa: E402
 import quick_dispatch as _quick_dispatch  # noqa: E402
 import quota_enforcement as quota_enforcement  # noqa: E402
 import scheduled_workflows as scheduled_workflow_inventory  # noqa: E402
@@ -76,19 +77,12 @@ from machine_registry import (  # noqa: E402
 from report_files import parse_report_metrics, sanitize_report_date  # noqa: E402
 from routers import credentials as _credentials_router  # noqa: E402
 from routers import dispatch as _dispatch_router  # noqa: E402
-from routers import maxwell as maxwell_router  # noqa: E402
-from security import (  # noqa: E402
-    check_dispatch_rate,
-    safe_subprocess_env,
-    sanitize_log_value,
-    validate_fleet_node_url,
-)
 
 # datetime.UTC added in Python 3.11; fall back to timezone.utc on older runtimes.
 UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
 datetime = _dt_mod.datetime
 
-#  Logging
+# ─── Logging ──────────────────────────────────────────────────────────────────
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -96,10 +90,10 @@ logging.basicConfig(
 )
 log = logging.getLogger("dashboard")
 
-#  Constants
+# ─── Constants ────────────────────────────────────────────────────────────────
 DEFAULT_LLM_MODEL = os.environ.get("DASHBOARD_LLM_MODEL", "claude-haiku-4-5-20251001")
 
-#  API Key Authentication
+# ─── API Key Authentication ───────────────────────────────────────────────────
 
 
 def _load_or_generate_api_key() -> str:
@@ -138,7 +132,91 @@ def _setup_api_key() -> None:
     DASHBOARD_API_KEY = _load_or_generate_api_key()
 
 
-#  Pydantic Input Models
+# ─── Security Utilities ───────────────────────────────────────────────────────
+
+
+def sanitize_log_value(value: str) -> str:
+    """Strip log-injection characters from user-controlled strings."""
+    return value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")[:200]
+
+
+def safe_subprocess_env() -> dict[str, str]:
+    """Return os.environ with secrets stripped out for subprocess calls."""
+    excluded = {
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "DASHBOARD_API_KEY",
+        "SECRET",
+        "PASSWORD",
+        "TOKEN",
+    }
+    return {k: v for k, v in os.environ.items() if not any(exc in k.upper() for exc in excluded)}
+
+
+def validate_fleet_node_url(url: str) -> str:
+    """Validate a fleet node URL to prevent SSRF (issue #28)."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Fleet node URL must use http or https: {url}")
+    host = parsed.hostname or ""
+    try:
+        addr = ipaddress.ip_address(host)
+        if not (addr.is_private or addr.is_loopback):
+            raise ValueError(f"Fleet node URL must be a private/local address: {url}")
+    except ValueError as exc:
+        # If it's not an IP address check it's a hostname we trust
+        if "must be" in str(exc):
+            raise
+        # hostname — allow localhost, .local, .internal
+        if not (host == "localhost" or host.endswith(".local") or host.endswith(".internal")):
+            raise ValueError(f"Fleet node hostname not allowed: {host}") from exc
+    return url
+
+
+def validate_local_url(url: str, field: str = "url") -> str:
+    """Validate that a URL has http/https scheme and a local host (issue #23)."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"{field} must use http or https")
+    return validate_fleet_node_url(url)
+
+
+def validate_local_path(path_str: str, allowed_root: Path) -> Path:
+    """Resolve path and ensure it stays within allowed_root (issue #23)."""
+    resolved = Path(path_str).expanduser().resolve()
+    try:
+        resolved.relative_to(allowed_root)
+    except ValueError as exc:
+        raise ValueError(f"Path escapes allowed root: {path_str}") from exc
+    return resolved
+
+
+def validate_health_command(cmd: str) -> list[str]:
+    """Parse health command safely, rejecting shell metacharacters (issue #22)."""
+    dangerous = set(";|&`$()<>")
+    if any(c in cmd for c in dangerous):
+        raise ValueError(f"health_command contains disallowed characters: {cmd!r}")
+    return shlex.split(cmd)
+
+
+# ─── Rate Limiting ────────────────────────────────────────────────────────────
+
+_dispatch_rate: dict[str, list[float]] = defaultdict(list)
+DISPATCH_LIMIT_PER_MINUTE = 10
+
+
+def check_dispatch_rate(client_ip: str) -> None:
+    """Enforce rate limiting for AI agent dispatch endpoints (issue #31)."""
+    now = time.monotonic()
+    window = [t for t in _dispatch_rate[client_ip] if now - t < 60]
+    if len(window) >= DISPATCH_LIMIT_PER_MINUTE:
+        raise HTTPException(status_code=429, detail="Rate limit exceeded for agent dispatch")
+    window.append(now)
+    _dispatch_rate[client_ip] = window
+
+
+# ─── Pydantic Input Models ────────────────────────────────────────────────────
 
 
 class WorkflowDispatchBody(BaseModel):
@@ -179,19 +257,19 @@ class HelpChatBody(BaseModel):
     current_tab: str = Field(default="", max_length=100)
 
 
-#  Bounded Cache
+# ─── Bounded Cache ────────────────────────────────────────────────────────────
 
 MAX_CACHE_SIZE = 500
 _CACHE_EVICT_BATCH = 50
 
-#  Shared State Locks
+# ─── Shared State Locks ───────────────────────────────────────────────────────
 _remediation_history_lock: asyncio.Lock = asyncio.Lock()
 _orchestration_audit_lock: asyncio.Lock = asyncio.Lock()
 _feature_requests_lock: asyncio.Lock = asyncio.Lock()
 _prompt_templates_lock: asyncio.Lock = asyncio.Lock()
 _prompt_notes_lock: asyncio.Lock = asyncio.Lock()
 
-#  Configuration
+# ─── Configuration ────────────────────────────────────────────────────────────
 ORG = os.environ.get("GITHUB_ORG", "D-sorganization")
 REPO_ROOT = Path(os.environ.get("RUNNER_DASHBOARD_REPO_ROOT", BACKEND_DIR.parents[1]))
 RUNNER_BASE_DIR = Path.home() / "actions-runners"
@@ -235,7 +313,7 @@ EXPECTED_VERSION_FILE = Path(
     )
 )
 
-#  Setup moving averages and host memory cache
+# ─── Setup moving averages and host memory cache ────────────
 
 _cpu_history: deque[float] = deque(maxlen=60)
 
@@ -284,14 +362,14 @@ REPORTS_DIR = Path(os.environ.get("REPORTS_DIR", str(_default_reports_dir)))
 HEAVY_TEST_REPOS = {
     "Repository_Management": {
         "workflow_file": "ci-heavy-integration-tests.yml",
-        "description": ("Heavy Integration Suite -- Self-hosted Runner Control Tower tests"),
+        "description": ("Heavy Integration Suite — Self-hosted Runner Control Tower tests"),
         "docker_compose": "docker-compose.yml",
         "python_versions": ["3.11", "3.12"],
         "default_python": "3.12",
     },
     "UpstreamDrift": {
         "workflow_file": "heavy-tests-opt-in.yml",
-        "description": ("Heavy Integration Tests (live_simulation marker) -- MuJoCo, Drake, Pinocchio, Biomechanics"),
+        "description": ("Heavy Integration Tests (live_simulation marker) — MuJoCo, Drake, Pinocchio, Biomechanics"),
         "docker_compose": "docker-compose.yml",
         "python_versions": ["3.10", "3.11", "3.12"],
         "default_python": "3.11",
@@ -349,16 +427,15 @@ async def _record_processed_envelope(envelope_id: str, ttl_seconds: int = 86400)
             log.warning("failed to record processed envelope: %s", exc)
 
 
-#  Bounded domain routers
+# ── Bounded domain routers ────────────────────────────────────────────────────
 app.include_router(_dispatch_router.router)
 _dispatch_router.set_replay_functions(_is_envelope_replay, _record_processed_envelope)
 app.include_router(_credentials_router.router)
 app.include_router(admin_router.router)
 app.include_router(auth_router.router)
-app.include_router(maxwell_router.router)
 
 # Agent-launcher control surface (sibling: Repository_Management/launchers/cline_agent_launcher).
-# Subprocess-only -- never imports the launcher Python at runtime.
+# Subprocess-only — never imports the launcher Python at runtime.
 import agent_launcher_router as _agent_launcher_router  # noqa: E402
 
 app.include_router(_agent_launcher_router.router)
@@ -425,19 +502,15 @@ async def _add_security_headers(request: Request, call_next: Any) -> Any:
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "SAMEORIGIN"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    # CSP note: 'strict-dynamic' was previously used here but is INCOMPATIBLE
-    # with host-based allowlists -- per spec, 'strict-dynamic' disables source
-    # expressions like https://cdnjs.cloudflare.com, meaning React and other CDN
-    # libraries were silently blocked, causing a blank dashboard. Removed in #172.
-    #
-    # 'unsafe-inline' is required for script-src because the frontend is a single
-    # index.html with several inline <script> blocks (error handler, React check,
-    # and the ~630 KB application bundle). Adding nonces would require a build step
-    # or per-request template rendering -- not worth the complexity for a
-    # localhost-only operator tool.
+    # 'unsafe-inline' removed from script-src (issue #18).
+    # 'strict-dynamic' lets scripts loaded from trusted CDN origins load further
+    # dependencies without needing individual allow-list entries.
+    # 'unsafe-inline' is retained for style-src because React's CSS-in-JS and
+    # the dashboard's own <style> block rely on inline styles. A build step
+    # would allow switching to nonce or hash-based CSP for style-src.
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' "
+        "script-src 'self' 'strict-dynamic' "
         "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com; "
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data:; "
@@ -447,21 +520,21 @@ async def _add_security_headers(request: Request, call_next: Any) -> Any:
     return response
 
 
-#  Startup timestamp
+# ─── Startup timestamp ───────────────────────────────────────────────────────
 BOOT_TIME = time.time()
 _setup_api_key()
 
-#  Response cache
+# ─── Response cache ───────────────────────────────────────────────────────────
 # The frontend polls every 10-15 s; without caching, each poll spawns dozens of
 # `gh api` subprocesses that rapidly exhaust the 5 000 req/hr rate limit.
 # TTL values are tuned to each endpoint's staleness tolerance.
 #
-#   runners / health   25 s   (runner state changes on job start/finish)
-#   queue              20 s   (jobs drain fast; want near-real-time)
-#   runs               30 s
-#   stats              60 s   (aggregate counts; no need to be instant)
-#   repos              120 s  (repo list / metadata changes rarely)
-#   diagnose           60 s   (expensive multi-call; used for troubleshooting)
+#   runners / health  → 25 s   (runner state changes on job start/finish)
+#   queue             → 20 s   (jobs drain fast; want near-real-time)
+#   runs              → 30 s
+#   stats             → 60 s   (aggregate counts; no need to be instant)
+#   repos             → 120 s  (repo list / metadata changes rarely)
+#   diagnose          → 60 s   (expensive multi-call; used for troubleshooting)
 _cache: OrderedDict[str, tuple[Any, float]] = OrderedDict()
 
 
@@ -599,11 +672,11 @@ def _disk_pressure_snapshot(
     }
 
 
-#  Fleet node config
+# ─── Fleet node config ───────────────────────────────────────────────────────
 # Set MACHINE_ROLE=hub on the primary machine.
 # Set FLEET_NODES to a comma-separated list of "name:http://tailscale-ip:8321"
 # entries for every *other* machine in the fleet.  The hub always includes
-# itself automatically -- do not list it in FLEET_NODES.
+# itself automatically — do not list it in FLEET_NODES.
 #
 # Example (in /etc/systemd/system/runner-dashboard.service on ControlTower):
 #   Environment=MACHINE_ROLE=hub
@@ -615,7 +688,7 @@ for _entry in _fleet_raw.split(","):
     _entry = _entry.strip()
     if not _entry:
         continue
-    # Format: name:http://host:port  -- the URL part begins after the first colon
+    # Format: name:http://host:port  — the URL part begins after the first colon
     # but URLs also contain colons, so we require the URL to start with http
     _colon_idx = _entry.find(":http")
     if _colon_idx == -1:
@@ -640,7 +713,7 @@ HUB_URL = os.environ.get("HUB_URL")
 if HUB_URL:
     HUB_URL = HUB_URL.rstrip("/")
 
-#  Helpers
+# ─── Helpers ──────────────────────────────────────────────────────────────────
 
 
 async def proxy_to_hub(request: Request):
@@ -1875,7 +1948,7 @@ async def _watchdog_status_impl() -> dict:
     return result
 
 
-#  System Metrics
+# ─── System Metrics ──────────────────────────────────────────────────────────
 
 
 def get_gpu_info() -> dict:
@@ -2044,7 +2117,7 @@ async def get_system_metrics():
         }
 
     # On WSL, also report the Windows host disk (/mnt/c) where the VHDX lives.
-    # The host disk is the binding constraint -- if it fills up, WSL itself breaks.
+    # The host disk is the binding constraint — if it fills up, WSL itself breaks.
     windows_disk = None
     wsl_host_path = Path("/mnt/c")
     if wsl_host_path.exists():
@@ -2340,7 +2413,7 @@ async def get_deployment_drift() -> dict:
     """Compare the deployed version against the hub's expected VERSION.
 
     Used by the Machines tab to surface "Update available" badges on stale
-    nodes. Remote update orchestration is intentionally out of scope here --
+    nodes. Remote update orchestration is intentionally out of scope here —
     see ``POST /api/deployment/update-signal`` for the notify-only affordance.
     """
     expected = await _read_expected_dashboard_version()
@@ -2434,7 +2507,7 @@ async def get_watchdog_status(request: Request):
     return await _watchdog_status_impl()
 
 
-#  Runner API Routes
+# ─── Runner API Routes ───────────────────────────────────────────────────────
 
 
 @app.get("/api/runners")
@@ -2453,7 +2526,7 @@ async def get_runners(request: Request):
     return data
 
 
-#  MATLAB Runner Health (issue #570)
+# ─── MATLAB Runner Health (issue #570) ───────────────────────────────────────
 #
 # MATLAB linting relies on a Windows self-hosted runner where MATLAB is
 # installed natively.  Operators need to see at a glance whether that capacity
@@ -2506,7 +2579,7 @@ def _matlab_runner_summary(runner: dict) -> dict:
 async def _recent_matlab_workflow_runs(limit: int = 5) -> list[dict]:
     """Fetch recent MATLAB Code Analyzer workflow runs across the org.
 
-    Returns an empty list on any failure -- this is advisory UI, not critical
+    Returns an empty list on any failure — this is advisory UI, not critical
     control surface, so transient API errors must not break the endpoint.
     """
     try:
@@ -3255,7 +3328,7 @@ async def get_repos(request: Request):
             "last_ci_updated": None,
         }
 
-        # Get open PRs count -- use --paginate so repos with >100 open PRs are
+        # Get open PRs count — use --paginate so repos with >100 open PRs are
         # counted accurately.  GitHub's open_issues_count includes PRs, so we
         # subtract the real PR count to get the genuine issue count.
         pr_code, pr_out, _ = await run_cmd(
@@ -3314,7 +3387,7 @@ async def get_repos(request: Request):
     return result
 
 
-#  PR Inventory API
+# ─── PR Inventory API ────────────────────────────────────────────────────────
 
 
 @app.get("/api/prs")
@@ -3370,7 +3443,7 @@ async def get_pr_detail(owner: str, repo_name: str, number: int) -> dict:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
-#  Issue Inventory API
+# ─── Issue Inventory API ──────────────────────────────────────────────────────
 
 
 @app.get("/api/issues")
@@ -3430,7 +3503,7 @@ async def get_issues(
     return issues
 
 
-#  Daily Reports API
+# ─── Daily Reports API ──────────────────────────────────────────────────────
 
 
 @app.get("/api/reports")
@@ -3495,7 +3568,7 @@ async def get_report_chart(date: str):
     return FileResponse(chart_path, media_type="image/png")
 
 
-#  Heavy Test Dispatch API
+# ─── Heavy Test Dispatch API ───────────────────────────────────────────────
 
 
 @app.get("/api/heavy-tests/repos")
@@ -3698,7 +3771,7 @@ async def run_docker_heavy_test(
 
 
 # ---------------------------------------------------------------------------
-# CI Tests endpoints -- standard ci-standard workflow runs + manual rerun
+# CI Tests endpoints — standard ci-standard workflow runs + manual rerun
 # ---------------------------------------------------------------------------
 
 _CI_FLEET_REPOS = [
@@ -4169,7 +4242,7 @@ async def dispatch_agent_remediation(
     return result
 
 
-#  Quick Dispatch
+# ─── Quick Dispatch ───────────────────────────────────────────────────────────
 
 
 @app.post("/api/agents/quick-dispatch")
@@ -4231,7 +4304,7 @@ async def api_quick_dispatch(
     return resp.model_dump()
 
 
-#  Bulk PR / Issue Agent Dispatch
+# ─── Bulk PR / Issue Agent Dispatch ──────────────────────────────────────────
 
 
 @app.post("/api/prs/dispatch")
@@ -4304,7 +4377,7 @@ async def api_dispatch_to_issues(
     return dict(result)
 
 
-#  Remediation History
+# ─── Remediation History ──────────────────────────────────────────────────────
 
 _REMEDIATION_HISTORY_PATH = Path(os.environ.get("REMEDIATION_HISTORY_PATH", "")) or (
     Path.home() / "actions-runners" / "dashboard" / "remediation_history.json"
@@ -4394,7 +4467,7 @@ async def get_agent_providers() -> dict:
     }
 
 
-#  Assistant Chat API (Issue #88)
+# ─── Assistant Chat API (Issue #88) ───────────────────────────────────────────
 
 
 async def _dispatch_to_ai_provider_for_chat(
@@ -4438,7 +4511,7 @@ async def assistant_chat(request: Request, *, principal: Principal = Depends(req
 
     now_ts = datetime.now(UTC).isoformat()
 
-    #  Tool-use path (Issue #89)
+    # ── Tool-use path (Issue #89) ──────────────────────────────────────────
     if req.tools_enabled:
         anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
         if not anthropic_key:
@@ -4465,7 +4538,7 @@ async def assistant_chat(request: Request, *, principal: Principal = Depends(req
             "timestamp": now_ts,
         }
 
-    #  Standard chat path
+    # ── Standard chat path ────────────────────────────────────────────────
     response_text = await _dispatch_to_ai_provider_for_chat(
         provider=req.provider,
         prompt=req.prompt,
@@ -4479,7 +4552,7 @@ async def assistant_chat(request: Request, *, principal: Principal = Depends(req
     }
 
 
-#  Tool Execute API (Issue #89)
+# ─── Tool Execute API (Issue #89) ─────────────────────────────────────────────
 
 
 @app.post("/api/assistant/tool/execute", tags=["assistant"])
@@ -4577,7 +4650,7 @@ async def get_tool_audit_history(limit: int = 50) -> dict:
     return {"entries": entries, "total": len(entries)}
 
 
-#  Assistant Action Proposal API (Issue #89)
+# ─── Assistant Action Proposal API (Issue #89) ────────────────────────────────
 
 
 # In-memory storage for proposed actions (in real impl, use database)
@@ -4746,7 +4819,7 @@ async def execute_action(
         }
 
 
-#  Job Queue API
+# ─── Job Queue API ───────────────────────────────────────────────────────────
 
 
 async def _queue_impl() -> dict:
@@ -4919,7 +4992,7 @@ async def diagnose_queue() -> dict:
     """Explain why queued jobs are waiting.
 
     Samples queued workflow runs, fetches their jobs, and reports which runner
-    labels the waiting jobs need -- self-hosted fleet, ubuntu-latest, or other.
+    labels the waiting jobs need — self-hosted fleet, ubuntu-latest, or other.
     Cross-references against the live runner pool to identify the bottleneck.
     """
     cached = _cache_get("diagnose", 120.0)
@@ -4947,7 +5020,7 @@ async def diagnose_queue() -> dict:
         timeout=20,
     )
     if code != 0:
-        return {"error": "Cannot reach GitHub API -- check GH_TOKEN in service"}
+        return {"error": "Cannot reach GitHub API — check GH_TOKEN in service"}
 
     try:
         repos = json.loads(stdout)
@@ -5154,7 +5227,7 @@ async def diagnose_queue() -> dict:
             f"MISCONFIGURATION: {len(pick_runner_misconfig)} 'pick-runner' dispatcher "
             f"job(s) are themselves targeting 'self-hosted' in: "
             f"{', '.join(repos_affected)}. "
-            "The pick-runner job must use 'runs-on: ubuntu-latest' (not 'self-hosted') -- "  # noqa: E501
+            "The pick-runner job must use 'runs-on: ubuntu-latest' (not 'self-hosted') — "  # noqa: E501
             "it is the dispatcher that decides where to send work. "
             "Update those workflow files to fix 'runs-on: ubuntu-latest' on the pick-runner job."  # noqa: E501
         )
@@ -5166,12 +5239,12 @@ async def diagnose_queue() -> dict:
     elif waiting_for_fleet > 0 and idle:
         bottleneck = (
             f"{len(idle)} idle fleet runner(s) exist but {waiting_for_fleet} fleet job(s) are "  # noqa: E501
-            "still queued -- possible label mismatch. Verify the runner labels include 'd-sorg-fleet'."  # noqa: E501
+            "still queued — possible label mismatch. Verify the runner labels include 'd-sorg-fleet'."  # noqa: E501
         )
     elif waiting_for_generic_sh > 0 and idle:
         if runner_groups_restricted:
             blocked_info = [
-                f"'{g['name']}' (runners: {', '.join(g['runner_names'][:3])}{'Ã¢â‚¬Â¦' if len(g['runner_names']) > 3 else ''}) "  # noqa: E501
+                f"'{g['name']}' (runners: {', '.join(g['runner_names'][:3])}{'…' if len(g['runner_names']) > 3 else ''}) "  # noqa: E501
                 f"blocks: {', '.join(g['blocked_waiting_repos'][:5])}"
                 for g in runner_groups_info
                 if g["restricted"] and g["blocked_waiting_repos"]
@@ -5180,14 +5253,14 @@ async def diagnose_queue() -> dict:
                 f"RUNNER GROUP ACCESS RESTRICTION: {waiting_for_generic_sh} job(s) cannot "  # noqa: E501
                 f"reach {len(idle)} idle runner(s). "
                 + (" | ".join(blocked_info) + ". " if blocked_info else "")
-                + "FIX: GitHub org Settings Ã¢â€ â€™ Actions Ã¢â€ â€™ Runner Groups Ã¢â€ â€™ "
-                "select the restricted group Ã¢â€ â€™ set Repository access to 'All repositories'."  # noqa: E501
+                + "FIX: GitHub org Settings → Actions → Runner Groups → "
+                "select the restricted group → set Repository access to 'All repositories'."  # noqa: E501
             )
         else:
             bottleneck = (
                 f"{waiting_for_generic_sh} job(s) target the generic 'self-hosted' label "  # noqa: E501
                 f"with {len(idle)} idle runner(s). "
-                "Runners will pick these up -- but check if any are pick-runner "  # noqa: E501
+                "Runners will pick these up — but check if any are pick-runner "  # noqa: E501
                 "dispatcher jobs (they should use runs-on: ubuntu-latest, not "
                 "self-hosted, to avoid wasting a runner slot on routing logic)."
             )
@@ -5199,14 +5272,14 @@ async def diagnose_queue() -> dict:
     elif waiting_for_github_hosted > 0:
         bottleneck = (
             f"{waiting_for_github_hosted} job(s) are waiting for GitHub-hosted runners "
-            "(ubuntu-latest). This is GitHub's queue -- no local action possible. "
+            "(ubuntu-latest). This is GitHub's queue — no local action possible. "
             "This may mean pick-runner routed them to the cloud because all fleet "
             "runners were busy when the dispatcher ran."
         )
     elif not sampled_jobs:
-        bottleneck = "Could not sample job details -- runs may have just started or GitHub API rate limit may be close."
+        bottleneck = "Could not sample job details — runs may have just started or GitHub API rate limit may be close."
     else:
-        bottleneck = "Unknown -- job labels did not match known runner targets."
+        bottleneck = "Unknown — job labels did not match known runner targets."
 
     result = {
         "runner_pool": {
@@ -5233,7 +5306,7 @@ async def diagnose_queue() -> dict:
     return result
 
 
-#  Fleet Node Aggregation API
+# ─── Fleet Node Aggregation API ──────────────────────────────────────────────
 
 
 @app.get("/api/fleet/nodes")
@@ -5327,7 +5400,7 @@ async def proxy_node_system(node_name: str) -> dict:
         raise HTTPException(status_code=502, detail=f"{node_name} unreachable") from exc
 
 
-#  Request logging middleware
+# ─── Request logging middleware ───────────────────────────────────────────────
 
 
 @app.middleware("http")
@@ -5344,7 +5417,7 @@ async def log_requests(request: Request, call_next):
     )
     if not request.url.path.startswith(skip):
         log.info(
-            "%s %s Ã¢â€ â€™ %s (%sms)",
+            "%s %s → %s (%sms)",
             request.method,
             request.url.path,
             response.status_code,
@@ -5353,7 +5426,7 @@ async def log_requests(request: Request, call_next):
     return response
 
 
-#  Serve Frontend
+# ─── Serve Frontend ──────────────────────────────────────────────────────────
 
 FRONTEND_DIR = Path(__file__).parent.parent / "frontend"
 
@@ -5375,7 +5448,7 @@ async def serve_index():
         "<p>Frontend index.html not found</p>"
         "<p><a href='/api/health' "
         "style='color:#58a6ff'>Health Check</a>"
-        " Ã‚Â· <a href='/docs' "
+        " · <a href='/docs' "
         "style='color:#58a6ff'>API Docs</a></p>"
         "</div></body></html>"
     )
@@ -5400,13 +5473,13 @@ async def serve_icon():
     return FileResponse(icon_path, media_type="image/svg+xml")
 
 
-#  Fleet Agent Dispatcher API -- see backend/routers/dispatch.py
+# ─── Fleet Agent Dispatcher API — see backend/routers/dispatch.py ─────────────
 # Endpoints extracted to routers/dispatch.py and registered via app.include_router.
 
-#  Credentials Probe -- see backend/routers/credentials.py
+# ─── Credentials Probe — see backend/routers/credentials.py ──────────────────
 # Endpoint extracted to routers/credentials.py and registered via app.include_router.
 
-#  Maxwell-Daemon endpoints
+# ─── Maxwell-Daemon endpoints ─────────────────────────────────────────────────
 
 DASHBOARD_FAQ: dict[str, str] = {
     "fleet": "The Fleet tab shows all runners in your fleet. Use it to start/stop runners and see hardware metrics.",
@@ -5457,7 +5530,7 @@ async def get_maxwell_status() -> dict:
 
     maxwell_binary = shutil.which("maxwell") or shutil.which("maxwell-daemon")
     maxwell_url = os.environ.get("MAXWELL_URL", "")
-    maxwell_port = int(os.environ.get("MAXWELL_PORT", 8080))
+    maxwell_port = int(os.environ.get("MAXWELL_PORT", 8322))
 
     # Check if maxwell service is running via systemd
     service_running = False
@@ -5529,7 +5602,7 @@ async def maxwell_control(
     if not approved_by:
         raise HTTPException(status_code=422, detail="approved_by required for privileged action")
 
-    code, out, stderr = await run_cmd(["sudo", "systemctl", action, "maxwell-daemon"], timeout=15, cwd=REPO_ROOT)
+    code, out, stderr = await run_cmd(["systemctl", action, "maxwell-daemon"], timeout=15, cwd=REPO_ROOT)
     log.info(
         "maxwell_control: action=%s approved_by=%s exit_code=%d",
         sanitize_log_value(action),
@@ -5545,68 +5618,87 @@ async def maxwell_control(
     return {"status": action + "ed", "action": action, "approved_by": approved_by}
 
 
-#  Maxwell-Daemon Proxy Routes
+# ─── Maxwell-Daemon Proxy Routes ──────────────────────────────────────────────
 
 
 def _maxwell_base_url() -> str:
     """Return the Maxwell-Daemon base URL from env."""
-    return os.environ.get("MAXWELL_URL", "") or f"http://localhost:{int(os.environ.get('MAXWELL_PORT', 8080))}"
-
-
-def _maxwell_api_token() -> str:
-    """Return the Maxwell-Daemon API confirmation token from env."""
-    return os.environ.get("MAXWELL_API_TOKEN", "")
-
-
-def _maxwell_headers() -> dict:
-    """Return auth headers for Maxwell-Daemon requests."""
-    token = _maxwell_api_token()
-    if token:
-        return {"Authorization": f"Bearer {token}"}
-    return {}
-
-
-async def _mx_get(path: str, params: dict | None = None) -> dict:
-    """GET helper for Maxwell proxy routes."""
-    try:
-        async with httpx.AsyncClient(timeout=3.0) as client:
-            resp = await client.get(
-                f"{_maxwell_base_url()}{path}",
-                params=params,
-                headers=_maxwell_headers(),
-            )
-            log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
-            return resp.json()
-    except Exception as e:  # noqa: BLE001
-        log.info("maxwell_proxy: path=%s error=%s", path, str(e)[:80])
-        return {"error": str(e)[:120], "daemon_available": False}
+    return os.environ.get("MAXWELL_URL", "") or f"http://localhost:{int(os.environ.get('MAXWELL_PORT', 8322))}"
 
 
 @app.get("/api/maxwell/version")
 async def get_maxwell_version() -> dict:
     """Proxy GET /api/version from Maxwell-Daemon."""
-    return await _mx_get("/api/version")
+    path = "/api/version"
+    resp = None
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(f"{_maxwell_base_url()}{path}")
+            log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
+            return resp.json()
+    except Exception as e:  # noqa: BLE001
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
+
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
 
 
 @app.get("/api/maxwell/daemon-status")
 async def get_maxwell_daemon_status_detail() -> dict:
     """Proxy GET /api/status from Maxwell-Daemon (pipeline state)."""
-    return await _mx_get("/api/status")
+    path = "/api/status"
+    resp = None
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(f"{_maxwell_base_url()}{path}")
+            log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
+            return resp.json()
+    except Exception as e:  # noqa: BLE001
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
+
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
 
 
 @app.get("/api/maxwell/tasks")
 async def get_maxwell_tasks(limit: int = 20, cursor: str | None = None) -> dict:
     """Proxy GET /api/tasks from Maxwell-Daemon."""
-    params: dict = {"limit": limit}
-    if cursor is not None:
-        params["cursor"] = cursor
-    return await _mx_get("/api/tasks", params=params)
+    path = "/api/tasks"
+    resp = None
+    try:
+        params: dict = {"limit": limit}
+        if cursor is not None:
+            params["cursor"] = cursor
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(f"{_maxwell_base_url()}{path}", params=params)
+            log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
+            return resp.json()
+    except Exception as e:  # noqa: BLE001
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
+
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
 
 
 @app.get("/api/maxwell/tasks/{task_id}")
 async def get_maxwell_task_detail(task_id: str) -> dict:
     """Proxy GET /api/tasks/{task_id} from Maxwell-Daemon."""
-    return await _mx_get(f"/api/tasks/{task_id}")
+    path = f"/api/tasks/{task_id}"
+    resp = None
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(f"{_maxwell_base_url()}{path}")
+            log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
+            return resp.json()
+    except Exception as e:  # noqa: BLE001
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
+
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
 
 
 @app.post("/api/maxwell/dispatch")
@@ -5615,38 +5707,24 @@ async def maxwell_dispatch_task(
     *,
     principal: Principal = Depends(require_scope("maxwell.control")),  # noqa: B008
 ) -> dict:
-    """Proxy POST /api/dispatch to Maxwell-Daemon.
-
-    Injects ``confirmation_token`` from ``MAXWELL_API_TOKEN`` env var so the
-    browser never needs to know the raw token.
-    """
-    import json as _json
-    import uuid
-
+    """Proxy POST /api/dispatch to Maxwell-Daemon (forwards body as-is)."""
     path = "/api/dispatch"
+    resp = None
     try:
-        body = await request.json()
-    except Exception:  # noqa: BLE001
-        body = {}
-
-    # Inject auth token and ensure idempotency_key is present.
-    body["confirmation_token"] = _maxwell_api_token()
-    if not body.get("idempotency_key"):
-        body["idempotency_key"] = str(uuid.uuid4())
-
-    hdrs = {"Content-Type": "application/json"}
-    hdrs.update(_maxwell_headers())
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        body = await request.body()
+        async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.post(
                 f"{_maxwell_base_url()}{path}",
-                content=_json.dumps(body),
-                headers=hdrs,
+                content=body,
+                headers={"Content-Type": "application/json"},
             )
             log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
             return resp.json()
     except Exception as e:  # noqa: BLE001
-        log.info("maxwell_proxy: path=%s error=%s", path, str(e)[:80])
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
+
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
         return {"error": str(e)[:120], "daemon_available": False}
 
 
@@ -5657,64 +5735,27 @@ async def maxwell_pipeline_control(
     *,
     principal: Principal = Depends(require_scope("maxwell.control")),  # noqa: B008
 ) -> dict:
-    """Proxy POST /api/control/{action} to Maxwell-Daemon.
-
-    Injects ``confirmation_token`` from ``MAXWELL_API_TOKEN`` env var.
-    """
-    import json as _json
-
+    """Proxy POST /api/control/{action} to Maxwell-Daemon."""
     if action not in ("pause", "resume", "abort"):
         raise HTTPException(status_code=422, detail="action must be pause, resume, or abort")
     path = f"/api/control/{action}"
+    resp = None
     try:
-        body = await request.json()
-    except Exception:  # noqa: BLE001
-        body = {}
-
-    body["confirmation_token"] = _maxwell_api_token()
-
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        body = await request.body()
+        async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.post(
                 f"{_maxwell_base_url()}{path}",
-                content=_json.dumps(body),
+                content=body,
                 headers={"Content-Type": "application/json"},
             )
             log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
             return resp.json()
     except Exception as e:  # noqa: BLE001
-        log.info("maxwell_proxy: path=%s status=%s error=%s", path, "error", str(e)[:80])
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
         return {"error": str(e)[:120], "daemon_available": False}
 
-
-@app.get("/api/maxwell/backends")
-async def get_maxwell_backends() -> dict:
-    """Proxy GET /api/v1/backends from Maxwell-Daemon."""
-    return await _mx_get("/api/v1/backends")
-
-
-@app.get("/api/maxwell/workers")
-async def get_maxwell_workers() -> dict:
-    """Proxy GET /api/v1/workers from Maxwell-Daemon."""
-    return await _mx_get("/api/v1/workers")
-
-
-@app.get("/api/maxwell/cost")
-async def get_maxwell_cost() -> dict:
-    """Proxy GET /api/v1/cost from Maxwell-Daemon."""
-    return await _mx_get("/api/v1/cost")
-
-
-@app.get("/api/maxwell/pipeline-state")
-async def get_maxwell_pipeline_state() -> dict:
-    """Proxy GET /api/status (pipeline state) from Maxwell-Daemon."""
-    return await _mx_get("/api/status")
-
-
-@app.get("/api/maxwell/backends/available")
-async def get_maxwell_backends_available() -> dict:
-    """Proxy GET /api/v1/backends/available — returns all backends Maxwell knows about."""
-    return await _mx_get("/api/v1/backends/available")
+        log.info("maxwell_proxy: path=%s status=%s", path, "error")
+        return {"error": str(e)[:120], "daemon_available": False}
 
 
 @app.post("/api/help/chat")
@@ -5787,7 +5828,7 @@ async def help_chat(request: Request, *, principal: Principal = Depends(require_
     }
 
 
-#  Assessments
+# ─── Assessments ──────────────────────────────────────────────────────────────
 
 
 @app.get("/api/assessments/scores")
@@ -5864,7 +5905,7 @@ async def dispatch_assessment(
     return {"status": "dispatched", "repository": repo, "provider": provider}
 
 
-#  Feature Requests
+# ─── Feature Requests ─────────────────────────────────────────────────────────
 
 _FEATURE_REQUESTS_PATH = Path.home() / "actions-runners" / "dashboard" / "feature_requests.json"
 _PROMPT_TEMPLATES_PATH = Path.home() / "actions-runners" / "dashboard" / "prompt_templates.json"
@@ -6104,7 +6145,7 @@ async def dispatch_feature_request(
     }
 
 
-#  Fleet Orchestration Control Plane
+# ─── Fleet Orchestration Control Plane ───────────────────────────────────────
 
 _ORCHESTRATION_AUDIT_PATH = Path.home() / "actions-runners" / "dashboard" / "orchestration_audit.json"
 _DEPLOY_ACTIONS = {"sync_workflows", "restart_runner", "update_config"}
@@ -6475,7 +6516,7 @@ async def fleet_orchestration_deploy(
     }
 
 
-#  Diagnostics & Launchers
+# ─── Diagnostics & Launchers ──────────────────────────────────────────────────
 
 
 @app.get("/api/deployment/git-drift")
@@ -6656,60 +6697,117 @@ async def generate_launchers(
     }
 
 
-# --- Stale Queue Cleanup ---
+# ─── Hosted-Runner Billing Audit ─────────────────────────────────────────────
+
+HOSTED_RUNNER_PATTERNS = re.compile(
+    r"^(ubuntu-|windows-|macos-|GitHub Actions \d|Hosted Agent)",
+    re.IGNORECASE,
+)
+_runner_audit_cache: dict[str, Any] = {"violations": [], "last_checked": None, "error": None}
+_runner_audit_lock = asyncio.Lock()
 
 
-@app.get("/api/queue/stale")
-async def get_stale_queue(
-    request: Request,
-    min_age: int = 60,
-) -> dict:
-    """List every queued run older than min_age minutes across the entire org.
-
-    Unlike /api/queue (15-repo sample), this scans every repo so ancient
-    runs in quiet repos are visible.  Cached 5 minutes.
-    """
-    if _should_proxy_fleet_to_hub(request):
-        return await proxy_to_hub(request)
-    cache_key = f"stale_queue_{min_age}"
-    cached = _cache_get(cache_key, 300.0)
-    if cached is not None:
-        return cached
-    stale = await queue_cleanup.find_stale_runs(ORG, min_age)
-    payload: dict = {
-        "min_age_minutes": min_age,
-        "stale_count": len(stale),
-        "runs": [r.as_dict() for r in stale],
-    }
-    _cache_set(cache_key, payload, 300.0)
-    return payload
+@app.get("/api/runner-routing-audit")
+async def get_runner_routing_audit() -> JSONResponse:
+    """Return recent workflow runs that executed on GitHub-hosted runners."""
+    return JSONResponse(_runner_audit_cache)
 
 
-@app.post("/api/queue/purge-stale")
-async def purge_stale_queue(
-    request: Request,
-    *,
-    principal: Principal = Depends(require_scope("workflows.control")),  # noqa: B008
-) -> dict:
-    """Cancel every queued run waiting longer than min_age minutes.
-
-    Body: {"min_age": 60, "dry_run": false}
-    Busts queue/diagnose/stale caches on success.
-    """
-    body = await request.json()
-    min_age = int(body.get("min_age", 60))
-    dry_run = bool(body.get("dry_run", False))
-    result = await queue_cleanup.purge_stale_runs(ORG, min_age, dry_run=dry_run)
-    if not dry_run and result.get("cancelled_count", 0) > 0:
-        _cache.pop("queue", None)
-        _cache.pop("diagnose", None)
-        for key in list(_cache.keys()):
-            if key.startswith("stale_queue_"):
-                _cache.pop(key, None)
-    return result
+@app.post("/api/runner-routing-audit/refresh")
+async def refresh_runner_routing_audit() -> JSONResponse:
+    """Trigger an immediate audit refresh."""
+    asyncio.create_task(_run_runner_audit())
+    return JSONResponse({"status": "refresh triggered"})
 
 
-#  Main
+async def _run_runner_audit() -> None:
+    async with _runner_audit_lock:
+        try:
+            violations = await _fetch_hosted_runner_violations()
+            _runner_audit_cache["violations"] = violations
+            _runner_audit_cache["last_checked"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            _runner_audit_cache["error"] = None
+            if violations:
+                log.warning(
+                    "BILLING ALERT: %d workflow run(s) detected on GitHub-hosted runners",
+                    len(violations),
+                )
+        except Exception as exc:  # noqa: BLE001
+            _runner_audit_cache["error"] = str(exc)
+            log.error("Runner routing audit failed: %s", exc)
+
+
+async def _fetch_hosted_runner_violations() -> list[dict[str, Any]]:
+    """Query GitHub API for recent runs on hosted runners across org repos."""
+    token = os.environ.get("GH_TOKEN", "").strip()
+    if not token:
+        return []
+
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"}
+    org = ORG
+    violations: list[dict[str, Any]] = []
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        repos_resp = await client.get(
+            f"https://api.github.com/orgs/{org}/repos",
+            headers=headers,
+            params={"per_page": 50, "sort": "pushed"},
+        )
+        if repos_resp.status_code != 200:
+            return []
+        repos = [r["name"] for r in repos_resp.json()]
+
+        for repo_name in repos[:20]:  # limit to 20 most recently pushed
+            try:
+                runs_resp = await client.get(
+                    f"https://api.github.com/repos/{org}/{repo_name}/actions/runs",
+                    headers=headers,
+                    params={"per_page": 10, "status": "completed"},
+                )
+                if runs_resp.status_code != 200:
+                    continue
+                for run in runs_resp.json().get("workflow_runs", []):
+                    jobs_resp = await client.get(
+                        f"https://api.github.com/repos/{org}/{repo_name}/actions/runs/{run['id']}/jobs",
+                        headers=headers,
+                        params={"per_page": 30},
+                    )
+                    if jobs_resp.status_code != 200:
+                        continue
+                    for job in jobs_resp.json().get("jobs", []):
+                        runner_name = job.get("runner_name") or ""
+                        runner_group = job.get("runner_group_name") or ""
+                        if HOSTED_RUNNER_PATTERNS.match(runner_name) or runner_group == "GitHub Actions":
+                            violations.append({
+                                "repo": repo_name,
+                                "workflow": run.get("name", ""),
+                                "run_id": run["id"],
+                                "job_name": job.get("name", ""),
+                                "runner_name": runner_name,
+                                "runner_group": runner_group,
+                                "run_url": run.get("html_url", ""),
+                                "started_at": job.get("started_at", ""),
+                                "conclusion": job.get("conclusion", ""),
+                            })
+            except Exception:  # noqa: BLE001
+                continue
+
+    return violations
+
+
+async def _runner_audit_loop() -> None:
+    await asyncio.sleep(30)  # initial delay
+    while True:
+        await _run_runner_audit()
+        await asyncio.sleep(900)  # 15 minutes
+
+
+@app.router.on_startup
+async def _start_background_tasks() -> None:
+    asyncio.create_task(_runner_audit_loop())
+
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
     import uvicorn
@@ -6726,7 +6824,8 @@ if __name__ == "__main__":
 
     uvicorn.run(
         app,
-        host="0.0.0.0",  # nosec B104 -- intentional for local LAN/Tailscale access
+        host="0.0.0.0",  # nosec B104 — intentional for local LAN/Tailscale access
         port=PORT,
         log_level="warning",  # FastAPI handles its own logging
     )
+# ci-trigger

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -86,107 +86,14 @@
       /* ── Header ── */
       .app-header {
         background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border);
+        padding: 0 24px;
+        display: flex;
+        align-items: center;
+        height: 56px;
         position: sticky;
         top: 0;
         z-index: 100;
-        display: flex;
-        flex-direction: column;
-      }
-      .ribbon-primary {
-        display: flex;
-        align-items: center;
-        padding: 0 24px;
-        height: 48px;
-        border-bottom: 1px solid var(--border);
-        gap: 2px;
-      }
-      .ribbon-secondary {
-        display: flex;
-        align-items: center;
-        padding: 0 16px;
-        height: 40px;
-        background: rgba(0,0,0,0.22);
-        border-bottom: 1px solid var(--border);
-        gap: 2px;
-        overflow-x: auto;
-      }
-      .ribbon-group {
-        display: flex;
-        align-items: center;
-        padding: 0 4px;
-        border-right: 1px solid var(--border);
-        height: 100%;
-        position: relative;
-      }
-      .ribbon-group:last-child {
-        border-right: none;
-      }
-      .ribbon-group-label {
-        position: absolute;
-        bottom: 1px;
-        left: 0;
-        right: 0;
-        text-align: center;
-        font-size: 9px;
-        color: var(--text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-        pointer-events: none;
-        opacity: 0.6;
-      }
-      .ribbon-cat-btn {
-        background: none;
-        border: none;
-        border-bottom: 3px solid transparent;
-        color: var(--text-secondary);
-        font-size: 13px;
-        font-weight: 600;
-        padding: 0 14px;
-        height: 100%;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        white-space: nowrap;
-        transition: color 0.15s, border-color 0.15s;
-        margin-bottom: -1px;
-      }
-      .ribbon-cat-btn:hover { color: var(--text-primary); }
-      .ribbon-cat-btn.active {
-        color: var(--text-primary);
-        background: rgba(255,255,255,0.06);
-        border-radius: 6px 6px 0 0;
-      }
-      .ribbon-tab-btn {
-        background: none;
-        border: none;
-        color: rgba(255,255,255,0.45);
-        font-size: 12px;
-        font-weight: 500;
-        padding: 0 12px;
-        height: 100%;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        gap: 5px;
-        white-space: nowrap;
-        position: relative;
-        transition: color 0.15s;
-      }
-      .ribbon-tab-btn:hover {
-        color: rgba(255,255,255,1);
-        background: rgba(255,255,255,0.05);
-      }
-      .ribbon-tab-btn.active { color: var(--text-primary); }
-      .ribbon-tab-btn.active::after {
-        content: "";
-        position: absolute;
-        bottom: 0;
-        left: 4px;
-        right: 4px;
-        height: 2px;
-        background: var(--accent-blue);
-        border-radius: 2px 2px 0 0;
       }
       .app-logo {
         display: flex;
@@ -5572,119 +5479,6 @@
       }
 
       // ════════════════════════ QUEUE TAB ════════════════════════
-
-      // STALE QUEUE CLEANUP PANEL
-      function StaleQueuePanel(p) {
-        var onRefresh = p.onRefresh;
-        var minAgeState = React.useState(60);
-        var minAge = minAgeState[0], setMinAge = minAgeState[1];
-        var scanState = React.useState(null);
-        var scanResult = scanState[0], setScanResult = scanState[1];
-        var loadingState = React.useState(false);
-        var loading = loadingState[0], setLoading = loadingState[1];
-        var purgeLoadingState = React.useState(false);
-        var purgeLoading = purgeLoadingState[0], setPurgeLoading = purgeLoadingState[1];
-        var confirmState = React.useState(false);
-        var confirmArmed = confirmState[0], setConfirmArmed = confirmState[1];
-        var msgState = React.useState(null);
-        var msg = msgState[0], setMsg = msgState[1];
-        function ageColor(mins) {
-          if (mins > 10080) return "var(--accent-red)";
-          if (mins > 1440)  return "#f0883e";
-          if (mins > 60)    return "var(--accent-yellow)";
-          return "var(--text-muted)";
-        }
-        function fmtAge(mins) {
-          if (mins < 60) return mins + "m";
-          var h = Math.floor(mins / 60);
-          if (h < 24) return h + "h " + (mins % 60) + "m";
-          return Math.floor(h / 24) + "d " + (h % 24) + "h";
-        }
-        function runScan() {
-          setLoading(true); setScanResult(null); setMsg(null); setConfirmArmed(false);
-          fetch("/api/queue/stale?min_age=" + minAge)
-            .then(function(r) { return r.json(); })
-            .then(function(d) { setScanResult(d); setLoading(false); })
-            .catch(function() { setMsg({ type: "error", text: "Scan failed" }); setLoading(false); });
-        }
-        function armPurge() {
-          setConfirmArmed(true);
-          setTimeout(function() { setConfirmArmed(function(c) { return c ? false : c; }); }, 6000);
-        }
-        function executePurge(dryRun) {
-          setPurgeLoading(true); setConfirmArmed(false);
-          fetch("/api/queue/purge-stale", {
-            method: "POST",
-            headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
-            body: JSON.stringify({ min_age: minAge, dry_run: dryRun }),
-          })
-            .then(function(r) { return r.json(); })
-            .then(function(d) {
-              setPurgeLoading(false);
-              var errPart = d.errors && d.errors.length ? " (errors: " + d.errors.length + ")" : "";
-              setMsg({ type: dryRun ? "info" : (d.cancelled_count > 0 ? "success" : "info"),
-                text: dryRun ? "Dry run: would cancel " + d.stale_count + " run(s)"
-                             : "Cancelled " + d.cancelled_count + " / " + d.stale_count + " stale run(s)" + errPart });
-              if (!dryRun) { setScanResult(null); if (onRefresh) setTimeout(onRefresh, 1500); }
-            })
-            .catch(function() { setPurgeLoading(false); setMsg({ type: "error", text: "Purge failed" }); });
-        }
-        var staleRuns = (scanResult && scanResult.runs) || [];
-        var staleCount = (scanResult && scanResult.stale_count) || 0;
-        return h("div", { style: { marginTop: 24, borderTop: "1px solid var(--border)", paddingTop: 16 } },
-          h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: 10 } },
-            h("span", { style: { fontWeight: 600, fontSize: 13 } }, "Stale Queue Cleanup"),
-            h("span", { style: { fontSize: 11, color: "var(--text-muted)" } }, "\u2014 scans all repos, not just recent 15"),
-          ),
-          h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: 10, flexWrap: "wrap" } },
-            h("label", { style: { fontSize: 12, color: "var(--text-muted)" } }, "Min age (min):"),
-            h("input", { type: "number", min: 0, value: minAge,
-              onChange: function(e) { setMinAge(parseInt(e.target.value, 10) || 0); },
-              style: { width: 70, padding: "3px 6px", borderRadius: 4, border: "1px solid var(--border)",
-                background: "var(--bg-secondary)", color: "var(--text-primary)", fontSize: 12 } }),
-            h("button", { className: "btn", onClick: runScan, disabled: loading, style: { fontSize: 12 } },
-              loading ? h("span", { className: "spinner" }) : null, loading ? " Scanning..." : "Scan all repos"),
-            staleCount > 0 && !purgeLoading
-              ? (confirmArmed
-                ? h("span", { style: { display: "flex", gap: 6 } },
-                    h("button", { className: "btn", onClick: function() { executePurge(false); },
-                      style: { fontSize: 12, background: "var(--accent-red)", color: "#fff" } },
-                      "Confirm: cancel " + staleCount + " run(s)"),
-                    h("button", { className: "btn", onClick: function() { setConfirmArmed(false); }, style: { fontSize: 12 } }, "Never mind"))
-                : h("button", { className: "btn", onClick: armPurge,
-                    style: { fontSize: 12, borderColor: "var(--accent-red)", color: "var(--accent-red)" } },
-                    "Purge " + staleCount + " stale run(s)"))
-              : null,
-            staleCount > 0
-              ? h("button", { className: "btn", onClick: function() { executePurge(true); }, disabled: purgeLoading, style: { fontSize: 12 } }, "Dry run")
-              : null,
-          ),
-          msg ? h("div", { role: "alert", style: {
-              margin: "0 0 10px", padding: "8px 14px", borderRadius: 6, fontSize: 12,
-              background: msg.type === "error" ? "rgba(248,81,73,0.12)" : msg.type === "success" ? "rgba(63,185,80,0.12)" : "rgba(88,166,255,0.12)",
-              color: msg.type === "error" ? "var(--accent-red)" : msg.type === "success" ? "var(--accent-green)" : "var(--accent-blue)",
-              border: "1px solid " + (msg.type === "error" ? "var(--accent-red)" : msg.type === "success" ? "var(--accent-green)" : "var(--accent-blue)"),
-            } }, msg.text) : null,
-          scanResult && staleCount === 0
-            ? h("div", { style: { fontSize: 12, color: "var(--accent-green)", padding: "6px 0" } },
-                "No stale runs found (queued > " + minAge + " min across all repos)") : null,
-          staleRuns.length > 0
-            ? h("div", { style: { overflowX: "auto" } },
-                h("table", { className: "data-table", style: { fontSize: 12, width: "100%" } },
-                  h("thead", null, h("tr", null,
-                    h("th", null, "Age"), h("th", null, "Repo"), h("th", null, "Workflow"),
-                    h("th", null, "Branch"), h("th", null, "Queued at"))),
-                  h("tbody", null, staleRuns.map(function(r) {
-                    return h("tr", { key: r.run_id },
-                      h("td", null, h("span", { style: { fontWeight: 600, color: ageColor(r.age_minutes) } }, fmtAge(r.age_minutes))),
-                      h("td", null, h("code", { style: { fontSize: 11 } }, r.repo)),
-                      h("td", null, r.workflow),
-                      h("td", null, h("code", { style: { fontSize: 11 } }, r.branch)),
-                      h("td", { style: { color: "var(--text-muted)" } }, r.created_at ? new Date(r.created_at).toLocaleString() : "-"));
-                  })))) : null,
-        );
-      }
-
       function QueueTab(p) {
         var q = p.queue || {};
         var loading = p.loading;
@@ -6699,7 +6493,6 @@
                   "Queue is empty \u2014 all runners idle",
                 ),
           ),
-          h(StaleQueuePanel, { onRefresh: onRefresh }),
         );
       }
 
@@ -8883,7 +8676,7 @@
               return r.json();
             })
             .then(function (data) {
-              setIssues(Array.isArray(data) ? data : (data.items || data.issues || []));
+              setIssues(Array.isArray(data) ? data : (data.issues || []));
               setLoading(false);
             })
             .catch(function (err) {
@@ -11400,267 +11193,537 @@
       }
 
       function MaxwellTab(p) {
-        // Props from parent app (systemd status + controls).
+        var status = p.status || {};
+        var loading = p.loading;
+        var error = p.error;
+        var onRefresh = p.onRefresh;
+        var onControl = p.onControl;
+        var cs = React.useState(null);
+        var controlStatus = cs[0],
+          setControlStatus = cs[1];
+        var cl = React.useState(false);
+        var controlling = cl[0],
+          setControlling = cl[1];
+        var pending = React.useState("");
+        var pendingAction = pending[0],
+          setPendingAction = pending[1];
+        var ts = React.useState([]);
+        var tasks = ts[0],
+          setTasks = ts[1];
+        var tl = React.useState(false);
+        var tasksLoading = tl[0],
+          setTasksLoading = tl[1];
+        var dv = React.useState("");
+        var daemonVersion = dv[0],
+          setDaemonVersion = dv[1];
+        var isRunning = status.status === "running";
+
+        function fetchTasks() {
+          setTasksLoading(true);
+          fetch("/api/maxwell/tasks?limit=10")
+            .then(function (r) { return r.json(); })
+            .then(function (data) { setTasks(data.tasks || []); })
+            .catch(function () { setTasks([]); })
+            .finally(function () { setTasksLoading(false); });
+        }
+
+        function fetchVersion() {
+          fetch("/api/maxwell/version")
+            .then(function (r) { return r.json(); })
+            .then(function (data) { setDaemonVersion(data.contract || data.daemon || ""); })
+            .catch(function () { setDaemonVersion(""); });
+        }
+
+        React.useEffect(function () {
+          fetchTasks();
+          fetchVersion();
+        }, []);
+
+        function doControl(action) {
+          setPendingAction(action);
+          setControlling(true);
+          setControlStatus(null);
+          onControl({ action: action })
+            .then(function () {
+              setControlStatus({ ok: true, msg: "Requested " + action + "." });
+              if (onRefresh) setTimeout(onRefresh, 1000);
+            })
+            .catch(function (err) {
+              setControlStatus({ ok: false, msg: String(err) });
+            })
+            .finally(function () {
+              setControlling(false);
+              setPendingAction("");
+            });
+        }
+        return h(
+          "div",
+          null,
+          h("div", { className: "stat-row" },
+            h(Stat, { label: "Status", value: status.status || "unknown", sub: status.service_detail || "" }),
+            h(Stat, { label: "HTTP", value: status.http_reachable ? "reachable" : "offline", sub: status.http_detail || "" }),
+            h(Stat, { label: "Binary", value: status.binary_found ? "found" : "missing", sub: status.binary_path || "not on PATH" }),
+            h(Stat, { label: "Contract", value: daemonVersion || "unknown" }),
+          ),
+          h("div", { style: { display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" } },
+            h("button", { className: "btn", onClick: onRefresh, disabled: loading }, I.refresh(12), loading ? "Refreshing..." : "Refresh"),
+            !isRunning ? h("button", { className: "btn", onClick: function () { doControl("start"); }, disabled: controlling }, "Start Maxwell") : null,
+            isRunning ? h("button", { className: "btn", onClick: function () { doControl("stop"); }, disabled: controlling }, "Stop Maxwell") : null,
+            isRunning ? h("button", { className: "btn", onClick: function () { doControl("restart"); }, disabled: controlling }, "Restart Maxwell") : null,
+          ),
+          controlStatus ? h("div", { style: { padding: "10px 12px", borderRadius: 8, marginBottom: 12, background: controlStatus.ok ? "rgba(63,185,80,0.12)" : "rgba(248,81,73,0.12)", color: controlStatus.ok ? "var(--accent-green)" : "var(--accent-red)" } }, controlStatus.msg) : null,
+          error ? h("div", { style: { padding: "10px 12px", borderRadius: 8, marginBottom: 12, background: "rgba(248,81,73,0.12)", color: "var(--accent-red)" } }, error) : null,
+          h("div", { className: "section" },
+            h("div", { className: "section-header" }, h("span", { className: "section-title" }, I.server(14), "Maxwell-Daemon")),
+            h("div", { className: "section-body" },
+              pendingAction ? h("div", { style: { fontSize: 12, color: "var(--text-muted)", marginBottom: 8 } }, "Working on " + pendingAction + "...") : null,
+              status.dashboard_url ? h("a", { href: status.dashboard_url, target: "_blank", rel: "noopener noreferrer", style: { color: "var(--accent-blue)" } }, status.dashboard_url + " ↗") : null,
+              !status.binary_found && !status.service_running && !status.http_reachable
+                ? h("div", { style: { marginTop: 12, fontSize: 12, color: "var(--text-muted)" } }, "Maxwell-Daemon is not detected on this machine.")
+                : null,
+            ),
+          ),
+          h("div", { className: "section" },
+            h("div", { className: "section-header" },
+              h("span", { className: "section-title" }, I.list ? I.list(14) : null, "Recent Tasks")
+            ),
+            h("div", { className: "section-body" },
+              tasksLoading ? h("div", { style: { color: "var(--text-muted)", fontSize: 12 } }, "Loading tasks…") :
+              !status.http_reachable ? h("div", { style: { fontSize: 12, color: "var(--text-muted)" } }, "Maxwell-Daemon offline — no task history") :
+              tasks.length === 0 ? h("div", { style: { fontSize: 12, color: "var(--text-muted)" } }, "No tasks yet") :
+              h("table", { className: "data-table" },
+                h("thead", null, h("tr", null,
+                  h("th", null, "ID"), h("th", null, "Status"), h("th", null, "Repo"), h("th", null, "Created")
+                )),
+                h("tbody", null, tasks.map(function(t) {
+                  return h("tr", { key: t.id },
+                    h("td", null, (t.id||"").slice(0,8)),
+                    h("td", null, t.status || "—"),
+                    h("td", null, t.repo || "—"),
+                    h("td", null, t.created_at ? t.created_at.slice(0,16).replace("T"," ") : "—")
+                  );
+                }))
+              )
+            )
+          ),
+        );
+      }
+
+      /*
+      function MaxwellTab(p) {
         var status = p.status || {};
         var loading = p.loading;
         var error = p.error;
         var onRefresh = p.onRefresh;
         var onControl = p.onControl;
 
-        // --- local state ---
-        var ts = React.useState([]);          var tasks = ts[0], setTasks = ts[1];
-        var bs = React.useState(null);        var backends = bs[0], setBackends = bs[1];
-        var avs = React.useState([]);         var availBackends = avs[0], setAvailBackends = avs[1];
-        var ws = React.useState(null);        var workers = ws[0], setWorkers = ws[1];
-        var cs = React.useState(null);        var cost = cs[0], setCost = cs[1];
-        var ps = React.useState(null);        var pipeline = ps[0], setPipeline = ps[1];
-        var tl = React.useState(false);       var tasksLoading = tl[0], setTasksLoading = tl[1];
-        var dv = React.useState("");          var daemonVersion = dv[0], setDaemonVersion = dv[1];
-        var ctrl = React.useState(null);      var ctrlStatus = ctrl[0], setCtrlStatus = ctrl[1];
-        var cb = React.useState(false);       var busy = cb[0], setBusy = cb[1];
-        var df = React.useState({ prompt: "", repo: "", backend: "" });
-        var dispForm = df[0], setDispForm = df[1];
-        var dr = React.useState(null);        var dispResult = dr[0], setDispResult = dr[1];
-        var db = React.useState(false);       var dispBusy = db[0], setDispBusy = db[1];
+        var cs = React.useState(null);
+        var controlStatus = cs[0],
+          setControlStatus = cs[1];
+        var cl = React.useState(false);
+        var controlling = cl[0],
+          setControlling = cl[1];
+        var ca = React.useState("");
+        var pendingAction = ca[0],
+          setPendingAction = ca[1];
+        var confirm = React.useState(false);
+        var showConfirm = confirm[0],
+          setShowConfirm = confirm[1];
 
         var isRunning = status.status === "running";
+        var statusColor = isRunning
+          ? "var(--accent-green)"
+          : "var(--accent-red)";
+        var statusBg = isRunning
+          ? "rgba(63,185,80,0.12)"
+          : "rgba(248,81,73,0.12)";
 
-        function fetchAll() {
-          setTasksLoading(true);
-          fetch("/api/maxwell/tasks?limit=20")
-            .then(function(r) { return r.json(); })
-            .then(function(d) { setTasks(d.tasks || []); })
-            .catch(function() { setTasks([]); })
-            .finally(function() { setTasksLoading(false); });
-          fetch("/api/maxwell/backends")
-            .then(function(r) { return r.json(); })
-            .then(function(d) { setBackends(d); })
-            .catch(function() {});
-          fetch("/api/maxwell/backends/available")
-            .then(function(r) { return r.json(); })
-            .then(function(d) {
-              // d is typically { backends: [{name, connected, ...}] } or an array
-              var list = [];
-              if (Array.isArray(d)) { list = d; }
-              else if (d && Array.isArray(d.backends)) { list = d.backends; }
-              else if (d && typeof d === "object") {
-                // fallback: each key is a backend name
-                list = Object.keys(d).map(function(k) {
-                  return { name: k, connected: !!(d[k] && d[k].connected) };
-                });
-              }
-              setAvailBackends(list);
-            })
-            .catch(function() {});
-          fetch("/api/maxwell/workers")
-            .then(function(r) { return r.json(); })
-            .then(function(d) { setWorkers(d); })
-            .catch(function() {});
-          fetch("/api/maxwell/cost")
-            .then(function(r) { return r.json(); })
-            .then(function(d) { setCost(d); })
-            .catch(function() {});
-          fetch("/api/maxwell/pipeline-state")
-            .then(function(r) { return r.json(); })
-            .then(function(d) { setPipeline(d); })
-            .catch(function() {});
-          fetch("/api/maxwell/version")
-            .then(function(r) { return r.json(); })
-            .then(function(d) { setDaemonVersion(d.contract || d.daemon || ""); })
-            .catch(function() {});
+        function initiateControl(action) {
+          setPendingAction(action);
+          setShowConfirm(true);
         }
 
-        React.useEffect(function() {
-          fetchAll();
-          var iv = setInterval(function() {
-            if (onRefresh) onRefresh();
-            fetchAll();
-          }, 8000);
-          return function() { clearInterval(iv); };
-        }, []);
-
-        function doControl(action) {
-          setBusy(true);
-          setCtrlStatus(null);
-          onControl({ action: action, approved_by: "dashboard" })
-            .then(function() {
-              setCtrlStatus({ ok: true, msg: action.charAt(0).toUpperCase() + action.slice(1) + "ed Maxwell." });
-              setTimeout(function() { if (onRefresh) onRefresh(); fetchAll(); }, 1200);
-            })
-            .catch(function(err) { setCtrlStatus({ ok: false, msg: String(err) }); })
-            .finally(function() { setBusy(false); });
-        }
-
-        function doDispatch() {
-          if (!dispForm.prompt.trim()) return;
-          setDispBusy(true);
-          setDispResult(null);
-          var payload = { prompt: dispForm.prompt, repo: dispForm.repo || null };
-          if (dispForm.backend) payload.backend = dispForm.backend;
-          fetch("/api/maxwell/dispatch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
-            body: JSON.stringify(payload),
+        function doControl() {
+          setControlling(true);
+          onControl({
+            action: pendingAction,
+            approved_by: (principal && principal.name) || "anonymous",
           })
-            .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, d: d }; }); })
-            .then(function(res) {
-              if (res.ok) {
-                setDispResult({ ok: true, msg: "Queued — task ID: " + res.d.task_id });
-                setDispForm({ prompt: "", repo: "", backend: dispForm.backend });
-                setTimeout(fetchAll, 800);
-              } else {
-                setDispResult({ ok: false, msg: res.d.detail || res.d.error || "Dispatch failed" });
-              }
+            .then(function (d) {
+              setControlStatus({ ok: true, msg: d.status || "Done" });
+              onRefresh();
             })
-            .catch(function(e) { setDispResult({ ok: false, msg: String(e) }); })
-            .finally(function() { setDispBusy(false); });
+            .catch(function (e) {
+              setControlStatus({
+                ok: false,
+                msg: e.message || "Control failed",
+              });
+            })
+            .finally(function () {
+              setControlling(false);
+              setShowConfirm(false);
+              setPendingAction("");
+            });
         }
 
-        var taskStatusColor = {
-          completed: "var(--accent-green)", failed: "var(--accent-red)",
-          running: "var(--accent-blue)", queued: "var(--accent-yellow)",
-          cancelled: "var(--text-muted)",
-        };
-
-        var costStr = cost && typeof cost.month_to_date_usd === "number"
-          ? "$" + cost.month_to_date_usd.toFixed(4) : "—";
-
-        // Build backend options for dispatch selector
-        var backendOptions = availBackends.filter(function(b) {
-          return b && (b.name || typeof b === "string");
-        }).map(function(b) {
-          var name = b.name || b;
-          var connected = b.connected !== false;
-          return { name: name, connected: connected };
-        });
-
-        return h("div", null,
-          h("div", { className: "stat-row" },
-            h(Stat, { label: "Service", value: status.status || "unknown", sub: status.service_detail || "" }),
-            h(Stat, { label: "HTTP", value: status.http_reachable ? "reachable" : "offline", sub: status.http_detail || "" }),
+        return h(
+          "div",
+          null,
+          h(
+            "div",
+            { className: "stat-row" },
             h(Stat, {
-              label: "Pipeline",
-              value: pipeline ? (pipeline.pipeline_state || "unknown") : "—",
-              sub: pipeline ? ("gate: " + (pipeline.gate || "?") + " \xb7 sandbox: " + (pipeline.sandbox || "?")) : "",
-            }),
-            h(Stat, { label: "Version", value: daemonVersion || "—", sub: "contract" }),
-          ),
-          h("div", { className: "stat-row" },
-            h(Stat, {
-              label: "Workers",
-              value: workers ? String(workers.worker_count || 0) : "—",
-              sub: workers ? ("queue depth: " + (workers.queue_depth || 0)) : "",
+              label: "Ready",
+              value: summary.ready || 0,
+              sub: "providers available",
             }),
             h(Stat, {
-              label: "Backends",
-              value: backends && backends.backends ? backends.backends.join(", ") : "—",
-              sub: "active backends",
+              label: "Not ready",
+              value: summary.not_ready || 0,
+              sub: "need setup",
             }),
-            h(Stat, { label: "MTD Cost", value: costStr, sub: "month-to-date USD" }),
+            h(Stat, {
+              label: "Total",
+              value: summary.total || 0,
+              sub: "providers probed",
+              label: "Status",
+              value: status.status || "unknown",
+              sub: status.service_detail || "",
+            }),
+            h(Stat, {
+              label: "HTTP",
+              value: status.http_reachable ? "reachable" : "offline",
+              sub: status.http_detail || "",
+            }),
+            h(Stat, {
+              label: "Binary",
+              value: status.binary_found ? "found" : "missing",
+              sub: status.binary_path || "not on PATH",
+            }),
           ),
-          h("div", { style: { display: "flex", gap: 8, marginBottom: 12, flexWrap: "wrap" } },
-            h("button", { className: "btn", onClick: function() { if(onRefresh) onRefresh(); fetchAll(); }, disabled: loading },
-              I.refresh ? I.refresh(12) : null, loading ? " Refreshing…" : " Refresh"),
-            !isRunning ? h("button", { className: "btn", onClick: function() { doControl("start"); }, disabled: busy }, "▶ Start Maxwell") : null,
-            isRunning ? h("button", { className: "btn", onClick: function() { doControl("stop"); }, disabled: busy }, "⏹ Stop") : null,
-            isRunning ? h("button", { className: "btn", onClick: function() { doControl("restart"); }, disabled: busy }, "↺ Restart") : null,
-          ),
-          ctrlStatus ? h("div", {
-            style: { padding: "8px 12px", borderRadius: 6, marginBottom: 10, fontSize: 13,
-                     background: ctrlStatus.ok ? "rgba(63,185,80,0.12)" : "rgba(248,81,73,0.12)",
-                     color: ctrlStatus.ok ? "var(--accent-green)" : "var(--accent-red)" }
-          }, ctrlStatus.msg) : null,
-          error ? h("div", {
-            style: { padding: "8px 12px", borderRadius: 6, marginBottom: 10, fontSize: 13,
-                     background: "rgba(248,81,73,0.12)", color: "var(--accent-red)" }
-          }, error) : null,
-          status.http_reachable ? h("div", { className: "section" },
-            h("div", { className: "section-header" },
-              h("span", { className: "section-title" }, "⚡ Dispatch Task")),
-            h("div", { className: "section-body" },
-              h("div", { style: { display: "flex", flexDirection: "column", gap: 8, maxWidth: 560 } },
-                h("textarea", {
-                  placeholder: "Prompt — e.g. 'Fix failing tests in owner/repo'",
-                  value: dispForm.prompt,
-                  onChange: function(e) { setDispForm(function(f) { return Object.assign({}, f, { prompt: e.target.value }); }); },
-                  rows: 3,
-                  style: { width: "100%", background: "var(--bg-tertiary)", color: "var(--text-primary)",
-                           border: "1px solid var(--border)", borderRadius: 6, padding: "8px 10px",
-                           fontFamily: "inherit", fontSize: 13, resize: "vertical" },
-                }),
-                h("div", { style: { display: "flex", gap: 8 } },
-                  h("input", {
-                    placeholder: "Repo (optional) — owner/repo",
-                    value: dispForm.repo,
-                    onChange: function(e) { setDispForm(function(f) { return Object.assign({}, f, { repo: e.target.value }); }); },
-                    style: { flex: 1, background: "var(--bg-tertiary)", color: "var(--text-primary)",
-                             border: "1px solid var(--border)", borderRadius: 6, padding: "7px 10px",
-                             fontFamily: "inherit", fontSize: 13 },
-                  }),
-                  h("select", {
-                    value: dispForm.backend,
-                    onChange: function(e) { setDispForm(function(f) { return Object.assign({}, f, { backend: e.target.value }); }); },
-                    title: "Backend to use for this task",
-                    style: { background: "var(--bg-tertiary)", color: "var(--text-primary)",
-                             border: "1px solid var(--border)", borderRadius: 6, padding: "7px 10px",
-                             fontFamily: "inherit", fontSize: 12, minWidth: 130 },
+          h(
+            "div",
+            {
+              style: {
+                display: "flex",
+                gap: 8,
+                marginBottom: 16,
+                alignItems: "center",
+              },
+            },
+            h(
+              "button",
+              { className: "btn", onClick: onRefresh, disabled: loading },
+              I.refresh(12),
+              loading ? "Probing…" : "Re-probe",
+            ),
+            h(
+              "span",
+              { style: { fontSize: 12, color: "var(--text-muted)" } },
+              "Probes run locally. No secrets are shown.",
+            ),
+              loading ? "Probing\u2026" : "Refresh",
+            ),
+            !isRunning
+              ? h(
+                  "button",
+                  {
+                    className: "btn",
+                    onClick: function () {
+                      initiateControl("start");
+                    },
+                    disabled: controlling,
                   },
-                    h("option", { value: "" }, "auto (default)"),
-                    backendOptions.map(function(b) {
-                      return h("option", {
-                        key: b.name,
-                        value: b.name,
-                        style: { color: b.connected ? "var(--text-primary)" : "var(--text-muted)" },
-                      }, b.name + (b.connected ? "" : " (offline)"));
-                    }),
+                  "Start Maxwell",
+                )
+              : null,
+            isRunning
+              ? h(
+                  "button",
+                  {
+                    className: "btn",
+                    onClick: function () {
+                      initiateControl("stop");
+                    },
+                    disabled: controlling,
+                  },
+                  "Stop Maxwell",
+                )
+              : null,
+            isRunning
+              ? h(
+                  "button",
+                  {
+                    className: "btn",
+                    onClick: function () {
+                      initiateControl("restart");
+                    },
+                    disabled: controlling,
+                  },
+                  "Restart Maxwell",
+                )
+              : null,
+          ),
+          error
+            ? h(
+                "div",
+                {
+                  style: {
+                    padding: "10px 12px",
+                    borderRadius: 8,
+                    background: "rgba(248,81,73,0.12)",
+                    color: "var(--accent-red)",
+                    fontSize: 12,
+                    marginBottom: 12,
+                  },
+                },
+                error,
+              )
+            : null,
+          h(
+            "div",
+            {
+              style: {
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+                gap: 12,
+              },
+            },
+            probes.map(function (probe) {
+              return h(
+                "div",
+                {
+                  key: probe.id,
+                  style: {
+                    background: "var(--bg-secondary)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 10,
+                    padding: 16,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 8,
+          controlStatus
+            ? h(
+                "div",
+                {
+                  style: {
+                    padding: "10px 12px",
+                    borderRadius: 8,
+                    fontSize: 12,
+                    marginBottom: 12,
+                    background: controlStatus.ok
+                      ? "rgba(63,185,80,0.12)"
+                      : "rgba(248,81,73,0.12)",
+                    color: controlStatus.ok
+                      ? "var(--accent-green)"
+                      : "var(--accent-red)",
+                  },
+                },
+                controlStatus.msg,
+              )
+            : null,
+          showConfirm
+            ? h(
+                "div",
+                {
+                  style: {
+                    padding: "12px 16px",
+                    borderRadius: 8,
+                    background: "rgba(210,153,34,0.1)",
+                    border: "1px solid var(--border)",
+                    marginBottom: 12,
+                  },
+                },
+                h(
+                  "div",
+                  {
+                    style: {
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      fontSize: 13,
+                      fontWeight: 600,
+                      marginBottom: 8,
+                      color: "var(--accent-yellow)",
+                    },
+                  },
+                  "Confirm: " + pendingAction + " Maxwell-Daemon?",
+                ),
+                h(
+                  "div",
+                  { style: { display: "flex", gap: 8 } },
+                  h(
+                    "button",
+                    {
+                      className: "btn",
+                      onClick: doControl,
+                      disabled: controlling,
+                    },
+                    controlling ? "Working\u2026" : "Confirm " + pendingAction,
+                  ),
+                  h(
+                    "button",
+                    {
+                      className: "btn",
+                      style: { opacity: 0.7 },
+                      onClick: function () {
+                        setShowConfirm(false);
+                      },
+                    },
+                    "Cancel",
                   ),
                 ),
-                h("button", {
-                  className: "btn",
-                  onClick: doDispatch,
-                  disabled: dispBusy || !dispForm.prompt.trim(),
-                  style: { alignSelf: "flex-start" },
-                }, dispBusy ? "Dispatching…" : "⚡ Dispatch"),
-                dispResult ? h("div", {
-                  style: { padding: "8px 12px", borderRadius: 6, fontSize: 12,
-                           background: dispResult.ok ? "rgba(63,185,80,0.12)" : "rgba(248,81,73,0.12)",
-                           color: dispResult.ok ? "var(--accent-green)" : "var(--accent-red)" }
-                }, dispResult.msg) : null,
               )
-            )
-          ) : null,
-          h("div", { className: "section" },
-            h("div", { className: "section-header" },
-              h("span", { className: "section-title" }, "📋 Task History"),
-              h("button", { className: "btn", style: { marginLeft: "auto", fontSize: 11 },
-                            onClick: fetchAll }, "↻ Refresh")),
-            h("div", { className: "section-body" },
-              tasksLoading
-                ? h("div", { style: { color: "var(--text-muted)", fontSize: 12 } }, "Loading tasks…")
-                : !status.http_reachable
-                  ? h("div", { style: { fontSize: 12, color: "var(--text-muted)" } }, "Maxwell offline — no task data")
-                  : tasks.length === 0
-                    ? h("div", { style: { fontSize: 12, color: "var(--text-muted)" } }, "No tasks yet")
-                    : h("table", { className: "data-table" },
-                        h("thead", null, h("tr", null,
-                          h("th", null, "ID"), h("th", null, "Status"),
-                          h("th", null, "Prompt"), h("th", null, "Repo"), h("th", null, "Created"),
-                        )),
-                        h("tbody", null, tasks.map(function(t) {
-                          return h("tr", { key: t.id },
-                            h("td", { style: { fontFamily: "monospace", fontSize: 11 } }, (t.id||"").slice(0,10)),
-                            h("td", null, h("span", { style: { color: taskStatusColor[t.status] || "var(--text-muted)", fontSize: 11, fontWeight: 600 } }, t.status || "—")),
-                            h("td", { style: { maxWidth: 220, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontSize: 12 } }, t.prompt_preview || "—"),
-                            h("td", { style: { fontSize: 12, color: "var(--text-muted)" } }, t.repo || "—"),
-                            h("td", { style: { fontSize: 11, color: "var(--text-muted)" } }, t.created_at ? t.created_at.slice(0,16).replace("T"," ") : "—"),
-                          );
-                        }))
-                      )
-            )
+            : null,
+          h(
+            "div",
+            { className: "section" },
+            h(
+              "div",
+              { className: "section-header" },
+              h(
+                "span",
+                { className: "section-title", style: { color: statusColor } },
+                I.server(14),
+                "Maxwell-Daemon",
+              ),
+            ),
+            h(
+              "div",
+              { className: "section-body" },
+              h(
+                "div",
+                {
+                  style: {
+                    display: "flex",
+                    gap: 12,
+                    flexWrap: "wrap",
+                    marginBottom: 12,
+                  },
+                },
+                h(
+                  "span",
+                  {
+                    className: "section-badge",
+                    style: {
+                      background: statusBg,
+                      color: statusColor,
+                      fontSize: 13,
+                      padding: "4px 12px",
+                    },
+                  },
+                  status.status || "unknown",
+                ),
+              ),
+              status.dashboard_url
+                ? h(
+                    "div",
+                    { style: { marginBottom: 8 } },
+                    h(
+                      "span",
+                      {
+                        style: { fontSize: 12, color: "var(--text-secondary)" },
+                      },
+                      "Dashboard URL: ",
+                    ),
+                    h(
+                      "a",
+                      {
+                        href: status.dashboard_url,
+                        target: "_blank",
+                        rel: "noopener noreferrer",
+                        style: { fontSize: 12, color: "var(--text-secondary)" },
+                      },
+                      status.dashboard_url + " \u2197",
+                    ),
+                  )
+                : null,
+              status.deep_links
+                ? h(
+                    "div",
+                    null,
+                    h(
+                      "div",
+                      {
+                        style: {
+                          fontSize: 12,
+                          color: "var(--text-secondary)",
+                          marginBottom: 6,
+                        },
+                      },
+                      "Deep links:",
+                    ),
+                    Object.entries(status.deep_links || {}).map(
+                      function (entry) {
+                        var k = entry[0],
+                          v = entry[1];
+                        return h(
+                          "div",
+                          { key: k, style: { fontSize: 12, marginBottom: 4 } },
+                          h(
+                            "span",
+                            {
+                              style: {
+                                color: "var(--text-muted)",
+                                minWidth: 80,
+                                display: "inline-block",
+                              },
+                            },
+                            k + ":",
+                          ),
+                          v.startsWith("http")
+                            ? h(
+                                "a",
+                                {
+                                  href: v,
+                                  target: "_blank",
+                                  rel: "noopener noreferrer",
+                                  style: { color: "var(--text-secondary)" },
+                                },
+                                v + " \u2197",
+                              )
+                            : h(
+                                "code",
+                                {
+                                  style: {
+                                    fontSize: 11,
+                                    color: "var(--text-secondary)",
+                                    background: "var(--bg-secondary)",
+                                    padding: "2px 6px",
+                                    borderRadius: 4,
+                                  },
+                                },
+                                v,
+                              ),
+                        );
+                      },
+                    ),
+                  )
+                : null,
+              !status.binary_found &&
+                !status.service_running &&
+                !status.http_reachable
+                ? h(
+                    "div",
+                    {
+                      style: {
+                        marginTop: 12,
+                        padding: "10px 12px",
+                        borderRadius: 8,
+                        background: "rgba(139,148,158,0.08)",
+                        fontSize: 12,
+                        color: "var(--text-muted)",
+                      },
+                    },
+                    "Maxwell-Daemon is not detected on this machine. If installed elsewhere, set MAXWELL_URL to point to it.",
+                  )
+                : null,
+            ),
           ),
         );
       }
 
+      */
 
       function DashboardHelp(p) {
         var currentTab = p.currentTab || "";
@@ -13403,402 +13466,186 @@
         );
       }
 
-      // ── Agent Launcher Tab ──────────────────────────────────────────────────
-      function AgentWorkflowDispatch(props) {
-        var repos = props.repos;
-        var wds = React.useState("Repository_Management");
-        var wdRepo = wds[0]; var setWdRepo = wds[1];
-        var wfs = React.useState("");
-        var wdWorkflow = wfs[0]; var setWdWorkflow = wfs[1];
-        var wrs = React.useState("main");
-        var wdRef = wrs[0]; var setWdRef = wrs[1];
-        var wss = React.useState(null);
-        var wdStatus = wss[0]; var setWdStatus = wss[1];
-
-        var SKILL_WORKFLOWS = [
-          { value: "Skills-Sync.yml", label: "Skills Sync" },
-          { value: "Agent-CI-Remediation.yml", label: "CI Remediation" },
-          { value: "Jules-Auto-Repair.yml", label: "Jules Auto-Repair" },
-          { value: "Jules-PR-AutoFix.yml", label: "Jules PR AutoFix" },
-          { value: "ci-standard.yml", label: "CI Standard" },
-        ];
-
-        function dispatchWorkflow() {
-          if (!wdRepo || !wdWorkflow) return;
-          setWdStatus("dispatching");
-          fetch("/api/workflows/dispatch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
-            body: JSON.stringify({ repository: wdRepo, workflow_id: wdWorkflow, ref: wdRef, inputs: {} }),
-          })
-            .then(function(r) { return r.json().then(function(j) { if (!r.ok) throw new Error(j.detail || "HTTP " + r.status); return j; }); })
-            .then(function() { setWdStatus("ok"); setTimeout(function() { setWdStatus(null); }, 3000); })
-            .catch(function(e) { setWdStatus("error: " + String(e)); });
-        }
-
-        return h("div", { style: { marginTop: 24, marginBottom: 8 } },
-          h("h3", { style: { marginBottom: 10 } }, "Workflow Dispatch"),
-          h("div", { style: { display: "flex", gap: 8, flexWrap: "wrap", alignItems: "flex-end" } },
-            h("div", { style: { display: "flex", flexDirection: "column", gap: 4 } },
-              h("label", { style: { fontSize: 12, color: "var(--text-muted)" } }, "Repository"),
-              h("input", {
-                className: "form-input",
-                style: { width: 200 },
-                value: wdRepo,
-                onChange: function(e) { setWdRepo(e.target.value); },
-                placeholder: "Repository_Management",
-              }),
-            ),
-            h("div", { style: { display: "flex", flexDirection: "column", gap: 4 } },
-              h("label", { style: { fontSize: 12, color: "var(--text-muted)" } }, "Workflow file"),
-              h("div", { style: { display: "flex", gap: 4 } },
-                h("input", {
-                  className: "form-input",
-                  style: { width: 220 },
-                  value: wdWorkflow,
-                  onChange: function(e) { setWdWorkflow(e.target.value); },
-                  placeholder: "Skills-Sync.yml",
-                }),
-                h("select", {
-                  className: "form-input",
-                  style: { width: 140 },
-                  value: "",
-                  onChange: function(e) { if (e.target.value) setWdWorkflow(e.target.value); },
-                },
-                  h("option", { value: "" }, "presets…"),
-                  SKILL_WORKFLOWS.map(function(w) {
-                    return h("option", { key: w.value, value: w.value }, w.label);
-                  }),
-                ),
-              ),
-            ),
-            h("div", { style: { display: "flex", flexDirection: "column", gap: 4 } },
-              h("label", { style: { fontSize: 12, color: "var(--text-muted)" } }, "Ref"),
-              h("input", {
-                className: "form-input",
-                style: { width: 100 },
-                value: wdRef,
-                onChange: function(e) { setWdRef(e.target.value); },
-                placeholder: "main",
-              }),
-            ),
-            h("button", {
-              className: "btn btn-primary",
-              disabled: !wdRepo || !wdWorkflow || wdStatus === "dispatching",
-              onClick: dispatchWorkflow,
-              style: { alignSelf: "flex-end" },
-            }, wdStatus === "dispatching" ? "Dispatching…" : "▶ Dispatch"),
-            wdStatus && wdStatus !== "dispatching" && h("span", {
-              style: { alignSelf: "center", fontSize: 12, color: wdStatus === "ok" ? "var(--accent-green)" : "var(--accent-red)" },
-            }, wdStatus === "ok" ? "✓ Dispatched" : wdStatus),
-          ),
-        );
-      }
-
-      function AgentLauncherTab() {
-        // Self-contained state — doesn't bloat parent
-        var ss = React.useState(null); var status = ss[0]; var setStatus = ss[1];
-        var cs = React.useState(null); var config = cs[0]; var setConfig = cs[1];
-        var rs = React.useState(null); var repos = rs[0]; var setRepos = rs[1];
-        var ls = React.useState(false); var loading = ls[0]; var setLoading = ls[1];
-        var es = React.useState(""); var error = es[0]; var setError = es[1];
-        var bs = React.useState({}); var busy = bs[0]; var setBusy = bs[1];
-        var eas = React.useState(null); var editingAgent = eas[0]; var setEditingAgent = eas[1];
-        var efs = React.useState({}); var editForm = efs[0]; var setEditForm = efs[1];
-        var svs = React.useState(null); var saveStatus = svs[0]; var setSaveStatus = svs[1];
-
-        var PROVIDERS = [
-          { value: "claude_code_cli", label: "Claude Code" },
-          { value: "codex_cli", label: "Codex CLI" },
-          { value: "jules_api", label: "Jules API" },
-        ];
-        var MODELS = [
-          { value: "claude-sonnet-4-6", label: "Sonnet 4.6 (recommended)" },
-          { value: "claude-opus-4-6", label: "Opus 4.6 (premium)" },
-          { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5 (fast)" },
-          { value: "claude-3-5-sonnet-20241022", label: "Sonnet 3.5" },
-        ];
+      function ClineLauncherTab() {
+        // Self-contained: this tab manages its own polling + actions so it
+        // doesn't bloat the parent state. The launcher's state is on the
+        // user's local FS — the dashboard only mirrors it.
+        var s = React.useState(null);
+        var status = s[0], setStatus = s[1];
+        var r = React.useState(null);
+        var repos = r[0], setRepos = r[1];
+        var l = React.useState(false);
+        var loading = l[0], setLoading = l[1];
+        var er = React.useState("");
+        var error = er[0], setError = er[1];
+        var bs = React.useState({});
+        var busy = bs[0], setBusy = bs[1];
 
         function fetchStatus() {
-          fetch("/api/agent-launcher/status", { headers: { "X-Requested-With": "XMLHttpRequest" } })
-            .then(function(r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
-            .then(function(j) { setStatus(j); setError(""); })
-            .catch(function(e) { setError(String(e)); });
-        }
-        function fetchConfig() {
-          fetch("/api/agent-launcher/config", { headers: { "X-Requested-With": "XMLHttpRequest" } })
-            .then(function(r) { return r.ok ? r.json() : null; })
-            .then(function(j) { if (j) setConfig(j); })
-            .catch(function() {});
-        }
-        function fetchRepos() {
-          setLoading(true);
-          fetch("/api/agent-launcher/repos", { headers: { "X-Requested-With": "XMLHttpRequest" } })
-            .then(function(r) {
-              if (r.status === 503) throw new Error("launcher not installed");
-              if (!r.ok) throw new Error("HTTP " + r.status);
-              return r.json();
+          fetch("/api/agent-launcher/status")
+            .then(function (resp) {
+              if (!resp.ok) throw new Error("HTTP " + resp.status);
+              return resp.json();
             })
-            .then(function(j) { setRepos(j); })
-            .catch(function(e) { setError(String(e)); })
-            .finally(function() { setLoading(false); });
-        }
-        function action(verb, body) {
-          var key = verb + (body && body.agent ? "/" + body.agent : "");
-          setBusy(function(p) { var n = Object.assign({}, p); n[key] = true; return n; });
-          var opts = { method: "POST", headers: { "X-Requested-With": "XMLHttpRequest" } };
-          if (body) { opts.headers["Content-Type"] = "application/json"; opts.body = JSON.stringify(body); }
-          return fetch("/api/agent-launcher/" + verb, opts)
-            .then(function(r) { return r.json().then(function(j) { if (!r.ok) throw new Error(j.detail || "HTTP " + r.status); return j; }); })
-            .then(function() { fetchStatus(); })
-            .catch(function(e) { setError(String(e)); })
-            .finally(function() { setBusy(function(p) { var n = Object.assign({}, p); delete n[key]; return n; }); });
-        }
-        function startEdit(agentName) {
-          var a = (config && config.agents && config.agents[agentName]) || {};
-          setEditingAgent(agentName);
-          setEditForm({
-            enabled: a.enabled !== false,
-            interval_seconds: a.interval_seconds || 3600,
-            provider: a.provider || "claude_code_cli",
-            model: a.model || "claude-sonnet-4-6",
-          });
-          setSaveStatus(null);
-        }
-        function cancelEdit() { setEditingAgent(null); setEditForm({}); setSaveStatus(null); }
-        function saveAgentConfig() {
-          if (!config || !editingAgent) return;
-          setSaveStatus("saving");
-          var agents = Object.assign({}, config.agents || {});
-          agents[editingAgent] = Object.assign({}, agents[editingAgent] || {}, editForm);
-          var newConfig = Object.assign({}, config, { agents: agents });
-          fetch("/api/agent-launcher/config", {
-            method: "PUT",
-            headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
-            body: JSON.stringify(newConfig),
-          })
-            .then(function(r) { return r.json().then(function(j) { if (!r.ok) throw new Error(j.detail || "HTTP " + r.status); return j; }); })
-            .then(function() {
-              setSaveStatus("ok");
-              setConfig(newConfig);
-              fetchStatus();
-              setTimeout(function() { setEditingAgent(null); setSaveStatus(null); }, 1200);
-            })
-            .catch(function(e) { setSaveStatus("error: " + String(e)); });
+            .then(function (j) { setStatus(j); setError(""); })
+            .catch(function (e) { setError(String(e)); });
         }
 
-        React.useEffect(function() {
-          fetchStatus(); fetchConfig(); fetchRepos();
+        function fetchRepos() {
+          setLoading(true);
+          fetch("/api/agent-launcher/repos")
+            .then(function (resp) {
+              if (resp.status === 503) {
+                throw new Error(
+                  "launcher not installed on this machine"
+                );
+              }
+              if (!resp.ok) throw new Error("HTTP " + resp.status);
+              return resp.json();
+            })
+            .then(function (j) { setRepos(j); setError(""); })
+            .catch(function (e) { setError(String(e)); })
+            .finally(function () { setLoading(false); });
+        }
+
+        function action(verb, body) {
+          var key = verb + (body && body.agent ? "/" + body.agent : "");
+          var nb = Object.assign({}, busy); nb[key] = true; setBusy(nb);
+          var opts = { method: "POST" };
+          if (body) {
+            opts.headers = { "Content-Type": "application/json" };
+            opts.body = JSON.stringify(body);
+          }
+          return fetch("/api/agent-launcher/" + verb, opts)
+            .then(function (resp) {
+              return resp.json().then(function (j) {
+                if (!resp.ok) throw new Error(j.detail || "HTTP " + resp.status);
+                return j;
+              });
+            })
+            .then(function () { fetchStatus(); })
+            .catch(function (e) { setError(String(e)); })
+            .finally(function () {
+              var nb2 = Object.assign({}, busy); delete nb2[key]; setBusy(nb2);
+            });
+        }
+
+        React.useEffect(function () {
+          fetchStatus(); fetchRepos();
           var t = setInterval(fetchStatus, 5000);
-          return function() { clearInterval(t); };
+          return function () { clearInterval(t); };
         }, []);
 
         var schedRunning = status && status.scheduler_running;
-        var agents = (status && status.agents) || [];
-        var configAgents = (config && config.agents) || {};
-
-        function nextRunMs(a) {
-          if (!a.last_run_iso) return null;
-          return new Date(a.last_run_iso).getTime() + a.interval_seconds * 1000;
-        }
+        var statusBadge = h("span", {
+          className: "section-badge",
+          style: {
+            background: schedRunning ? "rgba(63,185,80,0.15)" : "rgba(248,81,73,0.15)",
+            color: schedRunning ? "var(--accent-green)" : "var(--accent-red)",
+          },
+        }, schedRunning ? "running" : "stopped");
 
         return h("div", { className: "tab-panel" },
-          // Header
+          // Header + global controls
           h("div", { style: { display: "flex", alignItems: "center", gap: 12, marginBottom: 16 } },
-            h("h2", { style: { margin: 0 } }, "Agent Launcher"),
-            h("span", {
+            h("h2", { style: { margin: 0 } }, "Cline Agent Launcher"),
+            statusBadge,
+            status && status.scheduler_pid
+              ? h("span", { style: { fontSize: 12, color: "var(--text-secondary)" } },
+                  "pid " + status.scheduler_pid)
+              : null,
+          ),
+          error
+            ? h("div", { className: "alert alert-error", style: { marginBottom: 12 } }, error)
+            : null,
+          h("div", { style: { display: "flex", gap: 8, marginBottom: 16 } },
+            h("button", {
+              className: "btn btn-primary",
+              disabled: !!busy["start"] || schedRunning,
+              onClick: function () { action("start"); },
+            }, busy["start"] ? "starting..." : "Start scheduler"),
+            h("button", {
+              className: "btn",
+              disabled: !!busy["stop"] || !schedRunning,
+              onClick: function () { action("stop"); },
+            }, busy["stop"] ? "stopping..." : "Stop scheduler"),
+            h("button", {
+              className: "btn",
+              disabled: loading,
+              onClick: function () { fetchRepos(); fetchStatus(); },
+            }, loading ? "refreshing..." : "Refresh"),
+          ),
+
+          // Agents table
+          h("h3", null, "Agents"),
+          status && status.agents && status.agents.length
+            ? h("table", { className: "data-table", style: { width: "100%" } },
+                h("thead", null, h("tr", null,
+                  h("th", null, "Agent"),
+                  h("th", null, "Enabled"),
+                  h("th", null, "Interval"),
+                  h("th", null, "Last run (UTC)"),
+                  h("th", null, "Last repo"),
+                  h("th", null, "Window PID"),
+                  h("th", null, "Lock"),
+                  h("th", null, "Run now"),
+                )),
+                h("tbody", null, status.agents.map(function (a) {
+                  return h("tr", { key: a.name },
+                    h("td", null, a.name),
+                    h("td", null, a.enabled ? "yes" : "no"),
+                    h("td", null, a.interval_seconds + "s"),
+                    h("td", { style: { fontSize: 12 } }, a.last_run_iso || "-"),
+                    h("td", null, a.last_repo || "-"),
+                    h("td", null, a.last_window_pid || "-"),
+                    h("td", null, a.lock_alive
+                      ? h("span", { style: { color: "var(--accent-yellow)" } }, "alive")
+                      : "-"),
+                    h("td", null,
+                      h("button", {
+                        className: "btn btn-sm",
+                        disabled: !!busy["run-once/" + a.name] || a.lock_alive,
+                        onClick: function () {
+                          action("run-once", { agent: a.name });
+                        },
+                      }, busy["run-once/" + a.name] ? "spawning..." : "Run once"),
+                    ),
+                  );
+                })),
+              )
+            : h("div", { style: { color: "var(--text-secondary)" } },
+                "No agents configured. Edit %LOCALAPPDATA%\\cline_agent_launcher\\config.json"),
+
+          // Discovered repo inventory
+          h("h3", { style: { marginTop: 24 } },
+            "Discovered repositories",
+            repos ? h("span", {
               className: "section-badge",
-              style: {
-                background: schedRunning ? "rgba(63,185,80,0.15)" : "rgba(248,81,73,0.15)",
-                color: schedRunning ? "var(--accent-green)" : "var(--accent-red)",
-              },
-            }, schedRunning ? "scheduler running" : "scheduler stopped"),
-            status && status.scheduler_pid ? h("span", { style: { fontSize: 12, color: "var(--text-muted)" } }, "pid " + status.scheduler_pid) : null,
+              style: { marginLeft: 8, background: "rgba(136,108,228,0.15)", color: "var(--accent-purple)" },
+            }, repos.count + " " + (repos.org_filter || "")) : null,
           ),
-
-          error ? h("div", { className: "alert alert-error", style: { marginBottom: 12 } }, error) : null,
-
-          // Scheduler controls
-          h("div", { style: { display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" } },
-            h("button", { className: "btn btn-primary", disabled: !!busy["start"] || !!schedRunning, onClick: function() { action("start"); } },
-              busy["start"] ? "starting…" : "▶ Start Scheduler"),
-            h("button", { className: "btn", disabled: !!busy["stop"] || !schedRunning, onClick: function() { action("stop"); } },
-              busy["stop"] ? "stopping…" : "■ Stop"),
-            h("button", { className: "btn", disabled: loading, onClick: function() { fetchStatus(); fetchConfig(); fetchRepos(); } },
-              loading ? "refreshing…" : "↺ Refresh"),
-          ),
-
-          // Agent cards
-          h("div", { style: { marginBottom: 24 } },
-            h("div", { style: { display: "flex", alignItems: "center", gap: 10, marginBottom: 10 } },
-              h("h3", { style: { margin: 0 } }, "Agents"),
-              agents.length > 0 ? h("span", { style: { fontSize: 12, color: "var(--text-muted)" } },
-                agents.filter(function(a) { return a.lock_alive; }).length + " active · " + agents.length + " configured") : null,
-            ),
-            agents.length === 0
-              ? h("div", { style: { color: "var(--text-secondary)", padding: "16px 0" } },
-                  "No agents configured. Edit %LOCALAPPDATA%\\cline_agent_launcher\\config.json to add agents.")
-              : h("div", { style: { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(340px, 1fr))", gap: 12 } },
-                  agents.map(function(a) {
-                    var isEditing = editingAgent === a.name;
-                    var cfgA = configAgents[a.name] || {};
-                    var nextMs = nextRunMs(a);
-                    var now = Date.now();
-                    var isOverdue = nextMs && now > nextMs;
-                    var timeUntil = nextMs ? Math.round((nextMs - now) / 1000) : null;
-                    var nextStr = !nextMs ? "—"
-                      : isOverdue ? "overdue " + Math.abs(Math.round((now - nextMs) / 60000)) + "m ago"
-                      : timeUntil < 60 ? "in " + timeUntil + "s"
-                      : "in " + Math.round(timeUntil / 60) + "m";
-                    var runKey = "run-once/" + a.name;
-
-                    return h("div", {
-                      key: a.name,
-                      style: {
-                        background: "var(--bg-card)",
-                        border: "1px solid " + (isEditing ? "var(--accent-blue)" : a.lock_alive ? "rgba(63,185,80,0.3)" : "var(--border)"),
-                        borderRadius: 8,
-                        padding: 14,
-                      },
-                    },
-                      // Card header
-                      h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: 10 } },
-                        h("span", { style: { fontWeight: 700, fontSize: 14, flex: 1 } }, a.name),
-                        h("span", {
-                          className: "section-badge",
-                          style: {
-                            background: a.lock_alive ? "rgba(63,185,80,0.15)" : a.enabled ? "rgba(88,166,255,0.1)" : "rgba(255,255,255,0.05)",
-                            color: a.lock_alive ? "var(--accent-green)" : a.enabled ? "var(--accent-blue)" : "var(--text-muted)",
-                          },
-                        }, a.lock_alive ? "● running" : a.enabled ? "idle" : "disabled"),
-                      ),
-
-                      // Info grid (when not editing)
-                      !isEditing && h("div", { style: { fontSize: 12, color: "var(--text-secondary)", display: "grid", gridTemplateColumns: "auto 1fr", gap: "3px 12px", marginBottom: 10 } },
-                        h("span", { style: { color: "var(--text-muted)" } }, "Provider"),
-                        h("span", null, cfgA.provider || "—"),
-                        cfgA.provider === "claude_code_cli" || !cfgA.provider ? h("span", { style: { color: "var(--text-muted)" } }, "Model") : null,
-                        cfgA.provider === "claude_code_cli" || !cfgA.provider ? h("span", null, cfgA.model || "default") : null,
-                        h("span", { style: { color: "var(--text-muted)" } }, "Interval"),
-                        h("span", null, a.interval_seconds < 3600
-                          ? Math.round(a.interval_seconds / 60) + " min"
-                          : (a.interval_seconds / 3600).toFixed(1) + " hr"),
-                        h("span", { style: { color: "var(--text-muted)" } }, "Next run"),
-                        h("span", { style: { color: isOverdue ? "var(--accent-yellow)" : undefined } }, nextStr),
-                        a.last_repo ? h("span", { style: { color: "var(--text-muted)" } }, "Last repo") : null,
-                        a.last_repo ? h("span", null, a.last_repo) : null,
-                        a.last_run_iso ? h("span", { style: { color: "var(--text-muted)" } }, "Last run") : null,
-                        a.last_run_iso ? h("span", null, a.last_run_iso.slice(0, 16).replace("T", " ")) : null,
-                      ),
-
-                      // Edit form
-                      isEditing && h("div", { style: { display: "grid", gap: 10, marginBottom: 10, fontSize: 13 } },
-                        h("label", { style: { display: "flex", alignItems: "center", gap: 8 } },
-                          h("input", { type: "checkbox", checked: !!editForm.enabled, onChange: function(e) { setEditForm(function(p) { return Object.assign({}, p, { enabled: e.target.checked }); }); } }),
-                          "Enabled",
-                        ),
-                        h("div", { style: { display: "grid", gridTemplateColumns: "90px 1fr", gap: 8, alignItems: "center" } },
-                          h("label", { style: { color: "var(--text-muted)" } }, "Provider"),
-                          h("select", { className: "form-input", value: editForm.provider || "claude_code_cli", onChange: function(e) { setEditForm(function(p) { return Object.assign({}, p, { provider: e.target.value }); }); } },
-                            PROVIDERS.map(function(p) { return h("option", { key: p.value, value: p.value }, p.label); }),
-                          ),
-                          (editForm.provider === "claude_code_cli" || !editForm.provider) ? h("label", { style: { color: "var(--text-muted)" } }, "Model") : null,
-                          (editForm.provider === "claude_code_cli" || !editForm.provider) ? h("select", { className: "form-input", value: editForm.model || "claude-sonnet-4-6", onChange: function(e) { setEditForm(function(p) { return Object.assign({}, p, { model: e.target.value }); }); } },
-                            MODELS.map(function(m) { return h("option", { key: m.value, value: m.value }, m.label); }),
-                          ) : null,
-                          h("label", { style: { color: "var(--text-muted)" } }, "Interval (s)"),
-                          h("div", { style: { display: "flex", gap: 8 } },
-                            h("input", { type: "number", className: "form-input", style: { flex: 1 }, value: editForm.interval_seconds || 3600, min: 60, step: 60, onChange: function(e) { setEditForm(function(p) { return Object.assign({}, p, { interval_seconds: parseInt(e.target.value) || 3600 }); }); } }),
-                            h("span", { style: { alignSelf: "center", fontSize: 12, color: "var(--text-muted)" } },
-                              editForm.interval_seconds < 3600
-                                ? Math.round((editForm.interval_seconds || 3600) / 60) + " min"
-                                : ((editForm.interval_seconds || 3600) / 3600).toFixed(1) + " hr"),
-                          ),
-                        ),
-                        h("div", { style: { display: "flex", gap: 8, alignItems: "center" } },
-                          h("button", { className: "btn btn-primary", onClick: saveAgentConfig, disabled: saveStatus === "saving" }, saveStatus === "saving" ? "Saving…" : "Save"),
-                          h("button", { className: "btn", onClick: cancelEdit }, "Cancel"),
-                          saveStatus && saveStatus !== "saving" && h("span", { style: { fontSize: 12, color: saveStatus === "ok" ? "var(--accent-green)" : "var(--accent-red)" } },
-                            saveStatus === "ok" ? "✓ Saved" : saveStatus),
-                        ),
-                      ),
-
-                      // Card actions
-                      h("div", { style: { display: "flex", gap: 6 } },
-                        h("button", { className: "btn btn-sm", disabled: !!busy[runKey] || !!a.lock_alive, onClick: function() { action("run-once", { agent: a.name }); }, style: { fontSize: 11 } },
-                          busy[runKey] ? "spawning…" : "▶ Run Now"),
-                        h("button", {
-                          className: "btn btn-sm",
-                          style: { fontSize: 11, background: isEditing ? "var(--accent-blue)" : undefined, color: isEditing ? "#fff" : undefined },
-                          onClick: function() { isEditing ? cancelEdit() : startEdit(a.name); },
-                        }, isEditing ? "✕ Cancel" : "⚙ Configure"),
-                      ),
-                    );
-                  }),
-                ),
-          ),
-
-          // Schedule overview
-          agents.length > 0 && h("div", { style: { marginBottom: 24 } },
-            h("h3", { style: { marginBottom: 8 } }, "Schedule"),
-            h("table", { className: "data-table", style: { width: "100%", fontSize: 13 } },
-              h("thead", null, h("tr", null,
-                h("th", null, "Agent"),
-                h("th", null, "Status"),
-                h("th", null, "Interval"),
-                h("th", null, "Last Run (UTC)"),
-                h("th", null, "Next Run"),
-                h("th", null, "Last Repo"),
-              )),
-              h("tbody", null, agents.map(function(a) {
-                var nextMs = nextRunMs(a);
-                var now = Date.now();
-                var isOverdue = nextMs && now > nextMs;
-                var timeUntil = nextMs ? Math.round((nextMs - now) / 1000) : null;
-                var timeStr = !nextMs ? "—"
-                  : isOverdue ? "overdue " + Math.abs(Math.round((now - nextMs) / 60000)) + "m"
-                  : timeUntil < 60 ? "in " + timeUntil + "s"
-                  : "in " + Math.round(timeUntil / 60) + "m";
-                return h("tr", { key: a.name },
-                  h("td", { style: { fontWeight: 600 } }, a.name),
-                  h("td", null, h("span", {
+          repos && repos.repos && repos.repos.length
+            ? h("div", { style: { fontSize: 12, color: "var(--text-secondary)", marginBottom: 8 } },
+                "WSL distro: " + repos.wsl_distro + ", root: " + repos.repos_root)
+            : null,
+          repos && repos.repos
+            ? h("div", { style: { display: "flex", flexWrap: "wrap", gap: 6 } },
+                repos.repos.map(function (r) {
+                  return h("span", {
+                    key: r.name,
                     className: "section-badge",
-                    style: { background: a.lock_alive ? "rgba(63,185,80,0.15)" : a.enabled ? "rgba(88,166,255,0.1)" : "rgba(255,255,255,0.05)", color: a.lock_alive ? "var(--accent-green)" : a.enabled ? "var(--accent-blue)" : "var(--text-muted)" },
-                  }, a.lock_alive ? "running" : a.enabled ? "idle" : "off")),
-                  h("td", null, a.interval_seconds < 3600 ? Math.round(a.interval_seconds / 60) + " min" : (a.interval_seconds / 3600).toFixed(1) + " hr"),
-                  h("td", { style: { fontSize: 12, fontFamily: "monospace" } }, a.last_run_iso ? a.last_run_iso.slice(0, 16).replace("T", " ") : "—"),
-                  h("td", { style: { color: isOverdue ? "var(--accent-yellow)" : undefined } }, timeStr),
-                  h("td", null, a.last_repo || "—"),
-                );
-              })),
-            ),
-          ),
+                    title: r.wsl_path,
+                    style: { background: "var(--bg-tertiary)" },
+                  }, r.name);
+                }))
+            : h("div", { style: { color: "var(--text-secondary)" } },
+                loading ? "discovering..." : "No repos discovered yet."),
 
-          // Workflow dispatch panel
-          h(AgentWorkflowDispatch, { repos: repos }),
-
-          // Discovered repos
-          h("div", { style: { marginTop: 24 } },
-            h("div", { style: { display: "flex", alignItems: "center", gap: 8, marginBottom: 8 } },
-              h("h3", { style: { margin: 0 } }, "Discovered Repositories"),
-              repos ? h("span", { className: "section-badge", style: { background: "rgba(136,108,228,0.15)", color: "var(--accent-purple)" } }, repos.count + " repos") : null,
-            ),
-            repos && repos.repos && repos.repos.length
-              ? h("div", null,
-                  h("div", { style: { fontSize: 12, color: "var(--text-muted)", marginBottom: 6 } },
-                    "distro: " + repos.wsl_distro + " · root: " + repos.repos_root + " · org: " + (repos.org_filter || "all")),
-                  h("div", { style: { display: "flex", flexWrap: "wrap", gap: 6 } },
-                    repos.repos.map(function(r) {
-                      return h("span", { key: r.name, className: "section-badge", title: r.wsl_path, style: { background: "var(--bg-tertiary)" } }, r.name);
-                    })),
-                )
-              : h("div", { style: { color: "var(--text-secondary)" } }, loading ? "discovering…" : "No repos discovered yet."),
-          ),
-
-          // Footer
-          h("div", { style: { marginTop: 24, padding: 12, background: "var(--bg-tertiary)", borderRadius: 4, fontSize: 12, color: "var(--text-muted)" } },
-            h("div", null, "Runtime root: " + ((status && status.runtime_root) || "—")),
-            h("div", null, "Status polls every 5 s · Config saved immediately on each agent edit."),
+          // Notes
+          h("div", { style: { marginTop: 24, padding: 12, background: "var(--bg-tertiary)", borderRadius: 4, fontSize: 12, color: "var(--text-secondary)" } },
+            h("div", null, "Runtime root: " + (status && status.runtime_root || "-")),
+            h("div", null, "Status polls every 5s. Repo discovery is on-demand (Refresh button)."),
+            h("div", null, "Full config editor (model selector, repo multi-select, intervals) ships in a follow-up — for now edit config.json directly and click Refresh."),
           ),
         );
       }
@@ -14972,7 +14819,7 @@
           borderRight: position === "left" ? "1px solid var(--border)" : "none",
           display: "flex",
           flexDirection: "column",
-          height: "calc(100vh - 88px)",
+          height: "calc(100vh - 56px)",
           top: 0,
         };
 
@@ -15138,8 +14985,6 @@
           ) : null,
         );
       }
-
-      var PROVIDERS_WITH_MODEL = ["claude_code_cli", "codex_cli", "jules_api"];
 
       // ════════════════════════ QUICK DISPATCH POPOVER ════════════════════════
       function QuickDispatchPopover() {
@@ -15926,6 +15771,10 @@ function PrincipalsTab() {
         function toggleAsst() { setAsstOpen(function (o) { var n = !o; lsSet(ASST_LS.open, n); return n; }); }
         var rmS = React.useState(null);
         var recoveryModal = rmS[0], setRecoveryModal = rmS[1];
+        var rauS = React.useState({ violations: [], last_checked: null, error: null });
+        var runnerAudit = rauS[0], setRunnerAudit = rauS[1];
+        var rauDismissS = React.useState(false);
+        var auditBannerDismissed = rauDismissS[0], setAuditBannerDismissed = rauDismissS[1];
 
         function fetchFleetOrchestration() {
           setFleetOrchLoading(true);
@@ -16983,6 +16832,25 @@ function PrincipalsTab() {
             .catch(function() { setPrincipal(null); });
         }
 
+        function fetchRunnerAudit() {
+          fetch("/api/runner-routing-audit")
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+              setRunnerAudit(d || { violations: [], last_checked: null, error: null });
+              setAuditBannerDismissed(false);
+            })
+            .catch(function() {});
+        }
+
+        function triggerRunnerAuditRefresh() {
+          fetch("/api/runner-routing-audit/refresh", {
+            method: "POST",
+            headers: { "X-Requested-With": "XMLHttpRequest" },
+          })
+            .then(function() { setTimeout(fetchRunnerAudit, 3000); })
+            .catch(function() {});
+        }
+
         React.useEffect(function () {
           fetchPrincipal();
           fetchFleet();
@@ -16999,6 +16867,7 @@ function PrincipalsTab() {
           fetchDeploymentState();
           fetchScheduledJobs();
           fetchRunnerCapacity();
+          fetchRunnerAudit();
           var t1 = setInterval(fetchFleet, 30000);
           var t2 = setInterval(fetchRepos, 120000);
           var t3 = setInterval(fetchTests, 120000);
@@ -17013,6 +16882,7 @@ function PrincipalsTab() {
           var t11 = setInterval(fetchRunnerCapacity, 60000);
           var t12 = setInterval(fetchDeployment, 300000);
           var t13 = setInterval(fetchDeploymentState, 300000);
+          var t14 = setInterval(fetchRunnerAudit, 300000);
           return function () {
             clearInterval(t1);
             clearInterval(t2);
@@ -17028,6 +16898,7 @@ function PrincipalsTab() {
             clearInterval(t11);
             clearInterval(t12);
             clearInterval(t13);
+            clearInterval(t14);
           };
         }, []);
 
@@ -17085,48 +16956,619 @@ function PrincipalsTab() {
 
         var asstPosition = lsGet(ASST_LS.position, "right");
 
-        var TAB_CATEGORIES = {
-          monitor:  ["overview", "queue", "history", "stats", "machines", "local-apps"],
-          dispatch: ["workflows", "scheduled-jobs", "runner-schedule", "agent-launcher", "maxwell"],
-          manage:   ["remediation", "deployment", "fleet-orchestration", "credentials", "org", "principals"],
-          reports:  ["tests", "reports", "assessments", "feature-requests", "diagnostics"],
-        };
-        var TAB_TO_CATEGORY = {};
-        Object.keys(TAB_CATEGORIES).forEach(function(cat) {
-          TAB_CATEGORIES[cat].forEach(function(t) { TAB_TO_CATEGORY[t] = cat; });
-        });
-        var activeCategory = TAB_TO_CATEGORY[tab] || (tab === "agent-launcher" ? "dispatch" : "monitor");
-
         return h(
           "div",
           null,
           h(
             "header",
             { className: "app-header" },
-            // ── Primary ribbon row ────────────────────────────────────────
-            h("div", { className: "ribbon-primary" },
-              h("div", { className: "app-logo" },
-                h("svg", { width: 28, height: 28, viewBox: "0 0 32 32" },
-                  h("defs", null,
-                    h("linearGradient", { id: "lg", x1: 0, y1: 0, x2: 1, y2: 1 },
-                      h("stop", { offset: "0%", stopColor: "#4f8ff7" }),
-                      h("stop", { offset: "100%", stopColor: "#a855f7" }),
-                    ),
+            h(
+              "div",
+              { className: "app-logo" },
+              h(
+                "svg",
+                { width: 28, height: 28, viewBox: "0 0 32 32" },
+                h(
+                  "defs",
+                  null,
+                  h(
+                    "linearGradient",
+                    { id: "lg", x1: 0, y1: 0, x2: 1, y2: 1 },
+                    h("stop", { offset: "0%", stopColor: "#4f8ff7" }),
+                    h("stop", { offset: "100%", stopColor: "#a855f7" }),
                   ),
-                  h("rect", { width: 32, height: 32, rx: 6, fill: "url(#lg)" }),
-                  h("path", { d: "M18 6l-7 13h6l-1 7 7-13h-6z", fill: "white" }),
                 ),
-                h("span", { className: "logo-text" }, "Dashboard"),
+                h("rect", { width: 32, height: 32, rx: 6, fill: "url(#lg)" }),
+                h("path", { d: "M18 6l-7 13h6l-1 7 7-13h-6z", fill: "white" }),
               ),
-              h("div", { style: { width: 1, height: 24, background: "var(--border)", margin: "0 10px" } }),
-              h("button", { className: "ribbon-cat-btn" + (activeCategory === "monitor" ? " active" : ""), onClick: function () { setTab(TAB_CATEGORIES.monitor[0]); } }, I.server(14), "Monitor"),
-              h("button", { className: "ribbon-cat-btn" + (activeCategory === "dispatch" ? " active" : ""), onClick: function () { setTab(TAB_CATEGORIES.dispatch[0]); } }, I.queue(14), "Dispatch"),
-              h("button", { className: "ribbon-cat-btn" + (activeCategory === "manage" ? " active" : ""), onClick: function () { setTab(TAB_CATEGORIES.manage[0]); } }, I.settings(14), "Manage"),
-              h("button", { className: "ribbon-cat-btn" + (activeCategory === "reports" ? " active" : ""), onClick: function () { setTab(TAB_CATEGORIES.reports[0]); } }, I.fileText(14), "Reports"),
-              h("div", { className: "header-right" },
-                principal ? h("span", { className: "section-badge", style: { background: "rgba(88,166,255,0.15)", color: "var(--accent-blue)" } }, "Acting as: " + principal.name) : null,
-                h("a", {
-                  href: principal ? "#" : "/api/auth/github",
+              h("span", { className: "logo-text" }, "Dashboard"),
+            ),
+            h(
+              "div",
+              { className: "tab-bar", role: "tablist", "aria-label": "Dashboard sections" },
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "overview" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "overview",
+                  onClick: function () {
+                    setTab("overview");
+                  },
+                },
+                I.server(14),
+                "Overview",
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "remediation" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "remediation",
+                  onClick: function () {
+                    setTab("remediation");
+                    fetchRemediationConfig();
+                  },
+                },
+                I.issue(14),
+                "Remediation",
+                runs.filter(function (run) {
+                  return run.conclusion === "failure";
+                }).length > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(248,81,73,0.15)",
+                          color: "var(--accent-red)",
+                          marginLeft: 2,
+                        },
+                      },
+                      runs.filter(function (run) {
+                        return run.conclusion === "failure";
+                      }).length,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "queue" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "queue",
+                  onClick: function () {
+                    setTab("queue");
+                    fetchQueue();
+                  },
+                },
+                I.queue(14),
+                "Queue",
+                (queue.total || 0) > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(88,166,255,0.2)",
+                          color: "var(--accent-blue)",
+                          marginLeft: 2,
+                        },
+                      },
+                      queue.total || 0,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "machines" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "machines",
+                  onClick: function () {
+                    setTab("machines");
+                    fetchMachines();
+                  },
+                },
+                I.server(14),
+                "Machines",
+                (machinesData.count || 0) > 1
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(63,185,80,0.15)",
+                          color: "var(--accent-green)",
+                          marginLeft: 2,
+                        },
+                      },
+                      machinesData.count || 0,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "org" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "org",
+                  onClick: function () {
+                    setTab("org");
+                  },
+                },
+                I.repo(14),
+                "Organization",
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "tests" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "tests",
+                  onClick: function () {
+                    setTab("tests");
+                  },
+                },
+                I.flask(14),
+                "Tests",
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "stats" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "stats",
+                  onClick: function () {
+                    setTab("stats");
+                  },
+                },
+                I.activity(14),
+                "Stats",
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "reports" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "reports",
+                  onClick: function () {
+                    setTab("reports");
+                  },
+                },
+                I.fileText(14),
+                "Reports",
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "scheduled-jobs" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "scheduled-jobs",
+                  onClick: function () {
+                    setTab("scheduled-jobs");
+                    fetchScheduledJobs();
+                  },
+                },
+                I.clock(14),
+                "Schedules",
+                (scheduledJobs.scheduled_workflow_count || 0) > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(88,166,255,0.2)",
+                          color: "var(--accent-blue)",
+                          marginLeft: 2,
+                        },
+                      },
+                      scheduledJobs.scheduled_workflow_count,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "workflows" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "workflows",
+                  onClick: function () {
+                    setTab("workflows");
+                    fetchWorkflowsList();
+                  },
+                },
+                I.activity(14),
+                "Workflows",
+                workflowsList.length > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(88,166,255,0.15)",
+                          color: "#58a6ff",
+                          marginLeft: 2,
+                        },
+                      },
+                      workflowsList.length,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "runner-schedule" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "runner-schedule",
+                  onClick: function () {
+                    setTab("runner-schedule");
+                    fetchRunnerCapacity();
+                  },
+                },
+                I.clock(14),
+                "Runner Plan",
+                runnerCapacity && runnerCapacity.state
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(63,185,80,0.15)",
+                          color: "var(--accent-green)",
+                          marginLeft: 2,
+                        },
+                      },
+                      runnerCapacity.state.desired || 0,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "deployment" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "deployment",
+                  onClick: function () {
+                    setTab("deployment");
+                    fetchDeploymentState();
+                  },
+                },
+                I.server(14),
+                "Deployment",
+                deploymentStateLoading ||
+                  ((deploymentState.rollout_state || {}).machines_attention ||
+                    0) > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(210,153,34,0.2)",
+                          color: "var(--accent-yellow)",
+                          marginLeft: 2,
+                        },
+                      },
+                      deploymentStateLoading
+                        ? "\u2026"
+                        : (deploymentState.rollout_state || {})
+                            .machines_attention,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "history" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "history",
+                  onClick: function () {
+                    setTab("history");
+                    fetchEnrichedRuns();
+                  },
+                },
+                I.activity(14),
+                "History",
+                enrichedRuns.length > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(136,108,228,0.15)",
+                          color: "var(--accent-purple)",
+                          marginLeft: 2,
+                        },
+                      },
+                      enrichedRuns.length,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "local-apps" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "local-apps",
+                  onClick: function () {
+                    setTab("local-apps");
+                    fetchLocalApps();
+                  },
+                },
+                I.server(14),
+                "Local Tools",
+                (function () {
+                  var apps = localApps.tools || localApps.apps || [];
+                  var n = apps.filter(localAppNeedsAttention).length;
+                  return n > 0
+                    ? h(
+                        "span",
+                        {
+                          className: "section-badge",
+                          style: {
+                            background: "rgba(210,153,34,0.2)",
+                            color: "var(--accent-yellow)",
+                            marginLeft: 2,
+                          },
+                        },
+                        n,
+                      )
+                    : null;
+                })(),
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "credentials" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "credentials",
+                  onClick: function () {
+                    setTab("credentials");
+                    fetchCredentials();
+                  },
+                },
+                I.settings(14),
+                "Credentials",
+                credentialsData.summary && credentialsData.summary.not_ready > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(210,153,34,0.15)",
+                          color: "var(--accent-yellow)",
+                          marginLeft: 2,
+                        },
+                      },
+                      credentialsData.summary.not_ready,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" +
+                    (tab === "fleet-orchestration" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "fleet-orchestration",
+                  onClick: function () {
+                    setTab("fleet-orchestration");
+                    fetchFleetOrchestration();
+                  },
+                },
+                I.server(14),
+                "Fleet Orchestration",
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "assessments" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "assessments",
+                  onClick: function () {
+                    setTab("assessments");
+                    fetchAssessments();
+                  },
+                },
+                I.activity(14),
+                "Assessments",
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "feature-requests" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "feature-requests",
+                  onClick: function () {
+                    setTab("feature-requests");
+                    fetchFeatureRequests();
+                  },
+                },
+                I.issue(14),
+                "Feature Requests",
+                featureRequests.length > 0
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(136,108,228,0.15)",
+                          color: "var(--accent-purple)",
+                          marginLeft: 2,
+                        },
+                      },
+                      featureRequests.length,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "cline-launcher" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "cline-launcher",
+                  onClick: function () {
+                    setTab("cline-launcher");
+                  },
+                },
+                I.terminal ? I.terminal(14) : I.server(14),
+                "Cline Launcher",
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "maxwell" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "maxwell",
+                  onClick: function () {
+                    setTab("maxwell");
+                    fetchMaxwellStatus();
+                  },
+                },
+                I.server(14),
+                "Maxwell",
+                maxwellStatus.status === "running"
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(63,185,80,0.15)",
+                          color: "var(--accent-green)",
+                          marginLeft: 2,
+                        },
+                      },
+                      "on",
+                    )
+                  : maxwellStatus.status
+                    ? h(
+                        "span",
+                        {
+                          className: "section-badge",
+                          style: {
+                            background: "rgba(248,81,73,0.15)",
+                            color: "var(--accent-red)",
+                            marginLeft: 2,
+                          },
+                        },
+                        "off",
+                      )
+                    : null,
+              ),
+              h(
+                "button",
+                {
+                  className: "tab-btn" + (tab === "runner-audit" ? " active" : ""),
+                  role: "tab",
+                  "aria-selected": tab === "runner-audit",
+                  onClick: function () {
+                    setTab("runner-audit");
+                  },
+                  title: "Hosted-runner billing audit",
+                },
+                I.server(14),
+                "Runner Audit",
+                (runnerAudit.violations && runnerAudit.violations.length > 0)
+                  ? h(
+                      "span",
+                      {
+                        className: "section-badge",
+                        style: {
+                          background: "rgba(248,81,73,0.2)",
+                          color: "var(--accent-red)",
+                          marginLeft: 2,
+                        },
+                      },
+                      runnerAudit.violations.length,
+                    )
+                  : null,
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "diagnostics" ? " active" : ""),
+                  onClick: function () {
+                    setTab("diagnostics");
+                  },
+                },
+                I.settings(14),
+                "Diagnostics",
+              ),
+              h(
+                "button",
+                {
+                  className:
+                    "tab-btn" + (tab === "principals" ? " active" : ""),
+                  onClick: function () {
+                    setTab("principals");
+                  },
+                },
+                I.server(14),
+                "Principals",
+              ),
+            ),
+            h(
+              "div",
+              { className: "header-right" },
+              (function() {
+                // Mock quota data for visualization
+                var quotaUsed = 14;
+                var quotaTotal = 20;
+                var percent = (quotaUsed / quotaTotal) * 100;
+                return h(
+                  "div",
+                  { 
+                    className: "glass-card",
+                    style: { 
+                      padding: "4px 12px", 
+                      display: "flex", 
+                      alignItems: "center", 
+                      gap: "10px",
+                      marginRight: "12px",
+                      fontSize: "11px",
+                      height: "32px"
+                    } 
+                  },
+                  h("span", { style: { color: "var(--text-secondary)", fontWeight: "600" } }, "FLEET QUOTA"),
+                  h(
+                    "div",
+                    { 
+                      className: "progress-bar", 
+                      style: { width: "80px", height: "6px", background: "rgba(255,255,255,0.1)" },
+                      title: quotaUsed + "/" + quotaTotal + " Runners Active"
+                    },
+                    h("div", { 
+                      className: "progress-fill", 
+                      style: { 
+                        width: percent + "%", 
+                        background: "var(--grad-quota)",
+                        boxShadow: "0 0 10px rgba(0, 242, 254, 0.5)"
+                      } 
+                    })
+                  ),
+                  h("span", { style: { color: "var(--text-primary)", fontWeight: "700" } }, quotaUsed + "/" + quotaTotal)
+                );
+              })(),
+              principal ? h(
+                "span",
+                { className: "section-badge", style: { background: "rgba(88,166,255,0.15)", color: "var(--accent-blue)" } },
+                "Acting as: " + principal.name
+              ) : null,
+              h(
+                "a",
+                { 
+                  href: principal ? "#" : "/api/auth/github", 
                   onClick: principal ? function(e) {
                     e.preventDefault();
                     fetch("/api/auth/logout", {method: "POST", headers: { "X-Requested-With": "XMLHttpRequest" }})
@@ -17134,117 +17576,134 @@ function PrincipalsTab() {
                   } : undefined,
                   className: "btn",
                   style: { textDecoration: "none", marginRight: "12px", height: "24px", lineHeight: "12px", fontSize: "11px" }
-                }, principal ? "Logout" : "Login"),
-                h("span", { className: "status-dot " + (connected ? "green" : "red") }),
-                connected ? "Live" : "Offline",
-                h("span", { className: "hide-mobile" }, lastUpdate ? " \u00B7 " + lastUpdate : ""),
-                h("span", { className: "section-badge", title: "Queued and running workflows" }, "Queue " + ((queue.queued_count || 0) + "/" + (queue.in_progress_count || 0))),
-                h("span", { className: "section-badge", title: watchdog && watchdog.summary ? watchdog.summary : "WSL keepalive and watchdog state" }, "Keepalive " + (watchdog && watchdog.status ? watchdog.status : "unknown")),
-                h("span", { className: "section-badge", title: deployment.deployed_at || "Deployment revision" }, "Build " + shortSha(deployment.git_sha)),
-                h("button", {
-                  className: "btn",
-                  style: { marginLeft: 4, background: asstOpen ? "var(--accent-blue)" : undefined, color: asstOpen ? "#fff" : undefined },
-                  onClick: toggleAsst,
-                  title: "Toggle Assistant sidebar",
-                }, "\u2630 Asst"),
-                h(QuickDispatchPopover, null),
-                h("button", {
-                  className: "btn",
-                  style: { marginLeft: 4 },
-                  onClick: function () { window.open("https://github.com/D-sorganization/runner-dashboard", "_blank"); },
-                  title: "View documentation",
-                }, I.help ? I.help(12) : "?"),
-                h("button", {
+                },
+                principal ? "Logout" : "Login"
+              ),
+              h("span", {
+                className: "status-dot " + (connected ? "green" : "red"),
+              }),
+              connected ? "Live" : "Offline",
+              h(
+                "span",
+                { className: "hide-mobile" },
+                lastUpdate ? " \u00B7 " + lastUpdate : "",
+              ),
+              h(
+                "span",
+                {
+                  className: "section-badge",
+                  title: "Queued and running workflows",
+                },
+                "Queue " +
+                  ((queue.queued_count || 0) +
+                    "/" +
+                    (queue.in_progress_count || 0)),
+              ),
+              h(
+                "span",
+                {
+                  className: "section-badge",
+                  title:
+                    watchdog && watchdog.summary
+                      ? watchdog.summary
+                      : "WSL keepalive and watchdog state",
+                },
+                "Keepalive " +
+                  (watchdog && watchdog.status ? watchdog.status : "unknown"),
+              ),
+              h(
+                "span",
+                {
+                  className: "section-badge",
+                  title: deployment.deployed_at || "Deployment revision",
+                },
+                "Build " + shortSha(deployment.git_sha),
+              ),
+              h("button", {
+                className: "btn",
+                style: { marginLeft: 4, background: asstOpen ? "var(--accent-blue)" : undefined, color: asstOpen ? "#fff" : undefined },
+                onClick: toggleAsst,
+                title: "Toggle Assistant sidebar",
+              }, "☰ Asst"),
+              h(QuickDispatchPopover, null),
+              h(
+                "button",
+                {
                   className: "btn",
                   style: { marginLeft: 4 },
                   onClick: function () {
-                    fetchFleet(); fetchRepos(); fetchTests(); fetchReports();
-                    fetchQueue(); fetchMachines(); fetchLocalApps(); fetchEnrichedRuns();
-                    fetchWatchdog(); fetchDeployment(); fetchDeploymentState();
-                    fetchRemediationConfig(); fetchScheduledJobs(); fetchRunnerCapacity();
+                    fetchFleet();
+                    fetchRepos();
+                    fetchTests();
+                    fetchReports();
+                    fetchQueue();
+                    fetchMachines();
+                    fetchLocalApps();
+                    fetchEnrichedRuns();
+                    fetchWatchdog();
+                    fetchDeployment();
+                    fetchDeploymentState();
+                    fetchRemediationConfig();
+                    fetchScheduledJobs();
+                    fetchRunnerCapacity();
                   },
-                }, I.refresh(12)),
-              ),
-            ),
-            // ── Secondary ribbon (subtabs) ────────────────────────────────
-            h("div", { className: "ribbon-secondary" },
-              // Monitor
-              activeCategory === "monitor" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "overview" ? " active" : ""), onClick: function(){setTab("overview");} }, I.server(14), "Overview"),
-                h("button", { className: "ribbon-tab-btn" + (tab === "queue" ? " active" : ""), onClick: function(){setTab("queue"); fetchQueue();} }, I.queue(14), "Queue",
-                  (queue.total||0) > 0 ? h("span", {className:"section-badge",style:{background:"rgba(88,166,255,0.2)",color:"var(--accent-blue)",marginLeft:2}}, queue.total||0) : null),
-                h("button", { className: "ribbon-tab-btn" + (tab === "history" ? " active" : ""), onClick: function(){setTab("history"); fetchEnrichedRuns();} }, I.activity(14), "History",
-                  enrichedRuns.length > 0 ? h("span", {className:"section-badge",style:{background:"rgba(136,108,228,0.15)",color:"var(--accent-purple)",marginLeft:2}}, enrichedRuns.length) : null),
-                h("button", { className: "ribbon-tab-btn" + (tab === "stats" ? " active" : ""), onClick: function(){setTab("stats");} }, I.activity(14), "Stats"),
-                h("div", { className: "ribbon-group-label" }, "Overview")
-              ),
-              activeCategory === "monitor" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "machines" ? " active" : ""), onClick: function(){setTab("machines"); fetchMachines();} }, I.server(14), "Machines",
-                  (machinesData.count||0) > 1 ? h("span", {className:"section-badge",style:{background:"rgba(63,185,80,0.15)",color:"var(--accent-green)",marginLeft:2}}, machinesData.count||0) : null),
-                h("button", { className: "ribbon-tab-btn" + (tab === "local-apps" ? " active" : ""), onClick: function(){setTab("local-apps"); fetchLocalApps();} }, I.server(14), "Local Tools",
-                  (function(){var apps=localApps.tools||localApps.apps||[];var n=apps.filter(localAppNeedsAttention).length;return n>0?h("span",{className:"section-badge",style:{background:"rgba(210,153,34,0.2)",color:"var(--accent-yellow)",marginLeft:2}},n):null;})()),
-                h("div", { className: "ribbon-group-label" }, "Infrastructure")
-              ),
-              // Dispatch
-              activeCategory === "dispatch" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "workflows" ? " active" : ""), onClick: function(){setTab("workflows"); fetchWorkflowsList();} }, I.activity(14), "Workflows",
-                  workflowsList.length > 0 ? h("span", {className:"section-badge",style:{background:"rgba(88,166,255,0.15)",color:"#58a6ff",marginLeft:2}}, workflowsList.length) : null),
-                h("button", { className: "ribbon-tab-btn" + (tab === "scheduled-jobs" ? " active" : ""), onClick: function(){setTab("scheduled-jobs"); fetchScheduledJobs();} }, I.clock(14), "Schedules",
-                  (scheduledJobs.scheduled_workflow_count||0) > 0 ? h("span", {className:"section-badge",style:{background:"rgba(88,166,255,0.2)",color:"var(--accent-blue)",marginLeft:2}}, scheduledJobs.scheduled_workflow_count) : null),
-                h("div", { className: "ribbon-group-label" }, "Automation")
-              ),
-              activeCategory === "dispatch" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "runner-schedule" ? " active" : ""), onClick: function(){setTab("runner-schedule"); fetchRunnerCapacity();} }, I.clock(14), "Runner Plan",
-                  runnerCapacity&&runnerCapacity.state ? h("span", {className:"section-badge",style:{background:"rgba(63,185,80,0.15)",color:"var(--accent-green)",marginLeft:2}}, runnerCapacity.state.desired||0) : null),
-                h("div", { className: "ribbon-group-label" }, "Capacity")
-              ),
-              activeCategory === "dispatch" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "agent-launcher" ? " active" : ""), onClick: function(){setTab("agent-launcher");} }, I.terminal ? I.terminal(14) : I.server(14), "Agent Launcher"),
-                h("button", { className: "ribbon-tab-btn" + (tab === "maxwell" ? " active" : ""), onClick: function(){setTab("maxwell"); fetchMaxwellStatus();} }, I.server(14), "Maxwell",
-                  maxwellStatus.status === "running" ? h("span", {className:"section-badge",style:{background:"rgba(63,185,80,0.15)",color:"var(--accent-green)",marginLeft:2}}, "on") :
-                    maxwellStatus.status ? h("span", {className:"section-badge",style:{background:"rgba(248,81,73,0.15)",color:"var(--accent-red)",marginLeft:2}}, "off") : null),
-                h("div", { className: "ribbon-group-label" }, "Agents")
-              ),
-              // Manage
-              activeCategory === "manage" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "remediation" ? " active" : ""), onClick: function(){setTab("remediation"); fetchRemediationConfig();} }, I.issue(14), "Remediation",
-                  runs.filter(function(r){return r.conclusion==="failure";}).length > 0 ? h("span", {className:"section-badge",style:{background:"rgba(248,81,73,0.15)",color:"var(--accent-red)",marginLeft:2}}, runs.filter(function(r){return r.conclusion==="failure";}).length) : null),
-                h("button", { className: "ribbon-tab-btn" + (tab === "deployment" ? " active" : ""), onClick: function(){setTab("deployment"); fetchDeploymentState();} }, I.server(14), "Deployment",
-                  (deploymentStateLoading||((deploymentState.rollout_state||{}).machines_attention||0)>0) ? h("span", {className:"section-badge",style:{background:"rgba(210,153,34,0.2)",color:"var(--accent-yellow)",marginLeft:2}}, deploymentStateLoading?"\u2026":(deploymentState.rollout_state||{}).machines_attention) : null),
-                h("button", { className: "ribbon-tab-btn" + (tab === "fleet-orchestration" ? " active" : ""), onClick: function(){setTab("fleet-orchestration"); fetchFleetOrchestration();} }, I.server(14), "Fleet Orchestration"),
-                h("div", { className: "ribbon-group-label" }, "Operations")
-              ),
-              activeCategory === "manage" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "credentials" ? " active" : ""), onClick: function(){setTab("credentials"); fetchCredentials();} }, I.settings(14), "Credentials",
-                  credentialsData.summary&&credentialsData.summary.not_ready>0 ? h("span", {className:"section-badge",style:{background:"rgba(210,153,34,0.15)",color:"var(--accent-yellow)",marginLeft:2}}, credentialsData.summary.not_ready) : null),
-                h("div", { className: "ribbon-group-label" }, "Security")
-              ),
-              activeCategory === "manage" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "org" ? " active" : ""), onClick: function(){setTab("org");} }, I.repo(14), "Organization"),
-                h("button", { className: "ribbon-tab-btn" + (tab === "principals" ? " active" : ""), onClick: function(){setTab("principals");} }, I.server(14), "Principals"),
-                h("div", { className: "ribbon-group-label" }, "Identity")
-              ),
-              // Reports
-              activeCategory === "reports" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "tests" ? " active" : ""), onClick: function(){setTab("tests");} }, I.flask(14), "Tests"),
-                h("button", { className: "ribbon-tab-btn" + (tab === "reports" ? " active" : ""), onClick: function(){setTab("reports");} }, I.fileText(14), "Reports"),
-                h("div", { className: "ribbon-group-label" }, "Quality")
-              ),
-              activeCategory === "reports" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "assessments" ? " active" : ""), onClick: function(){setTab("assessments"); fetchAssessments();} }, I.activity(14), "Assessments"),
-                h("button", { className: "ribbon-tab-btn" + (tab === "feature-requests" ? " active" : ""), onClick: function(){setTab("feature-requests"); fetchFeatureRequests();} }, I.issue(14), "Feature Requests",
-                  featureRequests.length > 0 ? h("span", {className:"section-badge",style:{background:"rgba(136,108,228,0.15)",color:"var(--accent-purple)",marginLeft:2}}, featureRequests.length) : null),
-                h("div", { className: "ribbon-group-label" }, "Evals")
-              ),
-              activeCategory === "reports" && h("div", { className: "ribbon-group" },
-                h("button", { className: "ribbon-tab-btn" + (tab === "diagnostics" ? " active" : ""), onClick: function(){setTab("diagnostics");} }, I.settings(14), "Diagnostics"),
-                h("div", { className: "ribbon-group-label" }, "System")
+                },
+                I.refresh(12),
               ),
             ),
           ),
+          (runnerAudit.violations && runnerAudit.violations.length > 0 && !auditBannerDismissed)
+            ? h(
+                "div",
+                {
+                  id: "hosted-runner-alert-banner",
+                  style: {
+                    background: "linear-gradient(90deg, rgba(248,81,73,0.18) 0%, rgba(240,136,62,0.18) 100%)",
+                    borderBottom: "2px solid var(--accent-red)",
+                    padding: "10px 24px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "12px",
+                    fontSize: "13px",
+                    fontWeight: "500",
+                    color: "var(--text-primary)",
+                    zIndex: 90,
+                    position: "sticky",
+                    top: "56px",
+                  },
+                },
+                h("span", { style: { fontSize: "18px" } }, "⚠️"),
+                h(
+                  "span",
+                  { style: { flex: 1 } },
+                  h("strong", { style: { color: "var(--accent-red)" } }, "BILLING ALERT: "),
+                  runnerAudit.violations.length + " workflow job(s) detected on GitHub-hosted runners. This incurs unexpected billing costs.",
+                ),
+                h(
+                  "button",
+                  {
+                    className: "btn",
+                    style: { background: "rgba(248,81,73,0.2)", color: "var(--accent-red)", border: "1px solid var(--accent-red)", fontSize: "12px" },
+                    onClick: function() { setTab("runner-audit"); },
+                  },
+                  "View Details",
+                ),
+                h(
+                  "button",
+                  {
+                    className: "btn",
+                    style: { fontSize: "12px", marginLeft: 4 },
+                    title: "Dismiss banner (violations still visible in Runner Audit tab)",
+                    onClick: function() { setAuditBannerDismissed(true); },
+                  },
+                  "× Dismiss",
+                ),
+              )
+            : null,
           h(
             "div",
-            { style: { display: "flex", flexDirection: asstPosition === "left" ? "row-reverse" : "row", alignItems: "flex-start", minHeight: "calc(100vh - 88px)" } },            h(
+            { style: { display: "flex", flexDirection: asstPosition === "left" ? "row-reverse" : "row", alignItems: "flex-start", minHeight: "calc(100vh - 56px)" } },
+            h(
               "div",
               { className: "main-content", role: "main", style: { flex: 1, minWidth: 0 } },
               tab === "overview"
@@ -17456,13 +17915,109 @@ function PrincipalsTab() {
                                                       fetchMaxwellStatus,
                                                     onControl: maxwellControl,
                                                   })
-                                                : tab === "agent-launcher"
-                                                  ? h(AgentLauncherTab, null)
+                                                : tab === "cline-launcher"
+                                                  ? h(ClineLauncherTab, null)
                                                   : tab === "diagnostics"
                                                     ? h(DiagnosticsTab, null)
-                                                    : tab === "principals"
-                                                      ? h(PrincipalsTab, null)
-                                                      : null,
+                                                    : tab === "runner-audit"
+                                                      ? h(
+                                                          "div",
+                                                          { className: "section", style: { padding: "24px" } },
+                                                          h(
+                                                            "div",
+                                                            { className: "section-header", style: { marginBottom: "16px", display: "flex", alignItems: "center", justifyContent: "space-between" } },
+                                                            h("div", { className: "section-title" },
+                                                              h("span", { style: { fontSize: "18px", marginRight: "8px" } }, "⚠️"),
+                                                              "Hosted-Runner Billing Audit",
+                                                            ),
+                                                            h("div", { style: { display: "flex", gap: "8px", alignItems: "center" } },
+                                                              runnerAudit.last_checked
+                                                                ? h("span", { style: { fontSize: "12px", color: "var(--text-muted)" } },
+                                                                    "Last checked: " + new Date(runnerAudit.last_checked).toLocaleString(),
+                                                                  )
+                                                                : h("span", { style: { fontSize: "12px", color: "var(--text-muted)" } }, "Not yet checked"),
+                                                              h(
+                                                                "button",
+                                                                {
+                                                                  className: "btn",
+                                                                  style: { fontSize: "12px" },
+                                                                  onClick: triggerRunnerAuditRefresh,
+                                                                },
+                                                                I.refresh(12),
+                                                                " Refresh Now",
+                                                              ),
+                                                            ),
+                                                          ),
+                                                          runnerAudit.error
+                                                            ? h("div", { style: { color: "var(--accent-red)", marginBottom: "12px", fontSize: "13px" } },
+                                                                "Error: " + runnerAudit.error,
+                                                              )
+                                                            : null,
+                                                          (runnerAudit.violations && runnerAudit.violations.length > 0)
+                                                            ? h(
+                                                                "div",
+                                                                null,
+                                                                h("div", { style: { marginBottom: "12px", padding: "10px 14px", background: "rgba(248,81,73,0.1)", border: "1px solid rgba(248,81,73,0.3)", borderRadius: "6px", fontSize: "13px" } },
+                                                                  h("strong", { style: { color: "var(--accent-red)" } }, runnerAudit.violations.length + " violation(s) found. "),
+                                                                  "These jobs ran on GitHub-hosted runners and may incur unexpected billing costs.",
+                                                                ),
+                                                                h(
+                                                                  "div",
+                                                                  { style: { overflowX: "auto" } },
+                                                                  h(
+                                                                    "table",
+                                                                    { style: { width: "100%", borderCollapse: "collapse", fontSize: "13px" } },
+                                                                    h(
+                                                                      "thead",
+                                                                      null,
+                                                                      h(
+                                                                        "tr",
+                                                                        { style: { borderBottom: "1px solid var(--border)", textAlign: "left" } },
+                                                                        h("th", { style: { padding: "8px 12px", color: "var(--text-secondary)", fontWeight: "600" } }, "Repo"),
+                                                                        h("th", { style: { padding: "8px 12px", color: "var(--text-secondary)", fontWeight: "600" } }, "Workflow"),
+                                                                        h("th", { style: { padding: "8px 12px", color: "var(--text-secondary)", fontWeight: "600" } }, "Job"),
+                                                                        h("th", { style: { padding: "8px 12px", color: "var(--text-secondary)", fontWeight: "600" } }, "Runner"),
+                                                                        h("th", { style: { padding: "8px 12px", color: "var(--text-secondary)", fontWeight: "600" } }, "Started"),
+                                                                        h("th", { style: { padding: "8px 12px", color: "var(--text-secondary)", fontWeight: "600" } }, "Link"),
+                                                                      ),
+                                                                    ),
+                                                                    h(
+                                                                      "tbody",
+                                                                      null,
+                                                                      runnerAudit.violations.map(function(v, i) {
+                                                                        return h(
+                                                                          "tr",
+                                                                          { key: i, style: { borderBottom: "1px solid var(--border)", background: i % 2 === 0 ? "transparent" : "rgba(255,255,255,0.02)" } },
+                                                                          h("td", { style: { padding: "8px 12px", fontWeight: "500" } }, v.repo),
+                                                                          h("td", { style: { padding: "8px 12px", color: "var(--text-secondary)" } }, v.workflow),
+                                                                          h("td", { style: { padding: "8px 12px", color: "var(--text-secondary)" } }, v.job_name),
+                                                                          h("td", { style: { padding: "8px 12px" } },
+                                                                            h("span", { style: { background: "rgba(248,81,73,0.15)", color: "var(--accent-red)", padding: "2px 6px", borderRadius: "4px", fontSize: "11px", fontFamily: "monospace" } }, v.runner_name || v.runner_group || "unknown"),
+                                                                          ),
+                                                                          h("td", { style: { padding: "8px 12px", color: "var(--text-muted)", fontSize: "12px" } },
+                                                                            v.started_at ? new Date(v.started_at).toLocaleString() : "—",
+                                                                          ),
+                                                                          h("td", { style: { padding: "8px 12px" } },
+                                                                            v.run_url
+                                                                              ? h("a", { href: v.run_url, target: "_blank", rel: "noopener noreferrer", style: { color: "var(--accent-blue)", textDecoration: "none", fontSize: "12px" } }, "View Run ↗")
+                                                                              : "—",
+                                                                          ),
+                                                                        );
+                                                                      }),
+                                                                    ),
+                                                                  ),
+                                                                ),
+                                                              )
+                                                            : h("div", { style: { textAlign: "center", padding: "48px 24px", color: "var(--text-muted)", fontSize: "14px" } },
+                                                                h("div", { style: { fontSize: "32px", marginBottom: "12px" } }, "✓"),
+                                                                runnerAudit.last_checked
+                                                                  ? "No hosted-runner violations detected. All recent jobs ran on self-hosted runners."
+                                                                  : "Audit has not run yet. Click \"Refresh Now\" to trigger an immediate check.",
+                                                              ),
+                                                        )
+                                                      : tab === "principals"
+                                                        ? h(PrincipalsTab, null)
+                                                        : null,
             ),
             h(AssistantSidebar, { currentTab: tab, open: asstOpen, onToggle: toggleAsst }),
           ),
@@ -17579,4 +18134,4 @@ function PrincipalsTab() {
       ReactDOM.createRoot(document.getElementById("root")).render(h(App));
     </script>
   </body>
-</html>
+</html>


### PR DESCRIPTION
## Summary

- Adds `GET /api/runner-routing-audit` and `POST /api/runner-routing-audit/refresh` endpoints that detect recent workflow jobs executed on GitHub-hosted runners (ubuntu-*, windows-*, macos-*, etc.) across all org repos
- Adds a 15-minute background polling loop (`_runner_audit_loop`) started via `@app.router.on_startup`; initial run fires after 30 seconds
- Frontend shows a **persistent sticky red alert banner** below the header when violations are detected, with a dismiss button and "View Details" link
- Adds a **Runner Audit tab** with a violations table (Repo | Workflow | Job | Runner | Started | Link) and a "Refresh Now" button that triggers an immediate backend re-audit
- Frontend polls the audit endpoint on load and every 5 minutes (300 000 ms)

## Test plan

- [ ] Start the backend locally; verify `/api/runner-routing-audit` returns `{"violations": [], "last_checked": null, "error": null}` immediately
- [ ] After 30 seconds verify `last_checked` is populated
- [ ] `POST /api/runner-routing-audit/refresh` returns `{"status": "refresh triggered"}`
- [ ] With `GH_TOKEN` unset, endpoint returns empty violations list (graceful no-op)
- [ ] With a valid `GH_TOKEN`, verify violations table populates if any hosted-runner jobs exist
- [ ] Alert banner appears when `violations.length > 0` and disappears when dismissed
- [ ] "View Details" button switches to the Runner Audit tab
- [ ] Runner Audit tab badge count matches violation count

🤖 Generated with [Claude Code](https://claude.com/claude-code)