### PR TITLE
test(#155): add unit tests for small backend modules

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 ﻿# SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.10
+**Spec Version:** 2.5.11
 **Application Version:** 4.1.0 (see `VERSION`)
 **Last Updated:** 2026-04-29
 **Status:** Active
@@ -536,6 +536,82 @@ All endpoints are served under `http://localhost:8321/api/`.
 | POST | `/api/prs/dispatch` | Bulk-dispatch agent tasks to selected PRs |
 | POST | `/api/issues/dispatch` | Bulk-dispatch agent tasks to selected issues |
 
+### Authentication
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/auth/github` | Start GitHub OAuth flow |
+| GET | `/api/auth/callback` | GitHub OAuth callback |
+| GET | `/api/auth/dev-login` | Development login when OAuth is not configured |
+| POST | `/api/auth/logout` | Clear session and revoke all active sessions for this principal |
+| GET | `/api/auth/me` | Get current authenticated principal |
+| POST | `/api/auth/tokens` | Mint a new service token (admin only) |
+| DELETE | `/api/auth/tokens/{token_hash}` | Revoke a service token (admin only) |
+
+#### Session Management
+
+Sessions are bound to the originating IP address, user-agent substring, and an
+anti-CSRF double-submit token. Every successful login, session refresh, or
+token rotation updates the session `updated_at` timestamp and rotates the
+session ID stored in the client cookie.
+
+**Session revocation** (`backend/session_management.py`):
+- `revoke_all_sessions_for(principal_id, except_sid=None)` revokes every
+  active session for a principal except the optionally excluded session ID.
+- `revoke_session(session_id)` revokes a single session by ID.
+- Sessions revoked by backend change include `revoked_reason` metadata
+  (`password_change`, `remote_logout`, `suspicious_activity`).
+- Revoked sessions are kept for audit rather than deleted; they remain
+  visible to the current user for 7 days and to admins for 30 days.
+
+**Session cleanup** (`SessionCleanupJob`):
+- Runs every 10 minutes (first run delayed by 60 seconds).
+- Deletes expired sessions (`last_seen_at + max_age < now`).
+- Marks stale sessions inactive (`last_seen_at + stale_threshold < now`).
+- Cleans up orphaned revoked sessions older than 7 days.
+- Logs a summary of processed and removed counts at `INFO` level.
+
+**Remote logout** (`POST /api/auth/logout`):
+- When called with an authenticated session, clears the current session and
+  revokes all other sessions belonging to the same principal.
+- Returns `{"status": "logged_out", "revoked_sessions": N}` where `N` is the
+  count of other sessions invalidated.
+- Revoked sessions receive `revoked_reason: "remote_logout"` metadata for audit.
+
+#### WebAuthn Biometric Unlock
+
+The `/api/auth/webauthn/*` route surface provides fail-closed scaffolding for
+mobile biometric unlock. Registration and assertion begin endpoints require an
+already authenticated principal and issue short-lived, HMAC-signed server
+challenges. Credential metadata is stored per principal as
+`(user_id, credential_id, public_key, sign_count)` and can be listed or revoked
+by the owning principal. Completion endpoints intentionally fail closed until a
+pinned WebAuthn verifier validates attestation/assertion payloads and sign-count
+replay protection.
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/api/auth/webauthn/register/begin` | Start a WebAuthn registration ceremony |
+| POST | `/api/auth/webauthn/register/complete` | Complete registration (returns HTTP 501 until verifier wired) |
+| POST | `/api/auth/webauthn/assert/begin` | Start a WebAuthn assertion ceremony |
+| POST | `/api/auth/webauthn/assert/complete` | Complete assertion (returns HTTP 501 until verifier wired) |
+| GET | `/api/auth/webauthn/credentials` | List active credential metadata for the current principal |
+| DELETE | `/api/auth/webauthn/credentials/{credential_id}` | Revoke one WebAuthn credential |
+
+**Challenge lifecycle:**
+- Server challenges are 32-byte base64url tokens valid for 300 seconds.
+- Each challenge is HMAC-signed with a secret derived from
+  `DASHBOARD_WEBAUTHN_CHALLENGE_SECRET`, `SESSION_SECRET`, or
+  `DASHBOARD_API_KEY` (in that order of preference).
+- Challenges are stored in the server-side session under
+  `webauthn_challenges` and pruned of expired entries on each request.
+
+**Credential storage:**
+- Credentials are persisted as JSON to
+  `~/.config/runner-dashboard/webauthn_credentials.json`.
+- The file is created with `0600` permissions.
+- Active credentials are filtered by `user_id` and `revoked_at is None`.
+
 ### Credentials
 
 | Method | Path | Description |
@@ -886,6 +962,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 ## 7. Changelog
 
+### 2.5.12 - 2026-04-29
+- feat: document Authentication API, Session Management, Remote Logout, and WebAuthn Biometric Unlock endpoints (issue #193).
+
 ### 2.5.10 - 2026-04-29
 - feat: add the first M04 touch primitive implementation slice with
   `TouchButton` and `SegmentedControl` contracts.
@@ -960,6 +1039,12 @@ Test coverage areas:
 - **`tests/test_mobile_test_harness.py`** - validates the issue #202 mobile
   viewport profiles, smoke-page marker contract, touch helper exports, and the
   explicit visual-regression opt-in gate.
+- `tests/test_cache_utils.py` — unit tests for `backend/cache_utils.py`:
+  TTL get behavior, eviction on capacity, LRU ordering, float TTLs.
+- `tests/test_proxy_utils.py` — unit tests for `backend/proxy_utils.py`:
+  hub-proxy routing logic, local/scope query-param precedence, case-insensitive matching.
+- `tests/test_report_files.py` — unit tests for `backend/report_files.py`:
+  markdown-table metric parsing, date sanitization, separator/header skipping.
 
 `pytest>=8.0` and `pytest-asyncio>=0.23` are listed in `requirements.txt`.
 

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,108 @@
+"""Unit tests for backend/cache_utils.py (issue #155)."""
+
+from __future__ import annotations
+
+import sys  # noqa: E402
+import time
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+import cache_utils  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Ensure the global cache is cleared before and after each test."""
+    cache_utils.cache_clear()
+    yield
+    cache_utils.cache_clear()
+
+
+class TestCacheGet:
+    def test_miss_empty_cache(self) -> None:
+        assert cache_utils.cache_get("missing", ttl=60) is None
+
+    def test_hit_within_ttl(self) -> None:
+        cache_utils.cache_set("key", {"data": 123})
+        result = cache_utils.cache_get("key", ttl=60)
+        assert result == {"data": 123}
+
+    def test_miss_after_ttl_expires(self) -> None:
+        cache_utils.cache_set("key", "value")
+        # Simulate passage of time by manipulating the stored timestamp
+        original_entry = cache_utils._cache["key"]
+        cache_utils._cache["key"] = ("value", original_entry[1] - 100)
+        assert cache_utils.cache_get("key", ttl=60) is None
+
+    def test_miss_on_expired_but_key_exists(self) -> None:
+        cache_utils.cache_set("key", "stale")
+        # Backdate the entry so it's expired
+        data, ts = cache_utils._cache["key"]
+        cache_utils._cache["key"] = (data, ts - 1000)
+        assert cache_utils.cache_get("key", ttl=60) is None
+
+    def test_hit_with_zero_ttl(self) -> None:
+        cache_utils.cache_set("key", "value")
+        # With ttl=0, any entry is immediately expired
+        assert cache_utils.cache_get("key", ttl=0) is None
+
+    def test_ttl_as_float(self) -> None:
+        cache_utils.cache_set("key", "value")
+        result = cache_utils.cache_get("key", ttl=0.5)
+        assert result == "value"
+
+
+class TestCacheSet:
+    def test_stores_value(self) -> None:
+        cache_utils.cache_set("key", "value")
+        assert cache_utils._cache["key"][0] == "value"
+
+    def test_stores_current_timestamp(self) -> None:
+        before = time.time()
+        cache_utils.cache_set("key", "value")
+        after = time.time()
+        stored_ts = cache_utils._cache["key"][1]
+        assert before <= stored_ts <= after
+
+    def test_move_to_end_on_update(self) -> None:
+        from unittest.mock import patch
+
+        cache_utils.cache_set("key1", "a")
+        cache_utils.cache_set("key2", "b")
+        # Updating key1 should move it to the end
+        original_keys = list(cache_utils._cache.keys())
+        assert original_keys == ["key1", "key2"]
+        cache_utils.cache_set("key1", "aa")
+        new_keys = list(cache_utils._cache.keys())
+        assert new_keys == ["key2", "key1"]
+
+    def test_eviction_when_full(self) -> None:
+        from unittest.mock import patch
+
+        with patch.object(cache_utils, "MAX_CACHE_SIZE", 3):
+            with patch.object(cache_utils, "CACHE_EVICT_BATCH", 1):
+                # Populate to capacity
+                cache_utils.cache_set("k1", "v1")
+                cache_utils.cache_set("k2", "v2")
+                cache_utils.cache_set("k3", "v3")
+                # Adding a 4th should evict the oldest (k1)
+                cache_utils.cache_set("k4", "v4")
+                assert "k1" not in cache_utils._cache
+                assert "k4" in cache_utils._cache
+
+
+class TestCacheClear:
+    def test_clears_all_entries(self) -> None:
+        cache_utils.cache_set("a", 1)
+        cache_utils.cache_set("b", 2)
+        cache_utils.cache_clear()
+        assert len(cache_utils._cache) == 0
+        assert cache_utils.cache_get("a", ttl=60) is None
+        assert cache_utils.cache_get("b", ttl=60) is None
+
+    def test_clear_on_empty_cache(self) -> None:
+        cache_utils.cache_clear()
+        assert len(cache_utils._cache) == 0

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -68,8 +68,6 @@ class TestCacheSet:
         assert before <= stored_ts <= after
 
     def test_move_to_end_on_update(self) -> None:
-        from unittest.mock import patch
-
         cache_utils.cache_set("key1", "a")
         cache_utils.cache_set("key2", "b")
         # Updating key1 should move it to the end

--- a/tests/test_proxy_utils.py
+++ b/tests/test_proxy_utils.py
@@ -1,0 +1,116 @@
+"""Unit tests for backend/proxy_utils.py (issue #155)."""
+
+from __future__ import annotations
+
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+import proxy_utils  # noqa: E402
+
+
+def _make_request(query_params: dict[str, str]) -> MagicMock:
+    """Return a mocked FastAPI Request with the given query_params."""
+    mock = MagicMock()
+    mock.query_params.get = lambda key, default="": query_params.get(key, default)
+    return mock
+
+
+class TestShouldProxyFleetToHub:
+    def test_not_node_role_returns_false(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "hub"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_no_hub_url_returns_false(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", None):
+                req = _make_request({})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_node_with_hub_no_local_params_returns_true(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is True
+
+    def test_local_param_true_returns_false(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "true"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_local_param_yes_returns_false(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "yes"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_local_param_1_returns_false(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "1"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_local_param_local_returns_false(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "local"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_local_param_false_returns_true(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "false"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is True
+
+    def test_local_param_0_returns_true(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "0"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is True
+
+    def test_scope_local_returns_false(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"scope": "local"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_scope_fleet_returns_true(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"scope": "fleet"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is True
+
+    def test_local_case_insensitive(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "TRUE"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_scope_case_insensitive(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"scope": "LOCAL"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_multiple_params_local_wins(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "true", "scope": "fleet"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_multiple_params_scope_wins(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", "http://hub.internal"):
+                req = _make_request({"local": "false", "scope": "local"})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False
+
+    def test_empty_hub_url_string_not_configured(self) -> None:
+        with patch.object(proxy_utils, "MACHINE_ROLE", "node"):
+            with patch.object(proxy_utils, "HUB_URL", ""):
+                req = _make_request({})
+                assert proxy_utils.should_proxy_fleet_to_hub(req) is False

--- a/tests/test_report_files.py
+++ b/tests/test_report_files.py
@@ -1,0 +1,92 @@
+"""Unit tests for backend/report_files.py (issue #155)."""
+
+from __future__ import annotations
+
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+import report_files  # noqa: E402
+
+
+class TestSanitizeReportDate:
+    def test_keeps_digits_and_dashes(self) -> None:
+        assert report_files.sanitize_report_date("2024-03-15") == "2024-03-15"
+
+    def test_removes_slashes(self) -> None:
+        assert report_files.sanitize_report_date("2024/03/15") == "20240315"
+
+    def test_removes_spaces(self) -> None:
+        assert report_files.sanitize_report_date("2024 03 15") == "20240315"
+
+    def test_removes_letters(self) -> None:
+        assert report_files.sanitize_report_date("report-2024-03-15") == "-2024-03-15"
+
+    def test_empty_string(self) -> None:
+        assert report_files.sanitize_report_date("") == ""
+
+    def test_mixed_garbage(self) -> None:
+        assert report_files.sanitize_report_date("abc!@#2024-03-15xyz") == "2024-03-15"
+
+
+class TestParseReportMetrics:
+    def test_empty_content(self) -> None:
+        assert report_files.parse_report_metrics("") == {}
+
+    def test_single_metric_row(self) -> None:
+        content = "| Metric | Value | Delta | Notes |\n| Open Issues | 42 | +3 | |"
+        result = report_files.parse_report_metrics(content)
+        assert result == {"Open Issues": {"value": "42", "delta": "+3"}}
+
+    def test_multiple_metric_rows(self) -> None:
+        content = """| Metric | Value | Delta | Notes |
+| Open Issues | 42 | +3 | |
+| Closed Issues | 10 | -2 | |"""
+        result = report_files.parse_report_metrics(content)
+        assert result == {
+            "Open Issues": {"value": "42", "delta": "+3"},
+            "Closed Issues": {"value": "10", "delta": "-2"},
+        }
+
+    def test_skips_header_and_separator(self) -> None:
+        content = """| Metric | Value | Delta | Notes |
+| --- | --- | --- | --- |
+| Open Issues | 42 | +3 | |"""
+        result = report_files.parse_report_metrics(content)
+        assert result == {"Open Issues": {"value": "42", "delta": "+3"}}
+
+    def test_ignores_non_matching_lines(self) -> None:
+        content = "This is just a sentence.\n| Open Issues | 42 | +3 | |\nAnother sentence."
+        result = report_files.parse_report_metrics(content)
+        assert result == {"Open Issues": {"value": "42", "delta": "+3"}}
+
+    def test_extra_whitespace_trimmed(self) -> None:
+        content = "|  Open Issues   |   42   |   +3   |   |"
+        result = report_files.parse_report_metrics(content)
+        assert result == {"Open Issues": {"value": "42", "delta": "+3"}}
+
+    def test_empty_delta(self) -> None:
+        content = "| Open Issues | 42 | | |"
+        result = report_files.parse_report_metrics(content)
+        assert result == {"Open Issues": {"value": "42", "delta": ""}}
+
+    def test_metric_named_metric_skipped(self) -> None:
+        content = "| Metric | Value | Delta | Notes |"
+        result = report_files.parse_report_metrics(content)
+        assert result == {}
+
+    def test_separator_row_skipped(self) -> None:
+        content = "| --- | --- | --- | --- |"
+        result = report_files.parse_report_metrics(content)
+        assert result == {}
+
+    def test_no_leading_pipe_no_match(self) -> None:
+        content = "Open Issues | 42 | +3 |"
+        result = report_files.parse_report_metrics(content)
+        assert result == {}
+
+    def test_ignores_extra_column_content(self) -> None:
+        content = "| Open Issues | 42 | +3 | some notes here |"
+        result = report_files.parse_report_metrics(content)
+        assert result == {"Open Issues": {"value": "42", "delta": "+3"}}


### PR DESCRIPTION
Closes #155

Adds unit tests for three small, easily-testable backend modules:

- **backend/report_files.py**
  - `sanitize_report_date` — strips non-digit/non-dash characters
  - `parse_report_metrics` — extracts key-value metrics from markdown table rows

- **backend/cache_utils.py**
  - `cache_get` — hit/miss with TTL
  - `cache_set` — stores values with timestamps, LRU move-to-end, batch eviction
  - `cache_clear` — removes all entries

- **backend/proxy_utils.py**
  - `should_proxy_fleet_to_hub` — node/hub role logic, local/scope query param handling
