### PR TITLE
chore(ci): unify action SHA pinning and pin ruff/mypy (#390)

### DIFF
--- a/.github/workflows/Agent-Fleet-Dashboard.yml
+++ b/.github/workflows/Agent-Fleet-Dashboard.yml
@@ -31,11 +31,11 @@ jobs:
           private-key: ${{ secrets.JULES_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/Agent-Lease-Reaper.yml
+++ b/.github/workflows/Agent-Lease-Reaper.yml
@@ -48,12 +48,12 @@ jobs:
           private-key: ${{ secrets.JULES_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: D-sorganization/Repository_Management
           ref: main
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/Agent-Redundant-PR-Closer.yml
+++ b/.github/workflows/Agent-Redundant-PR-Closer.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Checkout Repository_Management (for scripts)
         if: steps.app-creds.outputs.configured == 'true'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: D-sorganization/Repository_Management
           ref: main
@@ -91,7 +91,7 @@ jobs:
 
       - name: Setup Python
         if: steps.app-creds.outputs.configured == 'true'
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -80,7 +80,7 @@ jobs:
           owner: ${{ github.repository_owner }}
       - name: Checkout Repository_Management
         if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       # SAFEGUARD: Check if we've exceeded max repair iterations in the time window
       - name: Check Iteration Limits
         id: check-limits
@@ -135,7 +135,7 @@ jobs:
       - name: Analyze Event Context
         id: decide
         if: steps.check-limits.outcome == 'skipped' || steps.check-limits.outputs.exceeded != 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v9
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const event = context.eventName;

--- a/.github/workflows/agent-panel-review.yml
+++ b/.github/workflows/agent-panel-review.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: d-sorg-fleet
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
@@ -78,7 +78,7 @@ jobs:
     runs-on: d-sorg-fleet
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         env:
           ISSUE_NUMBER: ${{ inputs.issue_number }}

--- a/.github/workflows/ci-spec-check.yml
+++ b/.github/workflows/ci-spec-check.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Post warning comment
         if: steps.check.outputs.needs_update == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v9
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |
             const body = `## ⚠️ SPEC.md Update Required

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -55,6 +55,46 @@ jobs:
             exit 1
           fi
           echo "All actions pinned."
+      - name: verify-action-pin-uniformity
+        run: |
+          # Issue #390: every guarded action must resolve to a single SHA across
+          # all workflows, and that SHA must carry one consistent `# vN` comment.
+          fail=0
+          for action in checkout setup-python setup-node github-script upload-artifact download-artifact create-github-app-token; do
+            shas=$(grep -hE "uses:\s+actions/${action}@" .github/workflows/*.yml \
+              | sed -E 's/.*@([0-9a-f]{40}).*/\1/' | sort -u)
+            count=$(printf '%s\n' "$shas" | grep -c '^[0-9a-f]\{40\}$' || true)
+            if [ "$count" -gt 1 ]; then
+              echo "::error::Inconsistent SHA pinning for actions/${action}: ${shas}"
+              fail=1
+            fi
+            comments=$(grep -hE "uses:\s+actions/${action}@" .github/workflows/*.yml \
+              | sed -E 's/.*#\s*(v[^ ]+).*/\1/' | sort -u)
+            ccount=$(printf '%s\n' "$comments" | grep -c '^v' || true)
+            if [ "$ccount" -gt 1 ]; then
+              echo "::error::actions/${action} has inconsistent version comments: ${comments}"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then exit 1; fi
+          echo "All guarded actions pinned uniformly."
+      - name: verify-tool-version-parity
+        run: |
+          # Issue #390: pyproject [dependency-groups.dev] must pin ruff/mypy
+          # to the exact versions used by .pre-commit-config.yaml.
+          ruff_pc=$(grep -A1 "astral-sh/ruff-pre-commit" .pre-commit-config.yaml | grep "rev:" | sed -E 's/.*rev:\s*v?//;s/\s.*//')
+          mypy_pc=$(grep -A1 "pre-commit/mirrors-mypy" .pre-commit-config.yaml | grep "rev:" | sed -E 's/.*rev:\s*v?//;s/\s.*//')
+          ruff_pp=$(grep -E '"ruff==' pyproject.toml | sed -E 's/.*ruff==([0-9A-Za-z.\-]+).*/\1/')
+          mypy_pp=$(grep -E '"mypy==' pyproject.toml | sed -E 's/.*mypy==([0-9A-Za-z.\-]+).*/\1/')
+          if [ "$ruff_pc" != "$ruff_pp" ] || [ -z "$ruff_pp" ]; then
+            echo "::error::ruff version drift: pre-commit=$ruff_pc pyproject=$ruff_pp"
+            exit 1
+          fi
+          if [ "$mypy_pc" != "$mypy_pp" ] || [ -z "$mypy_pp" ]; then
+            echo "::error::mypy version drift: pre-commit=$mypy_pc pyproject=$mypy_pp"
+            exit 1
+          fi
+          echo "ruff/mypy parity ok: ruff=$ruff_pc mypy=$mypy_pc"
       - name: Verify no source file exceeds 500 lines
         run: |
           OVER=$(find backend/ frontend/src/ -type f \( -name "*.py" -o -name "*.ts" -o -name "*.tsx" -o -name "*.js" \) -exec wc -l {} + 2>/dev/null | grep -vE "server.py|agent_remediation.py|dispatch_contract.py|agent_dispatch_router.py|credentials.py|App.tsx|queue.py|remediation.py|Queue/index.tsx|total" | awk '$1 > 500 {print $1, $2}')

--- a/.github/workflows/issue-taxonomy-backfill.yml
+++ b/.github/workflows/issue-taxonomy-backfill.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: d-sorg-fleet
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install js-yaml
         run: npm install --no-save js-yaml@4

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: d-sorg-fleet
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install js-yaml
         run: npm install --no-save js-yaml@4

--- a/.github/workflows/taxonomy-rollout.yml
+++ b/.github/workflows/taxonomy-rollout.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: d-sorg-fleet
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install js-yaml
         run: npm install --no-save js-yaml@4
@@ -204,7 +204,7 @@ jobs:
     runs-on: d-sorg-fleet
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install js-yaml
         run: npm install --no-save js-yaml@4

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 **Spec Version:** 2.5.13
 **Application Version:** 4.1.0 (see `VERSION`)
-**Last Updated:** 2026-04-30T00:00:00Z
+**Last Updated:** 2026-04-30T17:30:00Z
 **Status:** Active
 
 ---
@@ -1973,6 +1973,23 @@ New principals can be added by editing this file; the dashboard reloads it
 automatically. Service tokens for bot principals can be minted via the
 Identity Manager (`identity_manager.mint_service_token`).
 <!-- spec-trigger-145 -->
+
+### 18.6 CI Action Pinning & Tool Version Parity (Issue #390)
+
+To prevent silent drift between local development and CI, the repository
+enforces two invariants:
+
+- **Single SHA per action:** every `actions/<name>@<sha>` reference in
+  `.github/workflows/*.yml` must resolve to one 40-char SHA across all
+  files, with one consistent `# vN` comment. The `verify-action-pin-uniformity`
+  step in `ci-standard.yml` (job `ci-health-check`) enforces this, and
+  `tests/test_workflow_action_pinning.py` provides a fast pytest guard.
+- **Tool version parity:** `pyproject.toml [dependency-groups.dev]` pins
+  `ruff` and `mypy` exactly (e.g. `ruff==0.14.10`, `mypy==1.13.0`) to
+  match the `rev:` values in `.pre-commit-config.yaml`. The
+  `verify-tool-version-parity` step in `ci-standard.yml` enforces this,
+  preventing `uv sync` from installing a newer linter/type-checker than
+  CI uses.
 
 ### 18.5 Cross-Fleet Coherence & Admin API (Wave 4)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,10 @@ dev = [
     "pytest-xdist>=3.6.0",
     "pytest-rerunfailures>=14.0",
     "respx>=0.21.1",
-    "ruff>=0.9.0",
-    "mypy>=1.15.0",
+    # ruff/mypy are pinned exactly to match `.pre-commit-config.yaml` so
+    # `uv sync` cannot install a newer linter than CI uses (issue #390).
+    "ruff==0.14.10",
+    "mypy==1.13.0",
     "pip-audit>=2.10.0",
     "types-PyYAML",
     "types-requests",

--- a/tests/test_workflow_action_pinning.py
+++ b/tests/test_workflow_action_pinning.py
@@ -1,0 +1,178 @@
+"""Issue #390: enforce action SHA pinning uniformity across workflows.
+
+These tests guard against two forms of drift in `.github/workflows/*.yml`:
+
+1. Two different 40-char SHAs pinned for the same `actions/<name>@`
+   reference (the bug that motivated this issue: `actions/checkout`
+   pinned to v4 in agent workflows but v6 in CI).
+2. The same SHA carrying inconsistent `# vN` version comments across
+   files (the `# v7` vs `# v9` mislabel on `actions/github-script`).
+
+The tests also verify that `pyproject.toml`'s dev pins for `ruff` and
+`mypy` exactly match the versions in `.pre-commit-config.yaml`, so a
+local `uv sync` cannot install a newer linter/type-checker than CI.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+# `uses: <ref>@<sha> # <comment>` — only match 40-char SHAs (already-pinned).
+_USES_LINE = re.compile(
+    r"^\s*-?\s*(?:name:.*\n\s*)?uses:\s+(?P<ref>[A-Za-z0-9._/-]+)@(?P<sha>[0-9a-f]{40})\s*(?:#\s*(?P<comment>.+?))?\s*$"
+)
+
+# Actions covered by the uniformity guard. Local repo-relative refs
+# (`./.github/...`) are intentionally excluded.
+_GUARDED_ACTIONS = (
+    "actions/checkout",
+    "actions/setup-python",
+    "actions/setup-node",
+    "actions/github-script",
+    "actions/upload-artifact",
+    "actions/download-artifact",
+    "actions/create-github-app-token",
+)
+
+
+def _collect_uses() -> list[tuple[Path, int, str, str, str]]:
+    """Return (path, lineno, ref, sha, comment) for every pinned `uses:` line."""
+    rows: list[tuple[Path, int, str, str, str]] = []
+    for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        for lineno, raw in enumerate(wf.read_text().splitlines(), start=1):
+            m = _USES_LINE.match(raw)
+            if not m:
+                continue
+            rows.append(
+                (
+                    wf,
+                    lineno,
+                    m.group("ref"),
+                    m.group("sha"),
+                    (m.group("comment") or "").strip(),
+                )
+            )
+    return rows
+
+
+def test_workflows_directory_exists() -> None:
+    assert WORKFLOWS_DIR.is_dir(), f"missing workflows dir: {WORKFLOWS_DIR}"
+
+
+@pytest.mark.parametrize("action", _GUARDED_ACTIONS)
+def test_action_sha_uniform_per_action(action: str) -> None:
+    """Each guarded action must resolve to a single SHA across all workflows."""
+    by_sha: dict[str, list[tuple[Path, int]]] = defaultdict(list)
+    for path, lineno, ref, sha, _comment in _collect_uses():
+        if ref == action:
+            by_sha[sha].append((path, lineno))
+
+    if len(by_sha) <= 1:
+        return  # 0 or 1 SHAs: trivially uniform.
+
+    detail_lines = [f"{sha}:" for sha in by_sha]
+    for sha, sites in by_sha.items():
+        for path, lineno in sites:
+            detail_lines.append(f"  {sha}  {path.relative_to(REPO_ROOT)}:{lineno}")
+    pytest.fail(f"Inconsistent SHA pinning for {action} across workflows:\n" + "\n".join(detail_lines))
+
+
+@pytest.mark.parametrize("action", _GUARDED_ACTIONS)
+def test_action_version_comment_uniform_per_action(action: str) -> None:
+    """A single SHA must always carry the same `# vN` comment.
+
+    This catches the `actions/github-script@<sha> # v9` vs `# v7`
+    inconsistency reported in issue #390 — the SHA was identical but
+    the comment claimed two different major versions.
+    """
+    by_sha: dict[str, dict[str, list[tuple[Path, int]]]] = defaultdict(lambda: defaultdict(list))
+    for path, lineno, ref, sha, comment in _collect_uses():
+        if ref != action:
+            continue
+        by_sha[sha][comment].append((path, lineno))
+
+    for sha, comments in by_sha.items():
+        if len(comments) <= 1:
+            continue
+        detail = [f"{action}@{sha} carries multiple version comments:"]
+        for comment, sites in comments.items():
+            label = comment or "(no comment)"
+            detail.append(f"  {label}")
+            for path, lineno in sites:
+                detail.append(f"    {path.relative_to(REPO_ROOT)}:{lineno}")
+        pytest.fail("\n".join(detail))
+
+
+def test_no_floating_action_versions() -> None:
+    """No workflow may pin to a floating tag like `@v4` or `@main`."""
+    floating = re.compile(r"^\s*-?\s*uses:\s+(?P<ref>[\w./-]+)@(?P<tag>v\d+|main|latest)\s*$")
+    offenders: list[str] = []
+    for wf in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        for lineno, raw in enumerate(wf.read_text().splitlines(), start=1):
+            m = floating.match(raw)
+            if m:
+                offenders.append(f"{wf.relative_to(REPO_ROOT)}:{lineno}  {m.group('ref')}@{m.group('tag')}")
+    assert not offenders, "Floating action versions found (pin to SHA):\n" + "\n".join(offenders)
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml dev pins must match .pre-commit-config.yaml
+# ---------------------------------------------------------------------------
+
+_PRECOMMIT_REV = re.compile(
+    r"-\s*repo:\s*https://github\.com/(?P<repo>[^\s]+)\s*\n\s*rev:\s*v?(?P<rev>[0-9][0-9A-Za-z.\-+]*)"
+)
+_PYPROJECT_DEV_PIN = re.compile(r'"\s*(?P<name>[A-Za-z0-9_.\-]+)\s*==\s*(?P<rev>[0-9][0-9A-Za-z.\-+]*)\s*"')
+
+
+def _parse_precommit_revs() -> dict[str, str]:
+    """Map pre-commit repo slug → rev (without leading `v`)."""
+    text = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+    return {m.group("repo").rstrip("/"): m.group("rev") for m in _PRECOMMIT_REV.finditer(text)}
+
+
+def _parse_pyproject_dev_pins() -> dict[str, str]:
+    """Map dev-group package name → exact `==` pin (or empty if not exact)."""
+    text = (REPO_ROOT / "pyproject.toml").read_text()
+    # Narrow to `[dependency-groups]` block to avoid pulling project deps.
+    block = re.search(
+        r"\[dependency-groups\](?P<body>.*?)(?:\n\[|\Z)",
+        text,
+        flags=re.DOTALL,
+    )
+    if not block:
+        return {}
+    return {m.group("name").lower(): m.group("rev") for m in _PYPROJECT_DEV_PIN.finditer(block.group("body"))}
+
+
+def test_ruff_version_matches_pre_commit() -> None:
+    precommit = _parse_precommit_revs()
+    pyproject = _parse_pyproject_dev_pins()
+    expected = precommit.get("astral-sh/ruff-pre-commit")
+    assert expected, "ruff missing from .pre-commit-config.yaml"
+    actual = pyproject.get("ruff")
+    assert actual == expected, (
+        f"ruff version drift: pyproject [dependency-groups.dev] pins "
+        f"{actual!r}, .pre-commit-config.yaml pins v{expected}. "
+        f"Use exact `ruff=={expected}` in pyproject.toml."
+    )
+
+
+def test_mypy_version_matches_pre_commit() -> None:
+    precommit = _parse_precommit_revs()
+    pyproject = _parse_pyproject_dev_pins()
+    expected = precommit.get("pre-commit/mirrors-mypy")
+    assert expected, "mypy missing from .pre-commit-config.yaml"
+    actual = pyproject.get("mypy")
+    assert actual == expected, (
+        f"mypy version drift: pyproject [dependency-groups.dev] pins "
+        f"{actual!r}, .pre-commit-config.yaml pins v{expected}. "
+        f"Use exact `mypy=={expected}` in pyproject.toml."
+    )


### PR DESCRIPTION
## Summary

Resolves the action-SHA + tool-version drift documented in #390:

- **`actions/checkout`**: 8 agent/label workflows pinned to v4 SHA `11bd7190...`; CI used v6 SHA `de0fac2e...`. All workflows now pinned to the v6 SHA, with one consistent `# v6` comment.
- **`actions/setup-python`**: 3 agent workflows pinned to v5 SHA `0b93645e...`; CI used v6 SHA `a309ff8b...`. All workflows now pinned to the v6 SHA.
- **`actions/github-script`**: SHA `60a0d83...` (v7.0.1) was uniform, but two files incorrectly commented it `# v9`. Fixed to `# v7`.
- **`pyproject.toml [dependency-groups.dev]`**: pinned `ruff==0.14.10` and `mypy==1.13.0` exactly to match `.pre-commit-config.yaml`. Stops `uv sync` from installing a newer linter than CI.

## Acceptance criteria

- [x] (1) Single source of truth — every guarded `actions/*@<sha>` reference is uniform across `.github/workflows/*.yml` and carries one consistent `# vN` comment. (Implemented as text-level uniformity rather than a separate `versions.yml` include because GitHub Actions has no native include mechanism for `uses:` and a Python-rendered manifest would add cross-repo coupling forbidden by CLAUDE.md. The CI guard + pytest guard enforce the same invariant.)
- [x] (2) New CI step `verify-action-pin-uniformity` in `ci-standard.yml` (`ci-health-check` job) collects all `actions/{checkout,setup-python,setup-node,github-script,upload-artifact,download-artifact,create-github-app-token}` SHAs and asserts there is exactly one per name plus exactly one version comment.
- [x] (3) `pyproject.toml [dependency-groups.dev]` pins `ruff==0.14.10` and `mypy==1.13.0` exactly.
- [x] (4) New CI step `verify-tool-version-parity` parses both files and asserts equality. Backed by `tests/test_workflow_action_pinning.py::test_{ruff,mypy}_version_matches_pre_commit`.

## Test plan

- [x] `pytest tests/test_workflow_action_pinning.py -v` — 18 tests, all green.
- [x] `ruff check tests/test_workflow_action_pinning.py` — clean.
- [x] `ruff format --check tests/test_workflow_action_pinning.py` — clean.
- [x] All workflow YAML files parse via `yaml.safe_load`.
- [x] Confirmed pinned SHAs map to real tags via `git ls-remote`: checkout v6 = `de0fac2e`, setup-python v6 = `a309ff8b`, github-script v7.0.1 = `60a0d83`.
- [ ] CI green on `ci-standard.yml` (will run on this PR).

Closes #390.

https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT)_