### PR TITLE
chore: clean working trees (.gitignore hygiene) — #156

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,19 @@ backend/.venv/
 *.pyo
 .claude/worktrees/
 .agent_remediation_state.json
+
+# Common Python / IDE / test artifacts
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+*.egg
+pip-wheel-metadata/
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+*.db
+*.sqlite3


### PR DESCRIPTION
Closes #156

Adds common Python, IDE, and test artifact patterns to  to prevent dirty working trees:

-  — pytest cache directory
- ,  — coverage data files
- ,  — coverage HTML reports, tox environments
- ,  — packaging artifacts
- ,  — IDE directories
- , ,  — editor swap/backup files
- ,  — local database files

Also removes an untracked  that was not part of the tracked tree and was causing dirty-working-tree noise.