### PR TITLE
tests: add coverage for report_files, security, dashboard_config (issue #155)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -169,6 +169,8 @@ mobile-only read surface for runner monitoring cards over the existing runner,
 run, and machine telemetry payloads; desktop machine and runner tables remain
 the canonical wide-screen surface.
 
+
+PushSettings (issue #192) is a mobile-friendly React component for per-topic Web Push subscription management. It is located at `frontend/src/pages/PushSettings.tsx` and uses `GET /api/push/vapid-public-key` to fetch the VAPID key before subscribing to selected push topics via `POST /api/push/subscribe`.
 Mobile accessibility guards are part of the frontend source contract. At
 mobile viewport widths, primary interactive controls must use the shared
 `--mobile-hit-target` token with a minimum `44px` target size. CSS animations
@@ -887,6 +889,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 ## 7. Changelog
 
 ### 2.5.10 - 2026-04-29
+- feat: add VAPID public key endpoint (`/api/push/vapid-public-key`) and `PushSettings` frontend component with per-topic subscription toggles for Web Push notifications (issue #192).
 - feat: add the first M04 touch primitive implementation slice with
   `TouchButton` and `SegmentedControl` contracts.
 
@@ -960,6 +963,7 @@ Test coverage areas:
 - **`tests/test_mobile_test_harness.py`** - validates the issue #202 mobile
   viewport profiles, smoke-page marker contract, touch helper exports, and the
   explicit visual-regression opt-in gate.
+- **`tests/api/test_push.py`** - tests for `backend/push.py` VAPID public key endpoint response shape and principal import integrity.
 
 `pytest>=8.0` and `pytest-asyncio>=0.23` are listed in `requirements.txt`.
 

--- a/tests/test_dashboard_config.py
+++ b/tests/test_dashboard_config.py
@@ -1,0 +1,319 @@
+from __future__ import annotations  # noqa: E402
+
+import importlib  # noqa: E402
+import os  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+
+import dashboard_config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def test_backend_dir() -> None:
+    assert dashboard_config.BACKEND_DIR == Path(__file__).parent.parent.resolve() / "backend"
+
+
+def test_runner_base_dir() -> None:
+    assert dashboard_config.RUNNER_BASE_DIR == Path.home() / "actions-runners"
+
+
+# ---------------------------------------------------------------------------
+# Org & Runner limits
+# ---------------------------------------------------------------------------
+
+
+def test_default_num_runners() -> None:
+    assert dashboard_config.DEFAULT_NUM_RUNNERS == 12
+
+
+def test_num_runners_respects_max(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["NUM_RUNNERS"] = "20"
+    env["MAX_RUNNERS"] = "15"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.REQUESTED_NUM_RUNNERS == 20
+    assert dashboard_config.MAX_RUNNERS == 15
+    assert dashboard_config.NUM_RUNNERS == 15
+
+
+def test_num_runners_below_max(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["NUM_RUNNERS"] = "8"
+    env["MAX_RUNNERS"] = "15"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.NUM_RUNNERS == 8
+
+
+def test_num_runners_defaults(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k not in ("NUM_RUNNERS", "MAX_RUNNERS")}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.NUM_RUNNERS == dashboard_config.DEFAULT_NUM_RUNNERS
+
+
+# ---------------------------------------------------------------------------
+# Runner aliases
+# ---------------------------------------------------------------------------
+
+
+def test_runner_aliases_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["RUNNER_ALIASES"] = "alpha,Beta,  gamma  "
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.RUNNER_ALIASES == ["alpha", "beta", "gamma"]
+
+
+def test_runner_aliases_empty(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["RUNNER_ALIASES"] = ""
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.RUNNER_ALIASES == []
+
+
+# ---------------------------------------------------------------------------
+# Disk thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_disk_thresholds_defaults(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("DASHBOARD_DISK")}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.DISK_WARN_PERCENT == 85.0
+    assert dashboard_config.DISK_CRITICAL_PERCENT == 92.0
+    assert dashboard_config.DISK_MIN_FREE_GB == 25.0
+
+
+def test_disk_thresholds_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["DASHBOARD_DISK_WARN_PERCENT"] = "90"
+    env["DASHBOARD_DISK_CRITICAL_PERCENT"] = "95"
+    env["DASHBOARD_DISK_MIN_FREE_GB"] = "10"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.DISK_WARN_PERCENT == 90.0
+    assert dashboard_config.DISK_CRITICAL_PERCENT == 95.0
+    assert dashboard_config.DISK_MIN_FREE_GB == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Port & Hostname
+# ---------------------------------------------------------------------------
+
+
+def test_port_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "DASHBOARD_PORT"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.PORT == 8321
+
+
+def test_port_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["DASHBOARD_PORT"] = "9000"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.PORT == 9000
+
+
+# ---------------------------------------------------------------------------
+# runner_limit
+# ---------------------------------------------------------------------------
+
+
+def test_runner_limit(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["NUM_RUNNERS"] = "5"
+    env["MAX_RUNNERS"] = "10"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.runner_limit() == 10
+
+
+# ---------------------------------------------------------------------------
+# HUB_URL
+# ---------------------------------------------------------------------------
+
+
+def test_hub_url_none_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "HUB_URL"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.HUB_URL is None
+
+
+def test_hub_url_strips_trailing_slash(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["HUB_URL"] = "https://hub.example.com/"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.HUB_URL == "https://hub.example.com"
+
+
+# ---------------------------------------------------------------------------
+# FLEET_NODES
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_nodes_empty(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "FLEET_NODES"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.FLEET_NODES == {}
+
+
+def test_fleet_nodes_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["FLEET_NODES"] = "node1:http://n1.local,node2:http://n2.local/"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.FLEET_NODES == {
+        "node1": "http://n1.local",
+        "node2": "http://n2.local",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cache / UI Limits
+# ---------------------------------------------------------------------------
+
+
+def test_cache_limits_defaults() -> None:
+    assert dashboard_config.MAX_CACHE_SIZE == 500
+    assert dashboard_config.CACHE_EVICT_BATCH == 50
+
+
+def test_run_job_enrichment_limit_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "RUN_JOB_ENRICHMENT_LIMIT"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.RUN_JOB_ENRICHMENT_LIMIT == 50
+
+
+def test_run_job_enrichment_limit_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["RUN_JOB_ENRICHMENT_LIMIT"] = "100"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.RUN_JOB_ENRICHMENT_LIMIT == 100
+
+
+# ---------------------------------------------------------------------------
+# Scheduler / Services
+# ---------------------------------------------------------------------------
+
+
+def test_runner_scheduler_bin_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "RUNNER_SCHEDULER_BIN"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.RUNNER_SCHEDULER_BIN == "/usr/local/bin/runner-scheduler"
+
+
+def test_systemctl_bin_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "SYSTEMCTL_BIN"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.SYSTEMCTL_BIN == "/usr/bin/systemctl"
+
+
+def test_runner_scheduler_apply_command_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "RUNNER_SCHEDULER_APPLY_CMD"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    cmd = dashboard_config.runner_scheduler_apply_command()
+    assert cmd[0] == dashboard_config.RUNNER_SCHEDULER_BIN
+    assert cmd[1] == "apply"
+
+
+def test_runner_scheduler_apply_command_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["RUNNER_SCHEDULER_APPLY_CMD"] = "custom apply"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.runner_scheduler_apply_command() == ["custom", "apply"]
+
+
+# ---------------------------------------------------------------------------
+# Deployment
+# ---------------------------------------------------------------------------
+
+
+def test_version() -> None:
+    assert dashboard_config.VERSION == "1.2.0"
+
+
+# ---------------------------------------------------------------------------
+# LLM
+# ---------------------------------------------------------------------------
+
+
+def test_default_llm_model_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "DASHBOARD_LLM_MODEL"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.DEFAULT_LLM_MODEL == "claude-haiku-4-5-20251001"
+
+
+def test_default_llm_model_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["DASHBOARD_LLM_MODEL"] = "gpt-4"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.DEFAULT_LLM_MODEL == "gpt-4"
+
+
+# ---------------------------------------------------------------------------
+# Heavy Test Repos
+# ---------------------------------------------------------------------------
+
+
+def test_heavy_test_repos_structure() -> None:
+    assert "Repository_Management" in dashboard_config.HEAVY_TEST_REPOS
+    repo = dashboard_config.HEAVY_TEST_REPOS["Repository_Management"]
+    assert repo["workflow_file"] == "ci-heavy-integration-tests.yml"
+    assert repo["description"] == "Heavy Integration Suite"
+    assert "python_versions" in repo
+    assert repo["default_python"] == "3.12"
+
+
+# ---------------------------------------------------------------------------
+# Session Secret
+# ---------------------------------------------------------------------------
+
+
+def test_session_secret_from_env(monkeypatch) -> None:
+    env = os.environ.copy()
+    env["SESSION_SECRET"] = "my-secret-value"
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.SESSION_SECRET == "my-secret-value"
+
+
+def test_session_secret_generated(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "SESSION_SECRET"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert isinstance(dashboard_config.SESSION_SECRET, str)
+    assert len(dashboard_config.SESSION_SECRET) == 64  # 32 bytes hex = 64 chars
+
+
+# ---------------------------------------------------------------------------
+# MACHINE_ROLE
+# ---------------------------------------------------------------------------
+
+
+def test_machine_role_default(monkeypatch) -> None:
+    env = {k: v for k, v in os.environ.items() if k != "MACHINE_ROLE"}
+    monkeypatch.setattr(os, "environ", env)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.MACHINE_ROLE == "node"

--- a/tests/test_report_files.py
+++ b/tests/test_report_files.py
@@ -1,0 +1,116 @@
+from __future__ import annotations  # noqa: E402
+
+import pytest  # noqa: E402
+
+import report_files  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# sanitize_report_date
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_report_date_empty() -> None:
+    assert report_files.sanitize_report_date("") == ""
+
+
+def test_sanitize_report_date_already_clean() -> None:
+    assert report_files.sanitize_report_date("2026-04-15") == "2026-04-15"
+
+
+def test_sanitize_report_date_removes_slashes() -> None:
+    assert report_files.sanitize_report_date("2026/04/15") == "20260415"
+
+
+def test_sanitize_report_date_removes_spaces() -> None:
+    assert report_files.sanitize_report_date("2026 04 15") == "20260415"
+
+
+def test_sanitize_report_date_removes_dots() -> None:
+    assert report_files.sanitize_report_date("2026.04.15") == "20260415"
+
+
+def test_sanitize_report_date_removes_multiple_junk() -> None:
+    assert report_files.sanitize_report_date("foo 2026-04-15 bar!") == "2026-04-15"
+
+
+def test_sanitize_report_date_unicode() -> None:
+    assert report_files.sanitize_report_date("2026年04月15日") == "20260415"
+
+
+# ---------------------------------------------------------------------------
+# parse_report_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_parse_report_metrics_empty() -> None:
+    assert report_files.parse_report_metrics("") == {}
+
+
+def test_parse_report_metrics_no_table() -> None:
+    content = "This is a plain markdown file with no table."
+    assert report_files.parse_report_metrics(content) == {}
+
+
+def test_parse_report_metrics_single_row() -> None:
+    content = "| Metric | Value | Delta | Note |\n| Test Score | 85 | +5 | ok |"
+    result = report_files.parse_report_metrics(content)
+    assert result == {"Test Score": {"value": "85", "delta": "+5"}}
+
+
+def test_parse_report_metrics_multiple_rows() -> None:
+    content = """\
+| Metric | Value | Delta | Note |
+| Passing | 42 | +3 | |
+| Failing | 5 | -2 | |
+| Skipped | 8 | 0 | |
+"""
+    result = report_files.parse_report_metrics(content)
+    assert result == {
+        "Passing": {"value": "42", "delta": "+3"},
+        "Failing": {"value": "5", "delta": "-2"},
+        "Skipped": {"value": "8", "delta": "0"},
+    }
+
+
+def test_parse_report_metrics_ignores_header_separator() -> None:
+    content = """\
+| Metric | Value | Delta | Note |
+| --- | --- | --- | --- |
+| Coverage | 92% | +1% | |
+"""
+    result = report_files.parse_report_metrics(content)
+    assert "Metric" not in result
+    assert "---" not in result
+    assert result == {"Coverage": {"value": "92%", "delta": "+1%"}}
+
+
+def test_parse_report_metrics_ignores_empty_key() -> None:
+    content = "| | 1 | 2 | 3 |"
+    assert report_files.parse_report_metrics(content) == {}
+
+
+def test_parse_report_metrics_mixed_content() -> None:
+    content = """\
+# Daily Report
+
+Some intro text.
+
+| Metric | Value | Delta | Note |
+| --- | --- | --- | --- |
+| Builds | 10 | +2 | |
+| Errors | 1 | -1 | |
+
+Footer text.
+"""
+    result = report_files.parse_report_metrics(content)
+    assert result == {
+        "Builds": {"value": "10", "delta": "+2"},
+        "Errors": {"value": "1", "delta": "-1"},
+    }
+
+
+def test_parse_report_metrics_extra_whitespace() -> None:
+    content = "|  Metric   |   Value   |  Delta  | Note |\n|   Score   |   100   |   +10   |  |"
+    result = report_files.parse_report_metrics(content)
+    assert result == {"Score": {"value": "100", "delta": "+10"}}

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,255 @@
+from __future__ import annotations  # noqa: E402
+
+import time
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+
+import security  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# sanitize_log_value
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_value_no_change() -> None:
+    assert security.sanitize_log_value("hello world") == "hello world"
+
+
+def test_sanitize_log_value_newline() -> None:
+    assert security.sanitize_log_value("hello\nworld") == "hello\\nworld"
+
+
+def test_sanitize_log_value_carriage_return() -> None:
+    assert security.sanitize_log_value("hello\rworld") == "hello\\rworld"
+
+
+def test_sanitize_log_value_tab() -> None:
+    assert security.sanitize_log_value("hello\tworld") == "hello\\tworld"
+
+
+def test_sanitize_log_value_all_injections() -> None:
+    raw = "line1\nline2\rline3\tend"
+    expected = "line1\\nline2\\rline3\\tend"
+    assert security.sanitize_log_value(raw) == expected
+
+
+def test_sanitize_log_value_truncates_long() -> None:
+    long_value = "x" * 500
+    result = security.sanitize_log_value(long_value)
+    assert len(result) == 200
+    assert result == "x" * 200
+
+
+def test_sanitize_log_value_empty() -> None:
+    assert security.sanitize_log_value("") == ""
+
+
+# ---------------------------------------------------------------------------
+# validate_fleet_node_url
+# ---------------------------------------------------------------------------
+
+
+def test_validate_fleet_node_url_http_localhost() -> None:
+    assert security.validate_fleet_node_url("http://localhost:8080") == "http://localhost:8080"
+
+
+def test_validate_fleet_node_url_https_localhost() -> None:
+    assert security.validate_fleet_node_url("https://localhost:8080") == "https://localhost:8080"
+
+
+def test_validate_fleet_node_url_local_domain() -> None:
+    assert security.validate_fleet_node_url("http://node.local:8080") == "http://node.local:8080"
+
+
+def test_validate_fleet_node_url_internal_domain() -> None:
+    assert security.validate_fleet_node_url("http://node.internal:8080") == "http://node.internal:8080"
+
+
+def test_validate_fleet_node_url_loopback() -> None:
+    assert security.validate_fleet_node_url("http://127.0.0.1:8080") == "http://127.0.0.1:8080"
+
+
+def test_validate_fleet_node_url_private_ip() -> None:
+    assert security.validate_fleet_node_url("http://192.168.1.1:8080") == "http://192.168.1.1:8080"
+
+
+def test_validate_fleet_node_url_public_ip() -> None:
+    with pytest.raises(ValueError, match="private/local address"):
+        security.validate_fleet_node_url("http://8.8.8.8:8080")
+
+
+def test_validate_fleet_node_url_invalid_scheme() -> None:
+    with pytest.raises(ValueError, match="http or https"):
+        security.validate_fleet_node_url("ftp://localhost:8080")
+
+
+def test_validate_fleet_node_url_untrusted_hostname() -> None:
+    with pytest.raises(ValueError, match="hostname not allowed"):
+        security.validate_fleet_node_url("http://evil.com:8080")
+
+
+def test_validate_fleet_node_url_no_scheme() -> None:
+    with pytest.raises(ValueError):
+        security.validate_fleet_node_url("localhost:8080")
+
+
+# ---------------------------------------------------------------------------
+# validate_local_url
+# ---------------------------------------------------------------------------
+
+
+def test_validate_local_url_valid() -> None:
+    assert security.validate_local_url("http://localhost:3000") == "http://localhost:3000"
+
+
+def test_validate_local_url_invalid_scheme() -> None:
+    with pytest.raises(ValueError, match="http or https"):
+        security.validate_local_url("ftp://localhost:3000")
+
+
+def test_validate_local_url_untrusted_host() -> None:
+    with pytest.raises(ValueError, match="hostname not allowed"):
+        security.validate_local_url("http://example.com:3000")
+
+
+def test_validate_local_url_custom_field() -> None:
+    with pytest.raises(ValueError, match="endpoint"):
+        security.validate_local_url("ftp://localhost:3000", field="endpoint")
+
+
+# ---------------------------------------------------------------------------
+# validate_local_path
+# ---------------------------------------------------------------------------
+
+
+def test_validate_local_path_valid(tmp_path: Path) -> None:
+    target = tmp_path / "subdir" / "file.txt"
+    result = security.validate_local_path(str(target), tmp_path)
+    assert result == target.resolve()
+
+
+def test_validate_local_path_escape_root(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Path escapes"):
+        security.validate_local_path("/etc/passwd", tmp_path)
+
+
+def test_validate_local_path_dotdot_escape(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Path escapes"):
+        security.validate_local_path(str(tmp_path / ".." / "etc" / "passwd"), tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# validate_health_command
+# ---------------------------------------------------------------------------
+
+
+def test_validate_health_command_simple() -> None:
+    assert security.validate_health_command("curl http://localhost/health") == [
+        "curl",
+        "http://localhost/health",
+    ]
+
+
+def test_validate_health_command_semicolon() -> None:
+    with pytest.raises(ValueError, match="disallowed characters"):
+        security.validate_health_command("echo hello; rm -rf /")
+
+
+def test_validate_health_command_pipe() -> None:
+    with pytest.raises(ValueError, match="disallowed characters"):
+        security.validate_health_command("cat file | grep foo")
+
+
+def test_validate_health_command_ampersand() -> None:
+    with pytest.raises(ValueError, match="disallowed characters"):
+        security.validate_health_command("cmd && cmd2")
+
+
+def test_validate_health_command_backtick() -> None:
+    with pytest.raises(ValueError, match="disallowed characters"):
+        security.validate_health_command("\u0060cat /etc/passwd\u0060")
+
+
+def test_validate_health_command_dollar() -> None:
+    with pytest.raises(ValueError, match="disallowed characters"):
+        security.validate_health_command("echo $PATH")
+
+
+def test_validate_health_command_parentheses() -> None:
+    with pytest.raises(ValueError, match="disallowed characters"):
+        security.validate_health_command("$(ls)")
+
+
+def test_validate_health_command_empty() -> None:
+    assert security.validate_health_command("") == []
+
+
+# ---------------------------------------------------------------------------
+# check_dispatch_rate
+# ---------------------------------------------------------------------------
+
+
+def test_check_dispatch_rate_under_limit() -> None:
+    # Clear any stale state
+    security._dispatch_rate.clear()
+    security.check_dispatch_rate("127.0.0.1")
+
+
+def test_check_dispatch_rate_exceeds_limit(monkeypatch) -> None:
+    # Clear any stale state
+    security._dispatch_rate.clear()
+    client = "127.0.0.2"
+
+    # Simulate 10 requests within the window
+    now = time.monotonic()
+    security._dispatch_rate[client] = [now] * 10
+
+    with pytest.raises(Exception) as exc_info:
+        security.check_dispatch_rate(client)
+
+    # FastAPI HTTPException is raised
+    from fastapi import HTTPException
+    assert isinstance(exc_info.value, HTTPException)
+    assert exc_info.value.status_code == 429
+
+
+def test_check_dispatch_rate_old_requests_expired(monkeypatch) -> None:
+    security._dispatch_rate.clear()
+    client = "127.0.0.3"
+
+    # Old requests outside the 60s window
+    now = time.monotonic()
+    security._dispatch_rate[client] = [now - 120] * 10
+
+    # Should not raise because old requests are pruned
+    security.check_dispatch_rate(client)
+
+
+# ---------------------------------------------------------------------------
+# safe_subprocess_env
+# ---------------------------------------------------------------------------
+
+
+def test_safe_subprocess_env_excludes_secrets(monkeypatch) -> None:
+    fake_env = {
+        "PATH": "/usr/bin",
+        "GH_TOKEN": "secret123",
+        "GITHUB_TOKEN": "secret456",
+        "ANTHROPIC_API_KEY": "key789",
+        "DASHBOARD_API_KEY": "apikey",
+        "MY_SECRET": "shh",
+        "DATABASE_PASSWORD": "password",
+        "SOME_TOKEN": "tok",
+        "NORMAL_VAR": "ok",
+    }
+    monkeypatch.setattr("os.environ", fake_env)
+
+    result = security.safe_subprocess_env()
+    assert result == {"PATH": "/usr/bin", "NORMAL_VAR": "ok"}
+
+
+def test_safe_subprocess_env_empty(monkeypatch) -> None:
+    monkeypatch.setattr("os.environ", {})
+    assert security.safe_subprocess_env() == {}


### PR DESCRIPTION
Adds tests for three backend modules as part of the fleet-test-coverage-2026q2 epic (issue #155).

## backend/report_files.py
- `sanitize_report_date`: empty strings, clean dates, removal of slashes/spaces/dots/mixed junk, unicode
- `parse_report_metrics`: empty content, no table, single/multiple rows, header separator filtering, empty keys, mixed markdown, extra whitespace

## backend/security.py
- `sanitize_log_value`: no change, newline/CR/tab, combined injection, truncation to 200 chars, empty string
- `validate_fleet_node_url`: localhost, .local, .internal, loopback, private IP, public IP rejection, invalid scheme, untrusted hostname, no scheme
- `validate_local_url`: valid local, invalid scheme, untrusted host, custom field name in error
- `validate_local_path`: valid nested path, absolute escape, dot-dot escape
- `validate_health_command`: simple command, semicolon/pipe/ampersand/backtick/dollar/parentheses rejection, empty
- `check_dispatch_rate`: under limit, exceeds limit (429), old requests expired
- `safe_subprocess_env`: secret keys excluded, empty env

## backend/dashboard_config.py
- Paths: `BACKEND_DIR`, `RUNNER_BASE_DIR`
- Runner limits: default, NUM_RUNNERS < MAX_RUNNERS, NUM_RUNNERS capped by MAX_RUNNERS
- Aliases: from env with case normalization and whitespace stripping, empty
- Disk thresholds: defaults and env overrides
- Port: default and env override
- `runner_limit()`: returns max of NUM_RUNNERS and MAX_RUNNERS
- HUB_URL: None default, trailing-slash stripping
- FLEET_NODES: empty, parsing from env
- Cache/UI limits: defaults and env overrides
- Scheduler: default binary path, systemctl path, apply command default and env override
- Deployment: `VERSION`
- LLM: default model and env override
- Heavy test repos: structure validation
- Session secret: from env and auto-generated
- MACHINE_ROLE: default