### PR TITLE
fix(api-design): persist dev-login principal so session survives restart (#410)

### DIFF
--- a/backend/identity.py
+++ b/backend/identity.py
@@ -1,9 +1,14 @@
 # ruff: noqa: B008
+import logging
+import os
 import secrets
+import tempfile
 import time
 from pathlib import Path
 
 import yaml
+
+log = logging.getLogger("dashboard")
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import APIKeyCookie, APIKeyHeader
 from pydantic import BaseModel, Field
@@ -63,6 +68,29 @@ class IdentityManager:
         for p in data["principals"]:
             prin = Principal(**p)
             self.principals[prin.id] = prin
+
+    def save_principals(self) -> None:
+        """Atomically persist the in-memory principals dict to ``principals.yml``.
+
+        Uses a temp-file + os.replace pattern so readers never see a partial write.
+        """
+        self.principals_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"principals": [p.model_dump() for p in self.principals.values()]}
+        fd, tmp_path = tempfile.mkstemp(
+            dir=self.principals_path.parent,
+            prefix=".tmp-principals-",
+            suffix=".yml",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                yaml.dump(payload, fh, default_flow_style=False, allow_unicode=True)
+            os.replace(tmp_path, self.principals_path)
+        except (OSError, yaml.YAMLError):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def get_principal(self, principal_id: str) -> Principal | None:
         return self.principals.get(principal_id)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -102,9 +102,10 @@ async def dev_login(request: Request):
             )
             return RedirectResponse(url="/")
 
-    # If none exists, create a dummy one
+    # If none exists, create a dummy one and persist it so it survives restarts.
     dummy = Principal(id="dev-user", type="human", name="Developer")
     identity_manager.principals["dev-user"] = dummy
+    identity_manager.save_principals()
     request.session["principal_id"] = "dev-user"
     request.session["session_id"] = sm.register_session(
         "dev-user",


### PR DESCRIPTION
## Summary

Fixes the silent-logout-on-restart bug for the dev-login flow (issue #410).

When `GET /api/auth/dev-login` creates a dummy `dev-user` principal, it now immediately persists it to `principals.yml` via the new `IdentityManager.save_principals()` method. Previously the in-memory principal was lost on every server restart, invalidating the session cookie silently.

### Changes

- **`backend/identity.py`** — Added `save_principals()`: atomically writes the current `principals` dict to `principals.yml` using a temp-file + `os.replace()` pattern (readers never see a partial write).
- **`backend/routers/auth.py`** — `dev_login()` now calls `identity_manager.save_principals()` immediately after inserting the dummy principal.

### Acceptance criteria

- [x] Dev-login session survives a server restart — the principal is on disk before the redirect.
- [x] Atomic write — `os.replace()` guarantees no torn reads.
- [x] Existing principals already on disk are unaffected (load path unchanged).

## Test plan

- [ ] Start server, hit `/api/auth/dev-login`, restart server — session cookie still valid.
- [ ] `principals.yml` contains `dev-user` after first login.
- [ ] `ruff check backend/ && ruff format --check backend/` — clean.

Closes #410

https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT)_