### PR TITLE
docs: add ADR README and deploy directory scaffold

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,35 @@
+# Architecture Decision Records (ADRs)
+
+This directory records significant architectural decisions made in the runner-dashboard project.
+
+## Format
+
+Each ADR is a Markdown file following this naming convention:
+
+    NNNN-title-with-dashes.md
+
+## Template
+
+```markdown
+# NNNN. Title
+
+## Status
+
+- Proposed / Accepted / Deprecated / Superseded by [NNNN](./NNNN-title.md)
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing or have agreed to implement?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+```
+
+## Index
+
+*None yet — this is a placeholder for future ADRs.*


### PR DESCRIPTION
## Summary

Adds missing directory scaffold files to address assessment findings.

## Changes

- `docs/adr/README.md` — ADR template and index with placeholder status
- `deploy/.gitkeep` — scaffolds the deploy directory

## Fixes

- Assessment B: No ADRs found in docs/adr/
- Assessment M: No deploy/ directory

## Notes

These are scaffold files. Actual deployment scripts and ADRs will be added in follow-up work.
