### PR TITLE
fix(assessments): replace bare except blocks with except Exception

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -799,6 +799,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 - chore: migrate to `uv` for dependency management and add `uv.lock`.
 - ci: refactor CI workflows to be `uv`-native, ensuring reproducible builds and faster bootstrap times (resolves #163).
 - ci: updated `ci-spec-check` to monitor `uv.lock` for freshness.
+- fix: include `itsdangerous` in the `uv` dependency set so Starlette session middleware imports during test collection.
 
 ### 2.0.0 â€” 2026-04-23
 

--- a/assessments/assess_repo.py
+++ b/assessments/assess_repo.py
@@ -28,7 +28,7 @@ def grep_py(pattern, repo, directory):
             for i, line in enumerate(txt.splitlines(), 1):
                 if re.search(pattern, line):
                     matches.append((str(f.relative_to(repo)), i, line.strip()))
-        except:
+        except Exception:
             pass
     return matches
 
@@ -124,7 +124,7 @@ def assess(repo):
                     total_funcs += 1
                     if i + 1 < len(lines) and ('"""' in lines[i + 1] or "'''" in lines[i + 1]):
                         docstring_funcs += 1
-        except:
+        except Exception:
             pass
     if total_funcs > 0 and docstring_funcs / total_funcs < 0.5:
         findings.append(
@@ -184,7 +184,7 @@ def assess(repo):
                         "text": "try/except returning None without logging in {}".format(f.name),
                     }
                 )
-        except:
+        except Exception:
             pass
     scores["D"] = score_d
 
@@ -202,7 +202,7 @@ def assess(repo):
                         "text": "Possible repeated file I/O inside loop in {}".format(f.name),
                     }
                 )
-        except:
+        except Exception:
             pass
     if not (Path(repo) / "benchmarks").exists():
         findings.append({"criterion": "E", "severity": "P2", "principle": "PP4", "text": "No benchmarks/ directory"})
@@ -223,14 +223,14 @@ def assess(repo):
                     }
                 )
                 score_f = max(score_f - 2, 0)
-        except:
+        except Exception:
             pass
     magic = 0
     for f in all_py[:30]:
         try:
             txt = f.read_text(encoding="utf-8", errors="ignore")
             magic += len(re.findall(r"(?<![\w\d_])\d+\.\d+(?![\w\d_])", txt))
-        except:
+        except Exception:
             pass
     if magic > 20:
         findings.append(
@@ -268,7 +268,7 @@ def assess(repo):
             for i, line in enumerate(txt.splitlines(), 1):
                 if re.search(r'(password|secret|api[_-]?key|token)\s*=\s*["\']', line, re.IGNORECASE):
                     cred.append((str(f), i))
-        except:
+        except Exception:
             pass
     if cred:
         findings.append(
@@ -327,7 +327,7 @@ def assess(repo):
                     for line in txt.splitlines():
                         if re.search(r"TODO|FIXME|XXX|HACK|KLUDGE", line):
                             todo_count += 1
-                except:
+                except Exception:
                     pass
     if todo_count > 20:
         findings.append(

--- a/assessments/assess_runner_dashboard.py
+++ b/assessments/assess_runner_dashboard.py
@@ -30,7 +30,7 @@ def grep_py(pattern, directory):
             for i, line in enumerate(txt.splitlines(), 1):
                 if re.search(pattern, line):
                     matches.append((str(f.relative_to(REPO)), i, line.strip()))
-        except:
+        except Exception:
             pass
     return matches
 
@@ -128,7 +128,7 @@ def main():
                     total_funcs += 1
                     if i + 1 < len(lines) and ('"""' in lines[i + 1] or "'''" in lines[i + 1]):
                         docstring_funcs += 1
-        except:
+        except Exception:
             pass
     if total_funcs > 0 and docstring_funcs / total_funcs < 0.5:
         findings.append(
@@ -187,7 +187,7 @@ def main():
                             "text": "pytest.skip/xfail without issue link in {}".format(f.name),
                         }
                     )
-        except:
+        except Exception:
             pass
 
     scores["C"] = score_c
@@ -213,7 +213,7 @@ def main():
                         "text": "try/except returning None without logging in {}".format(f.name),
                     }
                 )
-        except:
+        except Exception:
             pass
 
     scores["D"] = score_d
@@ -232,7 +232,7 @@ def main():
                         "text": "Possible repeated file I/O inside loop in {}".format(f.name),
                     }
                 )
-        except:
+        except Exception:
             pass
 
     if not (Path(REPO) / "benchmarks").exists():
@@ -255,7 +255,7 @@ def main():
                     }
                 )
                 score_f = max(score_f - 2, 0)
-        except:
+        except Exception:
             pass
 
     magic = 0
@@ -263,7 +263,7 @@ def main():
         try:
             txt = f.read_text()
             magic += len(re.findall(r"(?<![\w\d_])\d+\.\d+(?![\w\d_])", txt))
-        except:
+        except Exception:
             pass
     if magic > 20:
         findings.append(
@@ -322,7 +322,7 @@ def main():
             for i, line in enumerate(txt.splitlines(), 1):
                 if re.search(r'(password|secret|api[_-]?key|token)\s*=\s*["\']', line, re.IGNORECASE):
                     cred.append((str(f), i))
-        except:
+        except Exception:
             pass
     if cred:
         findings.append(
@@ -390,7 +390,7 @@ def main():
                     for line in txt.splitlines():
                         if re.search(r"TODO|FIXME|XXX|HACK|KLUDGE", line):
                             todo_count += 1
-                except:
+                except Exception:
                     pass
     if todo_count > 20:
         findings.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "PyYAML==6.0.2",
     "anthropic==0.49.0",
     "requests==2.33.0",
+    "itsdangerous==2.2.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -309,6 +309,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -897,6 +906,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "itsdangerous" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -926,6 +936,7 @@ requires-dist = [
     { name = "anthropic", specifier = "==0.49.0" },
     { name = "fastapi", specifier = "==0.130.0" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "itsdangerous", specifier = "==2.2.0" },
     { name = "psutil", specifier = "==6.1.1" },
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.3" },


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in assessment scripts to follow Python best practices and avoid catching unexpected exceptions like KeyboardInterrupt and SystemExit.