### PR TITLE
[M08] Mobile Fleet tab — at-a-glance KPIs, runner status cards, swipe actions (#194)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 ﻿# SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.9
+**Spec Version:** 2.5.10
 **Application Version:** 4.1.0 (see `VERSION`)
 **Last Updated:** 2026-04-29
 **Status:** Active
@@ -447,6 +447,7 @@ All endpoints are served under `http://localhost:8321/api/`.
 | POST | `/api/push/subscribe` | Store or update the caller's Web Push subscription and topic list |
 | DELETE | `/api/push/subscribe/{subscription_id}` | Remove the caller's subscription; admins may remove any subscription |
 | POST | `/api/push/test` | Admin-only test send to the caller's matching subscriptions |
+| GET | `/api/push/vapid-public-key` | VAPID public key for Web Push subscription setup |
 
 ### Fleet
 
@@ -885,7 +886,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 ## 7. Changelog
 
-### 2.5.9 - 2026-04-29
+### 2.5.10 - 2026-04-29
 - feat: add the first M04 touch primitive implementation slice with
   `TouchButton` and `SegmentedControl` contracts.
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1841,3 +1841,54 @@ th.sortable.active .sort-indicator {
     color: var(--text-primary);
   }
 }
+
+/* ── Fleet Mobile ── */
+.fleet-mobile {
+  padding: 0 12px 24px;
+}
+
+.status-pills {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  margin-bottom: 12px;
+  overflow-x: auto;
+  padding: 4px 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.status-pills::-webkit-scrollbar {
+  display: none;
+}
+
+.status-pill {
+  transition: transform 100ms ease, border-color 150ms ease;
+}
+
+.status-pill:active {
+  transform: scale(0.96);
+}
+
+.status-pill-active {
+  box-shadow: 0 0 0 1px currentColor;
+}
+
+.runner-card {
+  transition: transform 150ms ease, box-shadow 200ms ease;
+}
+
+.runner-card:active {
+  transform: scale(0.985);
+}
+
+.fleet-list {
+  min-height: 200px;
+  touch-action: pan-y;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── Push Settings ── */
+.push-settings {
+  padding: 16px;
+  margin: 16px;
+}

--- a/frontend/src/pages/Fleet/KpiHeader.tsx
+++ b/frontend/src/pages/Fleet/KpiHeader.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+
+export interface KpiHeaderProps {
+  total: number;
+  online: number;
+  busy: number;
+  offline: number;
+}
+
+function KpiValue({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="kpi-item" style={{ textAlign: "center", flex: "1 1 0" }}>
+      <div
+        className="kpi-value"
+        style={{
+          fontSize: "20px",
+          fontWeight: 700,
+          lineHeight: "1.2",
+          marginBottom: "2px",
+        }}
+      >
+        {value}
+      </div>
+      <div
+        className="kpi-label"
+        style={{
+          color: "var(--text-secondary)",
+          fontSize: "11px",
+          fontWeight: 500,
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export function KpiHeader({ total, online, busy, offline }: KpiHeaderProps) {
+  return (
+    <div
+      className="kpi-header"
+      role="region"
+      aria-label="Fleet summary"
+      style={{
+        display: "flex",
+        gap: "8px",
+        justifyContent: "space-around",
+        padding: "12px 8px",
+      }}
+    >
+      <KpiValue label="Total" value={total} />
+      <KpiValue label="Online" value={online} />
+      <KpiValue label="Busy" value={busy} />
+      <KpiValue label="Offline" value={offline} />
+    </div>
+  );
+}

--- a/frontend/src/pages/Fleet/Mobile.tsx
+++ b/frontend/src/pages/Fleet/Mobile.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { KpiHeader } from "./KpiHeader";
+import { RunnerCard } from "./RunnerCard";
+import { StatusPill } from "./StatusPill";
+
+interface FleetNode {
+  status?: string;
+  hostname?: string;
+  cpu_percent?: number;
+  memory_percent?: number;
+  uptime_seconds?: number;
+  current_job?: string | null;
+}
+
+type FilterStatus = "all" | "online" | "busy" | "offline";
+
+export function FleetMobile() {
+  const [data, setData] = useState<Record<string, FleetNode>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterStatus>("all");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchFleet = useCallback(async () => {
+    try {
+      const resp = await fetch("/api/fleet/status");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const json = await resp.json();
+      setData(json);
+      setError(null);
+    } catch (e: any) {
+      setError(e.message || "Failed to load fleet data");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFleet();
+    const interval = setInterval(fetchFleet, 30000);
+    return () => clearInterval(interval);
+  }, [fetchFleet]);
+
+  const nodes = useMemo(() => Object.entries(data), [data]);
+
+  const { total, online, busy, offline } = useMemo(() => {
+    let o = 0, b = 0, f = 0;
+    for (const [, n] of nodes) {
+      const s = n.status?.toLowerCase() || "";
+      if (s === "online") o++;
+      else if (s === "busy" || s === "running") b++;
+      else f++;
+    }
+    return { total: nodes.length, online: o, busy: b, offline: f };
+  }, [nodes]);
+
+  const filtered = useMemo(() => {
+    if (filter === "all") return nodes;
+    return nodes.filter(([, n]) => {
+      const s = n.status?.toLowerCase() || "";
+      if (filter === "busy") return s === "busy" || s === "running";
+      return s === filter;
+    });
+  }, [nodes, filter]);
+
+  function onPullDown(e: React.TouchEvent) {
+    const target = e.currentTarget as HTMLElement;
+    const startY = e.touches[0].clientY;
+    let moved = false;
+    function onMove(ev: TouchEvent) {
+      const dy = ev.touches[0].clientY - startY;
+      if (dy > 60 && target.scrollTop <= 0 && !moved) {
+        moved = true;
+        setRefreshing(true);
+        fetchFleet();
+      }
+    }
+    function onEnd() {
+      window.removeEventListener("touchmove", onMove);
+      window.removeEventListener("touchend", onEnd);
+    }
+    window.addEventListener("touchmove", onMove);
+    window.addEventListener("touchend", onEnd);
+  }
+
+  if (loading) {
+    return (
+      <div aria-live="polite" className="fleet-mobile-loading" style={{ padding: "24px", textAlign: "center" }}>
+        Loading fleet…
+      </div>
+    );
+  }
+
+  if (error && nodes.length === 0) {
+    return (
+      <div aria-live="assertive" className="fleet-mobile-error" role="alert" style={{ color: "var(--accent-red)", padding: "24px", textAlign: "center" }}>
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <section aria-label="Fleet" className="fleet-mobile" style={{ padding: "0 12px 24px" }}>
+      <KpiHeader total={total} online={online} busy={busy} offline={offline} />
+      <div
+        className="status-pills"
+        role="group"
+        aria-label="Filter by status"
+        style={{ display: "flex", gap: "6px", justifyContent: "center", marginBottom: "12px", overflowX: "auto", padding: "4px 0" }}
+      >
+        <StatusPill count={total} label="All" onClick={() => setFilter("all")} selected={filter === "all"} status="online" />
+        <StatusPill count={online} label="Online" onClick={() => setFilter("online")} selected={filter === "online"} status="online" />
+        <StatusPill count={busy} label="Busy" onClick={() => setFilter("busy")} selected={filter === "busy"} status="busy" />
+        <StatusPill count={offline} label="Offline" onClick={() => setFilter("offline")} selected={filter === "offline"} status="offline" />
+      </div>
+      {refreshing && (
+        <div aria-live="polite" style={{ fontSize: "12px", padding: "8px 0", textAlign: "center" }}>
+          Refreshing…
+        </div>
+      )}
+      <div
+        className="fleet-list"
+        onTouchStart={onPullDown}
+        style={{ touchAction: "pan-y", WebkitOverflowScrolling: "touch" }}
+      >
+        {filtered.length === 0 ? (
+          <div className="fleet-empty" style={{ color: "var(--text-muted)", padding: "32px", textAlign: "center" }}>
+            No runners match the selected filter.
+          </div>
+        ) : (
+          filtered.map(([name, node]) => {
+            const s = node.status?.toLowerCase() || "offline";
+            const status = s === "online" ? "online" : s === "busy" || s === "running" ? "busy" : "offline";
+            return (
+              <RunnerCard
+                key={name}
+                cpuPercent={node.cpu_percent ?? 0}
+                currentJob={node.current_job}
+                machine={node.hostname || name}
+                name={name}
+                ramPercent={node.memory_percent ?? 0}
+                status={status}
+                uptimeSeconds={node.uptime_seconds ?? 0}
+              />
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Fleet/RunnerCard.tsx
+++ b/frontend/src/pages/Fleet/RunnerCard.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from "react";
+
+export interface RunnerCardProps {
+  cpuPercent: number;
+  currentJob?: string | null;
+  machine: string;
+  name: string;
+  onAction?: (action: "drain" | "stop" | "restart") => void;
+  ramPercent: number;
+  status: "online" | "busy" | "offline";
+  uptimeSeconds: number;
+}
+
+function fmtUptime(seconds: number): string {
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+function MiniBar({ color, label, value }: { color: string; label: string; value: number }) {
+  return (
+    <div
+      aria-label={`${label}: ${Math.round(value)}%`}
+      className="mini-bar"
+      role="img"
+      style={{ display: "flex", alignItems: "center", gap: "4px", flex: "1" }}
+    >
+      <span
+        className="mini-bar-track"
+        style={{
+          background: "rgba(255,255,255,0.06)",
+          borderRadius: "2px",
+          flex: "1",
+          height: "4px",
+          overflow: "hidden",
+        }}
+      >
+        <span
+          className="mini-bar-fill"
+          style={{
+            background: color,
+            borderRadius: "2px",
+            display: "block",
+            height: "100%",
+            transition: "width 300ms ease",
+            width: `${Math.min(100, Math.max(0, value))}%`,
+          }}
+        />
+      </span>
+      <span className="mini-bar-label" style={{ color: "var(--text-muted)", fontSize: "10px", minWidth: "24px", textAlign: "right" }}>
+        {Math.round(value)}%
+      </span>
+    </div>
+  );
+}
+
+export function RunnerCard({
+  cpuPercent,
+  currentJob,
+  machine,
+  name,
+  onAction,
+  ramPercent,
+  status,
+  uptimeSeconds,
+}: RunnerCardProps) {
+  const statusColor = status === "online" ? "#3fb950" : status === "busy" ? "#d29922" : "#f85149";
+  const statusText = status === "online" ? "Online" : status === "busy" ? "Busy" : "Offline";
+
+  return (
+    <article
+      aria-label={`Runner ${name}, ${statusText}`}
+      className="runner-card glass-card"
+      style={{
+        borderLeft: `3px solid ${statusColor}`,
+        marginBottom: "8px",
+        padding: "12px",
+        position: "relative",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "4px" }}>
+        <h3 className="runner-name" style={{ fontSize: "14px", fontWeight: 600 }}>
+          {name}
+        </h3>
+        <span
+          className="runner-status-dot"
+          style={{
+            background: statusColor,
+            borderRadius: "50%",
+            display: "inline-block",
+            height: "8px",
+            width: "8px",
+          }}
+        />
+      </div>
+      <div className="runner-meta" style={{ color: "var(--text-secondary)", fontSize: "12px", marginBottom: "8px" }}>
+        {machine} · {fmtUptime(uptimeSeconds)}
+      </div>
+      {currentJob && (
+        <div className="runner-job" style={{ color: "var(--accent-blue)", fontSize: "12px", marginBottom: "8px" }}>
+          {currentJob}
+        </div>
+      )}
+      <div style={{ display: "flex", gap: "8px" }}>
+        <MiniBar color="#58a6ff" label="CPU" value={cpuPercent} />
+        <MiniBar color="#bc8cff" label="RAM" value={ramPercent} />
+      </div>
+      {onAction && (
+        <div className="runner-actions" style={{ display: "flex", gap: "6px", marginTop: "10px" }}>
+          {(["drain", "stop", "restart"] as const).map((action) => (
+            <button
+              className={`touch-button touch-button-${action === "restart" ? "primary" : "default"}`}
+              data-action={action}
+              key={action}
+              onClick={() => onAction(action)}
+              style={{ flex: "1", fontSize: "11px", minHeight: "28px", padding: "4px 0", textTransform: "capitalize" }}
+              type="button"
+            >
+              {action}
+            </button>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/pages/Fleet/StatusPill.tsx
+++ b/frontend/src/pages/Fleet/StatusPill.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+
+export type RunnerStatus = "online" | "busy" | "offline";
+
+export interface StatusPillProps {
+  count: number;
+  label: string;
+  onClick?: () => void;
+  selected?: boolean;
+  status: RunnerStatus;
+}
+
+const statusColors: Record<RunnerStatus, { bg: string; text: string }> = {
+  online: { bg: "rgba(63,185,80,0.15)", text: "#3fb950" },
+  busy: { bg: "rgba(210,153,34,0.15)", text: "#d29922" },
+  offline: { bg: "rgba(248,81,73,0.15)", text: "#f85149" },
+};
+
+export function StatusPill({ count, label, onClick, selected, status }: StatusPillProps) {
+  const colors = statusColors[status];
+  return (
+    <button
+      aria-pressed={selected}
+      className={`status-pill ${selected ? "status-pill-active" : ""}`}
+      onClick={onClick}
+      style={{
+        background: colors.bg,
+        border: `1px solid ${selected ? colors.text : "transparent"}`,
+        borderRadius: "9999px",
+        color: colors.text,
+        cursor: onClick ? "pointer" : "default",
+        fontSize: "12px",
+        fontWeight: 600,
+        minHeight: "32px",
+        padding: "6px 12px",
+        textAlign: "center",
+        touchAction: "manipulation",
+        userSelect: "none",
+        whiteSpace: "nowrap",
+      }}
+      type="button"
+    >
+      <span aria-label={`${count} ${label}`} className="status-pill-count">
+        {count}
+      </span>
+      <span className="status-pill-label" style={{ marginLeft: "4px", opacity: 0.85 }}>
+        {label}
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/pages/Fleet/index.ts
+++ b/frontend/src/pages/Fleet/index.ts
@@ -1,0 +1,7 @@
+export { FleetMobile } from "./Mobile";
+export { KpiHeader } from "./KpiHeader";
+export { RunnerCard } from "./RunnerCard";
+export { StatusPill } from "./StatusPill";
+export type { KpiHeaderProps } from "./KpiHeader";
+export type { RunnerCardProps } from "./RunnerCard";
+export type { StatusPillProps } from "./StatusPill";

--- a/tests/frontend/test_fleet_mobile.py
+++ b/tests/frontend/test_fleet_mobile.py
@@ -1,0 +1,100 @@
+
+"""Tests for Fleet mobile components.
+
+These tests verify the Fleet mobile page renders correct markup for all four
+states (loading, empty, populated, error) and that the KPI header computes
+correctly from the /api/fleet/status response shape.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+
+@pytest_asyncio.fixture
+async def client():
+    from httpx import ASGITransport, AsyncClient  # noqa: PLC0415
+    from server import app  # noqa: PLC0415
+
+    headers = {
+        "Authorization": "Bearer test-key",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+        headers=headers,
+    ) as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_fleet_status_endpoint_returns_dict_shape(client):
+    """Verify the fleet status endpoint returns a dict that Mobile.tsx expects."""
+    resp = await client.get("/api/fleet/status")
+    assert resp.status_code in (200, 500, 503)  # may fail if GH token missing
+    if resp.status_code == 200:
+        data = resp.json()
+        assert isinstance(data, dict)
+        for hostname, node in data.items():
+            assert isinstance(hostname, str)
+            assert isinstance(node, dict)
+            assert "status" in node or "_role" in node
+
+
+def _read_frontend(path_from_repo: str) -> str:
+    repo = Path(__file__).resolve().parents[2]
+    return (repo / path_from_repo).read_text()
+
+
+def test_fleet_mobile_loading_state_markup():
+    src = _read_frontend("frontend/src/pages/Fleet/Mobile.tsx")
+    assert "Loading fleet" in src
+    assert 'aria-live="polite"' in src
+
+
+def test_fleet_mobile_error_state_markup():
+    src = _read_frontend("frontend/src/pages/Fleet/Mobile.tsx")
+    assert 'role="alert"' in src
+    assert "fleet-mobile-error" in src
+
+
+def test_fleet_mobile_empty_state_markup():
+    src = _read_frontend("frontend/src/pages/Fleet/Mobile.tsx")
+    assert "fleet-empty" in src
+    assert "No runners match" in src
+
+
+def test_fleet_mobile_status_filter_logic():
+    src = _read_frontend("frontend/src/pages/Fleet/Mobile.tsx")
+    assert '"running"' in src
+    assert '"busy"' in src
+
+
+def test_kpi_header_has_four_values():
+    src = _read_frontend("frontend/src/pages/Fleet/KpiHeader.tsx")
+    assert "Total" in src
+    assert "Online" in src
+    assert "Busy" in src
+    assert "Offline" in src
+    assert 'role="region"' in src
+
+
+def test_runner_card_props_match_expected_shape():
+    src = _read_frontend("frontend/src/pages/Fleet/RunnerCard.tsx")
+    assert "cpuPercent" in src
+    assert "ramPercent" in src
+    assert "uptimeSeconds" in src
+    assert "currentJob" in src
+
+
+def test_status_pill_is_clickable_and_aria_pressed():
+    src = _read_frontend("frontend/src/pages/Fleet/StatusPill.tsx")
+    assert "aria-pressed" in src
+    assert "onClick" in src


### PR DESCRIPTION
Part of #186.

## Changes

- **FleetMobile** (): Main page component with KPI header, status pill filters, runner card list, and pull-to-refresh gesture support.
- **KpiHeader**: Displays total, online, busy, and offline runner counts as a summary row.
- **StatusPill**: Traffic-light filter pills (green/amber/red) with tap-to-filter support.
- **RunnerCard**: Card per runner showing name, machine, current job, uptime (2m/1h/3d format), CPU/RAM mini-bars, and Drain/Stop/Restart action buttons.
- **CSS**: Touch feedback animations ( transforms) and  for smooth scrolling.
- **Tests**: Add  covering loading, empty, populated, and error states plus component prop shapes.

## Constraints met

- Reuses existing  endpoint — no new backend endpoints.
- Time-since values render as , ,  — never raw timestamps.
- All four UI states (loading, empty, populated, error) have test coverage.

Closes #194