### PR TITLE
refactor(backend): extract health and metrics modules from server.py (issue #159)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -110,6 +110,8 @@ surface task action details without exposing secrets.
 | `pr_inventory.py` | Fetch and normalise open PRs across repos (issue #80) |
 | `issue_inventory.py` | Fetch and normalise open issues with taxonomy (issue #81) |
 | `linear_inventory.py` | Fetch and normalise Linear issues into the canonical issue inventory shape |
+| `health.py` | Health check endpoints (`/api/health`, `/health`) extracted from server.py (issue #159) |
+| `metrics.py` | System metrics endpoints (`/api/system`, `/api/fleet/status`) extracted from server.py (issue #159) |
 
 **Bounded domain routers (`backend/routers/`):**
 

--- a/backend/health.py
+++ b/backend/health.py
@@ -1,0 +1,71 @@
+"""Health check endpoints for the runner dashboard.
+
+Extracted from server.py as part of issue #159 god-module-refactor-2026q2.
+"""
+
+from __future__ import annotations
+
+import time
+from fastapi import APIRouter, Request
+
+router = APIRouter(tags=["health"])
+
+
+async def _health_impl() -> dict:
+    """Core health logic, callable both from the HTTP endpoint and internally."""
+    # Lazy import to avoid circular dependency with server.py
+    from server import (  # noqa: PLC0415
+        _cache_get,
+        _cache_set,
+        gh_api_admin,
+        ORG,
+        HOSTNAME,
+        BOOT_TIME,
+        _deployment_info,
+        datetime,
+        UTC,
+    )
+
+    try:
+        # Reuse the runner cache so health checks don't add extra API calls.
+        data = _cache_get("runners", 25.0)
+        if data is None:
+            data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+            _cache_set("runners", data)
+        gh_ok = True
+        runner_count = len(data.get("runners", []))
+    except Exception:  # noqa: BLE001
+        gh_ok = False
+        runner_count = 0
+
+    return {
+        "status": "healthy" if gh_ok else "degraded",
+        "timestamp": datetime.now(UTC).isoformat(),
+        "hostname": HOSTNAME,
+        "github_api": "connected" if gh_ok else "unreachable",
+        "runners_registered": runner_count,
+        "dashboard_uptime_seconds": int(time.time() - BOOT_TIME),
+        "deployment": _deployment_info(),
+    }
+
+
+@router.get("/api/health")
+async def health_check(request: Request):
+    """Health endpoint for monitoring and load balancers."""
+    return await _health_impl()
+
+
+@router.get("/health", tags=["diagnostics"])
+async def launcher_health_check() -> dict:
+    """Minimal health check for launcher recovery detection.
+
+    Returns 200 if backend is ready. Used by PWA recovery modal for
+    polling before triggering custom URL protocol.
+    """
+    # Lazy import to avoid circular dependency with server.py
+    from server import datetime, UTC  # noqa: PLC0415
+
+    return {
+        "status": "ready",
+        "timestamp": datetime.now(UTC).isoformat(),
+    }

--- a/backend/health.py
+++ b/backend/health.py
@@ -6,6 +6,7 @@ Extracted from server.py as part of issue #159 god-module-refactor-2026q2.
 from __future__ import annotations
 
 import time
+
 from fastapi import APIRouter, Request
 
 router = APIRouter(tags=["health"])
@@ -15,15 +16,15 @@ async def _health_impl() -> dict:
     """Core health logic, callable both from the HTTP endpoint and internally."""
     # Lazy import to avoid circular dependency with server.py
     from server import (  # noqa: PLC0415
+        BOOT_TIME,
+        HOSTNAME,
+        ORG,
+        UTC,
         _cache_get,
         _cache_set,
-        gh_api_admin,
-        ORG,
-        HOSTNAME,
-        BOOT_TIME,
         _deployment_info,
         datetime,
-        UTC,
+        gh_api_admin,
     )
 
     try:
@@ -63,7 +64,7 @@ async def launcher_health_check() -> dict:
     polling before triggering custom URL protocol.
     """
     # Lazy import to avoid circular dependency with server.py
-    from server import datetime, UTC  # noqa: PLC0415
+    from server import UTC, datetime  # noqa: PLC0415
 
     return {
         "status": "ready",

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -247,6 +247,7 @@ async def get_fleet_status(request: Request):
 
     async def fetch_node(name, url):
         import httpx  # noqa: PLC0415
+
         try:
             async with httpx.AsyncClient() as client:
                 target = f"{url}/api/system"
@@ -274,6 +275,7 @@ async def get_fleet_status(request: Request):
 
     if FLEET_NODES:
         import asyncio  # noqa: PLC0415
+
         results = await asyncio.gather(*[fetch_node(n, u) for n, u in FLEET_NODES.items()])
         for name, data in results:
             responses[name] = data

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -15,25 +15,25 @@ async def get_system_metrics():
     """Real-time system resource metrics."""
     # Lazy import to avoid circular dependency with server.py
     from server import (  # noqa: PLC0415
-        psutil,
-        platform,
-        shutil,
-        os,
-        time,
-        Path,
-        RUNNER_BASE_DIR,
-        HOSTNAME,
         BOOT_TIME,
         HOST_MEMORY_GB,
+        HOSTNAME,
+        RUNNER_BASE_DIR,
+        UTC,
+        Path,
         _cpu_history,
         _disk_pressure_snapshot,
         _local_hardware_specs,
         _workload_capacity_from_specs,
+        datetime,
         get_gpu_info,
         get_per_runner_resources,
         get_runner_capacity_snapshot,
-        datetime,
-        UTC,
+        os,
+        platform,
+        psutil,
+        shutil,
+        time,
     )
 
     cpu_freq = psutil.cpu_freq()
@@ -230,14 +230,12 @@ async def get_fleet_status(request: Request):
     """Get full system metrics state for all machines in the fleet network."""
     # Lazy import to avoid circular dependency with server.py
     from server import (  # noqa: PLC0415
-        HOSTNAME,
         FLEET_NODES,
+        HOSTNAME,
+        _classify_node_offline,
+        _resource_offline_reason,
         _should_proxy_fleet_to_hub,
         proxy_to_hub,
-        _resource_offline_reason,
-        _classify_node_offline,
-        datetime,
-        UTC,
     )
 
     if _should_proxy_fleet_to_hub(request):

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1,0 +1,283 @@
+"""System metrics endpoints for the runner dashboard.
+
+Extracted from server.py as part of issue #159 god-module-refactor-2026q2.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+router = APIRouter(tags=["metrics"])
+
+
+@router.get("/api/system")
+async def get_system_metrics():
+    """Real-time system resource metrics."""
+    # Lazy import to avoid circular dependency with server.py
+    from server import (  # noqa: PLC0415
+        psutil,
+        platform,
+        shutil,
+        os,
+        time,
+        Path,
+        RUNNER_BASE_DIR,
+        HOSTNAME,
+        BOOT_TIME,
+        HOST_MEMORY_GB,
+        _cpu_history,
+        _disk_pressure_snapshot,
+        _local_hardware_specs,
+        _workload_capacity_from_specs,
+        get_gpu_info,
+        get_per_runner_resources,
+        get_runner_capacity_snapshot,
+        datetime,
+        UTC,
+    )
+
+    cpu_freq = psutil.cpu_freq()
+    mem = psutil.virtual_memory()
+    swap = psutil.swap_memory()
+    disk_path = str(RUNNER_BASE_DIR) if RUNNER_BASE_DIR.exists() else "/"
+    disk = shutil.disk_usage(disk_path)
+    disk_total_gb = round(disk.total / (1024**3), 1)
+    disk_used_gb = round(disk.used / (1024**3), 1)
+    disk_free_gb = round(disk.free / (1024**3), 1)
+    disk_percent = round(disk.used / disk.total * 100, 1)
+
+    if os.name == "nt":
+        net = psutil.net_io_counters()
+        per_cpu = psutil.cpu_percent(interval=0, percpu=True)
+        current_cpu = psutil.cpu_percent(interval=0)
+        _cpu_history.append(current_cpu)
+        cpu_avg_1m = round(sum(_cpu_history) / len(_cpu_history), 1) if _cpu_history else current_cpu
+        uptime_seconds = time.time() - psutil.boot_time()
+        dashboard_uptime = time.time() - BOOT_TIME
+        disk_pressure = _disk_pressure_snapshot(
+            path=disk_path,
+            total_gb=disk_total_gb,
+            used_gb=disk_used_gb,
+            free_gb=disk_free_gb,
+            percent=disk_percent,
+        )
+        hardware_specs = _local_hardware_specs(None)
+        return {
+            "hostname": HOSTNAME,
+            "platform": platform.platform(),
+            "timestamp": datetime.now(UTC).isoformat(),
+            "uptime_seconds": int(uptime_seconds),
+            "dashboard_uptime_seconds": int(dashboard_uptime),
+            "cpu": {
+                "cores_physical": psutil.cpu_count(logical=False),
+                "cores_logical": psutil.cpu_count(logical=True),
+                "percent": current_cpu,
+                "percent_1m_avg": cpu_avg_1m,
+                "per_cpu_percent": per_cpu,
+                "freq_current_mhz": round(cpu_freq.current, 0) if cpu_freq else None,
+                "freq_max_mhz": round(cpu_freq.max, 0) if cpu_freq else None,
+                "load_avg_1m": 0,
+                "load_avg_5m": 0,
+                "load_avg_15m": 0,
+            },
+            "memory": {
+                "host_total_gb": round(mem.total / (1024**3), 1),
+                "wsl_total_gb": None,
+                "total_gb": round(mem.total / (1024**3), 1),
+                "used_gb": round(mem.used / (1024**3), 1),
+                "available_gb": round(mem.available / (1024**3), 1),
+                "percent": mem.percent,
+                "swap_total_gb": round(swap.total / (1024**3), 1),
+                "swap_used_gb": round(swap.used / (1024**3), 1),
+                "swap_percent": swap.percent,
+            },
+            "disk": {
+                "path": disk_path,
+                "total_gb": disk_total_gb,
+                "used_gb": disk_used_gb,
+                "free_gb": disk_free_gb,
+                "percent": disk_percent,
+                "pressure": disk_pressure,
+                "windows_host": None,
+            },
+            "network": {
+                "bytes_sent": net.bytes_sent,
+                "bytes_recv": net.bytes_recv,
+                "packets_sent": net.packets_sent,
+                "packets_recv": net.packets_recv,
+            },
+            "gpu": None,
+            "hardware_specs": hardware_specs,
+            "workload_capacity": _workload_capacity_from_specs(hardware_specs),
+            "runner_processes": [],
+            "runner_capacity": {},
+        }
+
+    # On WSL, also report the Windows host disk (/mnt/c) where the VHDX lives.
+    # The host disk is the binding constraint — if it fills up, WSL itself breaks.
+    windows_disk = None
+    wsl_host_path = Path("/mnt/c")
+    if wsl_host_path.exists():
+        try:
+            wd = shutil.disk_usage(str(wsl_host_path))
+            windows_disk = {
+                "path": str(wsl_host_path),
+                "total_gb": round(wd.total / (1024**3), 1),
+                "used_gb": round(wd.used / (1024**3), 1),
+                "free_gb": round(wd.free / (1024**3), 1),
+                "percent": round(wd.used / wd.total * 100, 1),
+                "pressure": _disk_pressure_snapshot(
+                    path=str(wsl_host_path),
+                    total_gb=round(wd.total / (1024**3), 1),
+                    used_gb=round(wd.used / (1024**3), 1),
+                    free_gb=round(wd.free / (1024**3), 1),
+                    percent=round(wd.used / wd.total * 100, 1),
+                ),
+            }
+        except OSError:
+            pass
+
+    # Use the more critical disk for the top-level pressure signal.
+    windows_pct = (windows_disk or {}).get("percent", 0)
+    effective_pct = max(disk_percent, windows_pct)
+    effective_free = min(
+        disk_free_gb,
+        (windows_disk or {}).get("free_gb", disk_free_gb),
+    )
+    disk_pressure = _disk_pressure_snapshot(
+        path=disk_path,
+        total_gb=disk_total_gb,
+        used_gb=disk_used_gb,
+        free_gb=effective_free,
+        percent=effective_pct,
+    )
+
+    # Load averages (1, 5, 15 min)
+    try:
+        load_avg = os.getloadavg() if hasattr(os, "getloadavg") else (0, 0, 0)
+    except OSError:
+        load_avg = (0, 0, 0)
+
+    # Network I/O
+    net = psutil.net_io_counters()
+
+    # Per-CPU usage
+    per_cpu = psutil.cpu_percent(interval=0, percpu=True)
+    current_cpu = psutil.cpu_percent(interval=0)
+    _cpu_history.append(current_cpu)
+    cpu_avg_1m = round(sum(_cpu_history) / len(_cpu_history), 1) if _cpu_history else current_cpu
+
+    # Uptime
+    uptime_seconds = time.time() - psutil.boot_time()
+    dashboard_uptime = time.time() - BOOT_TIME
+    gpu = get_gpu_info()
+    hardware_specs = _local_hardware_specs(gpu)
+
+    return {
+        "hostname": HOSTNAME,
+        "platform": platform.platform(),
+        "timestamp": datetime.now(UTC).isoformat(),
+        "uptime_seconds": int(uptime_seconds),
+        "dashboard_uptime_seconds": int(dashboard_uptime),
+        "cpu": {
+            "cores_physical": psutil.cpu_count(logical=False),
+            "cores_logical": psutil.cpu_count(logical=True),
+            "percent": current_cpu,
+            "percent_1m_avg": cpu_avg_1m,
+            "per_cpu_percent": per_cpu,
+            "freq_current_mhz": round(cpu_freq.current, 0) if cpu_freq else None,
+            "freq_max_mhz": round(cpu_freq.max, 0) if cpu_freq else None,
+            "load_avg_1m": round(load_avg[0], 2),
+            "load_avg_5m": round(load_avg[1], 2),
+            "load_avg_15m": round(load_avg[2], 2),
+        },
+        "memory": {
+            "host_total_gb": HOST_MEMORY_GB,
+            "wsl_total_gb": round(mem.total / (1024**3), 1),
+            "total_gb": HOST_MEMORY_GB or round(mem.total / (1024**3), 1),
+            "used_gb": round(mem.used / (1024**3), 1),
+            "available_gb": round(mem.available / (1024**3), 1),
+            "percent": mem.percent,
+            "swap_total_gb": round(swap.total / (1024**3), 1),
+            "swap_used_gb": round(swap.used / (1024**3), 1),
+            "swap_percent": swap.percent,
+        },
+        "disk": {
+            "path": disk_path,
+            "total_gb": disk_total_gb,
+            "used_gb": disk_used_gb,
+            "free_gb": disk_free_gb,
+            "percent": disk_percent,
+            "pressure": disk_pressure,
+            "windows_host": windows_disk,
+        },
+        "network": {
+            "bytes_sent": net.bytes_sent,
+            "bytes_recv": net.bytes_recv,
+            "packets_sent": net.packets_sent,
+            "packets_recv": net.packets_recv,
+        },
+        "gpu": gpu,
+        "hardware_specs": hardware_specs,
+        "workload_capacity": _workload_capacity_from_specs(hardware_specs),
+        "runner_processes": get_per_runner_resources(),
+        "runner_capacity": get_runner_capacity_snapshot(),
+    }
+
+
+@router.get("/api/fleet/status")
+async def get_fleet_status(request: Request):
+    """Get full system metrics state for all machines in the fleet network."""
+    # Lazy import to avoid circular dependency with server.py
+    from server import (  # noqa: PLC0415
+        HOSTNAME,
+        FLEET_NODES,
+        _should_proxy_fleet_to_hub,
+        proxy_to_hub,
+        _resource_offline_reason,
+        _classify_node_offline,
+        datetime,
+        UTC,
+    )
+
+    if _should_proxy_fleet_to_hub(request):
+        return await proxy_to_hub(request)
+
+    responses = {}
+    responses[HOSTNAME] = await get_system_metrics()
+    responses[HOSTNAME]["_role"] = "hub"
+
+    async def fetch_node(name, url):
+        import httpx  # noqa: PLC0415
+        try:
+            async with httpx.AsyncClient() as client:
+                target = f"{url}/api/system"
+                resp = await client.get(target, timeout=5)
+                if resp.status_code == 200:
+                    data = resp.json()
+                    data["_role"] = "node"
+                    resource_reason = _resource_offline_reason(data)
+                    if resource_reason:
+                        data.update(resource_reason)
+                    return name, data
+                reason = _classify_node_offline(status_code=resp.status_code)
+                return name, {
+                    "status": "offline",
+                    "error": reason["offline_detail"],
+                    **reason,
+                }
+        except Exception as e:  # noqa: BLE001
+            reason = _classify_node_offline(e)
+            return name, {
+                "status": "offline",
+                "error": reason["offline_detail"],
+                **reason,
+            }
+
+    if FLEET_NODES:
+        import asyncio  # noqa: PLC0415
+        results = await asyncio.gather(*[fetch_node(n, u) for n, u in FLEET_NODES.items()])
+        for name, data in results:
+            responses[name] = data
+
+    return responses

--- a/backend/server.py
+++ b/backend/server.py
@@ -65,10 +65,10 @@ import config_schema as config_schema  # noqa: E402
 import deployment_drift as deployment_drift  # noqa: E402
 import dispatch_contract as dispatch_contract  # noqa: E402
 import health as _health_router  # noqa: E402
-import metrics as _metrics_router  # noqa: E402
 import issue_inventory as issue_inventory  # noqa: E402
 import lease_synchronizer as lease_synchronizer  # noqa: E402
 import linear_inventory as linear_inventory  # noqa: E402
+import metrics as _metrics_router  # noqa: E402
 import pr_inventory as pr_inventory  # noqa: E402
 import push as _push_router  # noqa: E402
 import quick_dispatch as _quick_dispatch  # noqa: E402
@@ -2114,7 +2114,7 @@ async def _collect_live_fleet_nodes() -> list[dict]:
                 **reason,
             }
 
-    local_sys = await get_system_metrics()
+    local_sys = await _metrics_router.get_system_metrics()
     local_health = await _health_router._health_impl()
     local_resource_reason = _resource_offline_reason(local_sys)
     nodes: list[dict] = [
@@ -5167,7 +5167,7 @@ async def _get_fleet_nodes_impl() -> dict:
 async def proxy_node_system(node_name: str) -> dict:
     """Proxy /api/system from a named fleet node (for detailed drill-down)."""
     if node_name in (HOSTNAME, "local"):
-        return await get_system_metrics()
+        return await _metrics_router.get_system_metrics()
     url = FLEET_NODES.get(node_name)
     if not url:
         raise HTTPException(status_code=404, detail=f"Node not found: {node_name}")

--- a/backend/server.py
+++ b/backend/server.py
@@ -64,6 +64,8 @@ import auth_webauthn as _auth_webauthn_router  # noqa: E402
 import config_schema as config_schema  # noqa: E402
 import deployment_drift as deployment_drift  # noqa: E402
 import dispatch_contract as dispatch_contract  # noqa: E402
+import health as _health_router  # noqa: E402
+import metrics as _metrics_router  # noqa: E402
 import issue_inventory as issue_inventory  # noqa: E402
 import lease_synchronizer as lease_synchronizer  # noqa: E402
 import linear_inventory as linear_inventory  # noqa: E402
@@ -447,6 +449,8 @@ app.include_router(_push_router.router)
 app.include_router(admin_router.router)
 app.include_router(auth_router.router)
 app.include_router(_auth_webauthn_router.router)
+app.include_router(_health_router.router)
+app.include_router(_metrics_router.router)
 
 # Agent-launcher control surface (sibling: Repository_Management/launchers/cline_agent_launcher).
 # Subprocess-only — never imports the launcher Python at runtime.
@@ -2050,198 +2054,6 @@ def get_per_runner_resources() -> list[dict]:
     return runner_procs
 
 
-@app.get("/api/system")
-async def get_system_metrics():
-    """Real-time system resource metrics."""
-    cpu_freq = psutil.cpu_freq()
-    mem = psutil.virtual_memory()
-    swap = psutil.swap_memory()
-    disk_path = str(RUNNER_BASE_DIR) if RUNNER_BASE_DIR.exists() else "/"
-    disk = shutil.disk_usage(disk_path)
-    disk_total_gb = round(disk.total / (1024**3), 1)
-    disk_used_gb = round(disk.used / (1024**3), 1)
-    disk_free_gb = round(disk.free / (1024**3), 1)
-    disk_percent = round(disk.used / disk.total * 100, 1)
-
-    if os.name == "nt":
-        net = psutil.net_io_counters()
-        per_cpu = psutil.cpu_percent(interval=0, percpu=True)
-        current_cpu = psutil.cpu_percent(interval=0)
-        _cpu_history.append(current_cpu)
-        cpu_avg_1m = round(sum(_cpu_history) / len(_cpu_history), 1) if _cpu_history else current_cpu
-        uptime_seconds = time.time() - psutil.boot_time()
-        dashboard_uptime = time.time() - BOOT_TIME
-        disk_pressure = _disk_pressure_snapshot(
-            path=disk_path,
-            total_gb=disk_total_gb,
-            used_gb=disk_used_gb,
-            free_gb=disk_free_gb,
-            percent=disk_percent,
-        )
-        hardware_specs = _local_hardware_specs(None)
-        return {
-            "hostname": HOSTNAME,
-            "platform": platform.platform(),
-            "timestamp": datetime.now(UTC).isoformat(),
-            "uptime_seconds": int(uptime_seconds),
-            "dashboard_uptime_seconds": int(dashboard_uptime),
-            "cpu": {
-                "cores_physical": psutil.cpu_count(logical=False),
-                "cores_logical": psutil.cpu_count(logical=True),
-                "percent": current_cpu,
-                "percent_1m_avg": cpu_avg_1m,
-                "per_cpu_percent": per_cpu,
-                "freq_current_mhz": round(cpu_freq.current, 0) if cpu_freq else None,
-                "freq_max_mhz": round(cpu_freq.max, 0) if cpu_freq else None,
-                "load_avg_1m": 0,
-                "load_avg_5m": 0,
-                "load_avg_15m": 0,
-            },
-            "memory": {
-                "host_total_gb": round(mem.total / (1024**3), 1),
-                "wsl_total_gb": None,
-                "total_gb": round(mem.total / (1024**3), 1),
-                "used_gb": round(mem.used / (1024**3), 1),
-                "available_gb": round(mem.available / (1024**3), 1),
-                "percent": mem.percent,
-                "swap_total_gb": round(swap.total / (1024**3), 1),
-                "swap_used_gb": round(swap.used / (1024**3), 1),
-                "swap_percent": swap.percent,
-            },
-            "disk": {
-                "path": disk_path,
-                "total_gb": disk_total_gb,
-                "used_gb": disk_used_gb,
-                "free_gb": disk_free_gb,
-                "percent": disk_percent,
-                "pressure": disk_pressure,
-                "windows_host": None,
-            },
-            "network": {
-                "bytes_sent": net.bytes_sent,
-                "bytes_recv": net.bytes_recv,
-                "packets_sent": net.packets_sent,
-                "packets_recv": net.packets_recv,
-            },
-            "gpu": None,
-            "hardware_specs": hardware_specs,
-            "workload_capacity": _workload_capacity_from_specs(hardware_specs),
-            "runner_processes": [],
-            "runner_capacity": {},
-        }
-
-    # On WSL, also report the Windows host disk (/mnt/c) where the VHDX lives.
-    # The host disk is the binding constraint — if it fills up, WSL itself breaks.
-    windows_disk = None
-    wsl_host_path = Path("/mnt/c")
-    if wsl_host_path.exists():
-        try:
-            wd = shutil.disk_usage(str(wsl_host_path))
-            windows_disk = {
-                "path": str(wsl_host_path),
-                "total_gb": round(wd.total / (1024**3), 1),
-                "used_gb": round(wd.used / (1024**3), 1),
-                "free_gb": round(wd.free / (1024**3), 1),
-                "percent": round(wd.used / wd.total * 100, 1),
-                "pressure": _disk_pressure_snapshot(
-                    path=str(wsl_host_path),
-                    total_gb=round(wd.total / (1024**3), 1),
-                    used_gb=round(wd.used / (1024**3), 1),
-                    free_gb=round(wd.free / (1024**3), 1),
-                    percent=round(wd.used / wd.total * 100, 1),
-                ),
-            }
-        except OSError:
-            pass
-
-    # Use the more critical disk for the top-level pressure signal.
-    windows_pct = (windows_disk or {}).get("percent", 0)
-    effective_pct = max(disk_percent, windows_pct)
-    effective_free = min(
-        disk_free_gb,
-        (windows_disk or {}).get("free_gb", disk_free_gb),
-    )
-    disk_pressure = _disk_pressure_snapshot(
-        path=disk_path,
-        total_gb=disk_total_gb,
-        used_gb=disk_used_gb,
-        free_gb=effective_free,
-        percent=effective_pct,
-    )
-
-    # Load averages (1, 5, 15 min)
-    try:
-        load_avg = os.getloadavg() if hasattr(os, "getloadavg") else (0, 0, 0)
-    except OSError:
-        load_avg = (0, 0, 0)
-
-    # Network I/O
-    net = psutil.net_io_counters()
-
-    # Per-CPU usage
-    per_cpu = psutil.cpu_percent(interval=0, percpu=True)
-    current_cpu = psutil.cpu_percent(interval=0)
-    _cpu_history.append(current_cpu)
-    cpu_avg_1m = round(sum(_cpu_history) / len(_cpu_history), 1) if _cpu_history else current_cpu
-
-    # Uptime
-    uptime_seconds = time.time() - psutil.boot_time()
-    dashboard_uptime = time.time() - BOOT_TIME
-    gpu = get_gpu_info()
-    hardware_specs = _local_hardware_specs(gpu)
-
-    return {
-        "hostname": HOSTNAME,
-        "platform": platform.platform(),
-        "timestamp": datetime.now(UTC).isoformat(),
-        "uptime_seconds": int(uptime_seconds),
-        "dashboard_uptime_seconds": int(dashboard_uptime),
-        "cpu": {
-            "cores_physical": psutil.cpu_count(logical=False),
-            "cores_logical": psutil.cpu_count(logical=True),
-            "percent": current_cpu,
-            "percent_1m_avg": cpu_avg_1m,
-            "per_cpu_percent": per_cpu,
-            "freq_current_mhz": round(cpu_freq.current, 0) if cpu_freq else None,
-            "freq_max_mhz": round(cpu_freq.max, 0) if cpu_freq else None,
-            "load_avg_1m": round(load_avg[0], 2),
-            "load_avg_5m": round(load_avg[1], 2),
-            "load_avg_15m": round(load_avg[2], 2),
-        },
-        "memory": {
-            "host_total_gb": HOST_MEMORY_GB,
-            "wsl_total_gb": round(mem.total / (1024**3), 1),
-            "total_gb": HOST_MEMORY_GB or round(mem.total / (1024**3), 1),
-            "used_gb": round(mem.used / (1024**3), 1),
-            "available_gb": round(mem.available / (1024**3), 1),
-            "percent": mem.percent,
-            "swap_total_gb": round(swap.total / (1024**3), 1),
-            "swap_used_gb": round(swap.used / (1024**3), 1),
-            "swap_percent": swap.percent,
-        },
-        "disk": {
-            "path": disk_path,
-            "total_gb": disk_total_gb,
-            "used_gb": disk_used_gb,
-            "free_gb": disk_free_gb,
-            "percent": disk_percent,
-            "pressure": disk_pressure,
-            "windows_host": windows_disk,
-        },
-        "network": {
-            "bytes_sent": net.bytes_sent,
-            "bytes_recv": net.bytes_recv,
-            "packets_sent": net.packets_sent,
-            "packets_recv": net.packets_recv,
-        },
-        "gpu": gpu,
-        "hardware_specs": hardware_specs,
-        "workload_capacity": _workload_capacity_from_specs(hardware_specs),
-        "runner_processes": get_per_runner_resources(),
-        "runner_capacity": get_runner_capacity_snapshot(),
-    }
-
-
 async def _collect_live_fleet_nodes() -> list[dict]:
     """Collect the live fleet node payload before registry metadata is merged."""
 
@@ -2303,7 +2115,7 @@ async def _collect_live_fleet_nodes() -> list[dict]:
             }
 
     local_sys = await get_system_metrics()
-    local_health = await _health_impl()
+    local_health = await _health_router._health_impl()
     local_resource_reason = _resource_offline_reason(local_sys)
     nodes: list[dict] = [
         {
@@ -2329,81 +2141,6 @@ async def _collect_live_fleet_nodes() -> list[dict]:
         nodes.extend(remote)
 
     return nodes
-
-
-@app.get("/api/fleet/status")
-async def get_fleet_status(request: Request):
-    """Get full system metrics state for all machines in the fleet network."""
-    if _should_proxy_fleet_to_hub(request):
-        return await proxy_to_hub(request)
-
-    responses = {}
-    responses[HOSTNAME] = await get_system_metrics()
-    responses[HOSTNAME]["_role"] = "hub"
-
-    async def fetch_node(name, url):
-        try:
-            async with httpx.AsyncClient() as client:
-                target = f"{url}/api/system"
-                resp = await client.get(target, timeout=5)
-                if resp.status_code == 200:
-                    data = resp.json()
-                    data["_role"] = "node"
-                    resource_reason = _resource_offline_reason(data)
-                    if resource_reason:
-                        data.update(resource_reason)
-                    return name, data
-                reason = _classify_node_offline(status_code=resp.status_code)
-                return name, {
-                    "status": "offline",
-                    "error": reason["offline_detail"],
-                    **reason,
-                }
-        except Exception as e:  # noqa: BLE001
-            reason = _classify_node_offline(e)
-            return name, {
-                "status": "offline",
-                "error": reason["offline_detail"],
-                **reason,
-            }
-
-    if FLEET_NODES:
-        results = await asyncio.gather(*[fetch_node(n, u) for n, u in FLEET_NODES.items()])
-        for name, data in results:
-            responses[name] = data
-
-    return responses
-
-
-async def _health_impl() -> dict:
-    """Core health logic, callable both from the HTTP endpoint and internally."""
-    try:
-        # Reuse the runner cache so health checks don't add extra API calls.
-        data = _cache_get("runners", 25.0)
-        if data is None:
-            data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-            _cache_set("runners", data)
-        gh_ok = True
-        runner_count = len(data.get("runners", []))
-    except Exception:  # noqa: BLE001
-        gh_ok = False
-        runner_count = 0
-
-    return {
-        "status": "healthy" if gh_ok else "degraded",
-        "timestamp": datetime.now(UTC).isoformat(),
-        "hostname": HOSTNAME,
-        "github_api": "connected" if gh_ok else "unreachable",
-        "runners_registered": runner_count,
-        "dashboard_uptime_seconds": int(time.time() - BOOT_TIME),
-        "deployment": _deployment_info(),
-    }
-
-
-@app.get("/api/health")
-async def health_check(request: Request):
-    """Health endpoint for monitoring and load balancers."""
-    return await _health_impl()
 
 
 @app.get("/api/deployment")
@@ -2443,19 +2180,6 @@ async def get_deployment_state(request: Request) -> dict:
     fleet = await _get_fleet_nodes_impl()
     expected = await _read_expected_dashboard_version()
     return _build_deployment_state(fleet.get("nodes", []), expected)
-
-
-@app.get("/health", tags=["diagnostics"])
-async def launcher_health_check() -> dict:
-    """Minimal health check for launcher recovery detection.
-
-    Returns 200 if backend is ready. Used by PWA recovery modal for
-    polling before triggering custom URL protocol.
-    """
-    return {
-        "status": "ready",
-        "timestamp": datetime.now(UTC).isoformat(),
-    }
 
 
 @app.post("/api/deployment/update-signal")

--- a/tests/test_health_module.py
+++ b/tests/test_health_module.py
@@ -1,0 +1,49 @@
+"""Tests for the extracted health module (issue #159).
+
+Structural and integration tests for the backend/health.py router.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+
+def test_health_module_importable() -> None:
+    import health  # noqa: PLC0415
+
+    assert hasattr(health, "router"), "health.py must export 'router'"
+
+
+def test_health_router_has_expected_routes() -> None:
+    import health  # noqa: PLC0415
+
+    paths = {r.path for r in health.router.routes}  # type: ignore[attr-defined]
+    assert "/api/health" in paths, "health router must expose /api/health"
+    assert "/health" in paths, "health router must expose /health"
+
+
+def test_health_router_not_inline_in_server() -> None:
+    """The health endpoints must not be defined inline in server.py."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert '@app.get("/api/health")' not in server_src, "/api/health must be in router, not inline"
+    assert '@app.get("/health"' not in server_src, "/health must be in router, not inline"
+
+
+def test_server_registers_health_router() -> None:
+    """server.py must include the health router."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert "import health as _health_router" in server_src
+    assert "include_router(_health_router.router)" in server_src
+
+
+def test_health_impl_exported() -> None:
+    """The _health_impl function must be callable from the module."""
+    import health  # noqa: PLC0415
+
+    assert callable(health._health_impl), "_health_impl must be callable"

--- a/tests/test_metrics_module.py
+++ b/tests/test_metrics_module.py
@@ -1,0 +1,42 @@
+"""Tests for the extracted metrics module (issue #159).
+
+Structural and integration tests for the backend/metrics.py router.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+
+def test_metrics_module_importable() -> None:
+    import metrics  # noqa: PLC0415
+
+    assert hasattr(metrics, "router"), "metrics.py must export 'router'"
+
+
+def test_metrics_router_has_expected_routes() -> None:
+    import metrics  # noqa: PLC0415
+
+    paths = {r.path for r in metrics.router.routes}  # type: ignore[attr-defined]
+    assert "/api/system" in paths, "metrics router must expose /api/system"
+    assert "/api/fleet/status" in paths, "metrics router must expose /api/fleet/status"
+
+
+def test_metrics_router_not_inline_in_server() -> None:
+    """The metrics endpoints must not be defined inline in server.py."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert '@app.get("/api/system")' not in server_src, "/api/system must be in router, not inline"
+    assert '@app.get("/api/fleet/status")' not in server_src, "/api/fleet/status must be in router, not inline"
+
+
+def test_server_registers_metrics_router() -> None:
+    """server.py must include the metrics router."""
+    server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    assert "import metrics as _metrics_router" in server_src
+    assert "include_router(_metrics_router.router)" in server_src


### PR DESCRIPTION
## Summary
Part of issue #159 [EPIC] god-module-refactor-2026q2 — Split oversized modules.

Extracts health check and system metrics endpoints from the ~6900-line backend/server.py into dedicated router modules.

## Changes
- **New:** backend/health.py — contains health check endpoints:
  - GET /api/health — full health check with GitHub API status, runner count, deployment info
  - GET /health — minimal launcher recovery check
  - Exported _health_impl() for reuse by server.py::_collect_live_fleet_nodes()
- **New:** backend/metrics.py — contains metrics endpoints:
  - GET /api/system — real-time CPU, memory, disk, GPU, runner process metrics
  - GET /api/fleet/status — fleet-wide system metrics aggregation
- **Updated:** backend/server.py — imports and mounts both routers; ~280 lines of endpoint code removed
- **New tests:** tests/test_health_module.py, tests/test_metrics_module.py — structural tests verifying routers are correctly wired

## Verification
- All existing tests pass (24 passed, 2 skipped)
- FastAPI app imports cleanly and routes are registered
- No breaking changes to API surface or behavior