### PR TITLE
fix(privacy): add localStorage opt-out for assistant chat history (#428)

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,38 @@
+# Privacy — Runner Dashboard
+
+## Assistant Chat History
+
+The in-app assistant sidebar (`✨ Assistant`) may be used on **shared developer
+machines**. To prevent chat transcripts from leaking to the next user, history
+persistence is **opt-in and off by default**.
+
+### Behaviour
+
+| Setting | Stored in localStorage? |
+|---------|------------------------|
+| `Save chat history` OFF (default) | No — transcript is discarded on page unload |
+| `Save chat history` ON | Yes — capped at 200 messages, auto-expired after **24 hours** |
+
+### Controls
+
+- **Save chat history toggle** — found in the assistant sidebar settings panel
+  (⚙️ icon). Default: off.
+- **Clear chat history button** — also in the settings panel. Wipes the stored
+  transcript immediately and removes both the `assistant:transcript` and
+  `assistant:transcript:ts` localStorage keys.
+
+### localStorage keys
+
+| Key | Purpose |
+|-----|---------|
+| `assistant:transcript` | Serialised message array (written only when toggle is on) |
+| `assistant:transcript:ts` | Unix-ms timestamp of last write, used for 24 h TTL |
+| `assistant:saveHistory` | Persists the user's toggle preference across sessions |
+
+### Recommendations for shared boxes
+
+- Leave `Save chat history` **off** (the default).
+- If history was previously enabled, click **Clear chat history** before
+  handing the machine to another user.
+- Operators with stricter requirements can clear `localStorage` in the browser
+  developer tools (`Application → Storage → Local Storage → Clear All`).

--- a/frontend/src/legacy/App.tsx
+++ b/frontend/src/legacy/App.tsx
@@ -13638,9 +13638,27 @@ var ASST_LS = {
   position: "assistant:position",
   width: "assistant:width",
   transcript: "assistant:transcript",
+  transcriptTimestamp: "assistant:transcript:ts",
   openByDefault: "assistant:openByDefault",
   includeContext: "assistant:includeContext",
+  saveHistory: "assistant:saveHistory",
 };
+
+var ASST_HISTORY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function lsLoadTranscript() {
+  try {
+    var ts = parseInt(localStorage.getItem(ASST_LS.transcriptTimestamp) || "0", 10);
+    if (!ts || Date.now() - ts > ASST_HISTORY_TTL_MS) {
+      localStorage.removeItem(ASST_LS.transcript);
+      localStorage.removeItem(ASST_LS.transcriptTimestamp);
+      return [];
+    }
+    return lsGet(ASST_LS.transcript, []);
+  } catch (e) {
+    return [];
+  }
+}
 
 function lsGet(key, fallback) {
   try { var v = localStorage.getItem(key); return v === null ? fallback : JSON.parse(v); } catch (e) { return fallback; }
@@ -13660,7 +13678,10 @@ function AssistantSidebar(props) {
   var ws2 = React.useState(lsGet(ASST_LS.width, 360));
   var width = ws2[0], setWidth = ws2[1];
 
-  var ts2 = React.useState(lsGet(ASST_LS.transcript, []));
+  var sh2 = React.useState(lsGet(ASST_LS.saveHistory, false));
+  var saveHistory = sh2[0], setSaveHistory = sh2[1];
+
+  var ts2 = React.useState(function () { return saveHistory ? lsLoadTranscript() : []; });
   var transcript = ts2[0], setTranscript = ts2[1];
 
   var ic2 = React.useState(lsGet(ASST_LS.includeContext, true));
@@ -13694,10 +13715,19 @@ function AssistantSidebar(props) {
   React.useEffect(function () { lsSet(ASST_LS.width, width); }, [width]);
   React.useEffect(function () { lsSet(ASST_LS.includeContext, includeCtx); }, [includeCtx]);
   React.useEffect(function () { lsSet(ASST_LS.openByDefault, openByDefault); }, [openByDefault]);
+  React.useEffect(function () { lsSet(ASST_LS.saveHistory, saveHistory); }, [saveHistory]);
   React.useEffect(function () {
+    if (!saveHistory) {
+      try {
+        localStorage.removeItem(ASST_LS.transcript);
+        localStorage.removeItem(ASST_LS.transcriptTimestamp);
+      } catch (e) {}
+      return;
+    }
     var capped = transcript.length > 200 ? transcript.slice(-200) : transcript;
     lsSet(ASST_LS.transcript, capped);
-  }, [transcript]);
+    try { localStorage.setItem(ASST_LS.transcriptTimestamp, String(Date.now())); } catch (e) {}
+  }, [transcript, saveHistory]);
 
   function getPageContext() {
     return {
@@ -13859,10 +13889,36 @@ function AssistantSidebar(props) {
           h("input", { type: "checkbox", checked: includeCtx, onChange: function (e) { setIncludeCtx(e.target.checked); }, style: { accentColor: "var(--accent-blue)" } }),
           "Include page context with messages"
         ),
+        h("label", { style: { fontSize: 12, display: "flex", alignItems: "center", gap: 8, cursor: "pointer" } },
+          h("input", {
+            type: "checkbox",
+            checked: saveHistory,
+            onChange: function (e) {
+              var next = e.target.checked;
+              setSaveHistory(next);
+              if (!next) {
+                setTranscript([]);
+                try {
+                  localStorage.removeItem(ASST_LS.transcript);
+                  localStorage.removeItem(ASST_LS.transcriptTimestamp);
+                } catch (ex) {}
+              }
+            },
+            style: { accentColor: "var(--accent-blue)" },
+          }),
+          "Save chat history"
+        ),
         h("button", {
-          onClick: function () { setTranscript([]); setShowSettings(false); },
+          onClick: function () {
+            setTranscript([]);
+            try {
+              localStorage.removeItem(ASST_LS.transcript);
+              localStorage.removeItem(ASST_LS.transcriptTimestamp);
+            } catch (e) {}
+            setShowSettings(false);
+          },
           style: { background: "var(--accent-red)", color: "#fff", border: "none", borderRadius: 6, padding: "6px 12px", cursor: "pointer", fontSize: 12, width: "100%", marginTop: 8 },
-        }, "Clear conversation"),
+        }, "Clear chat history"),
       )
     : null;
 

--- a/tests/frontend/test_assistant_chat_privacy.py
+++ b/tests/frontend/test_assistant_chat_privacy.py
@@ -1,0 +1,108 @@
+"""Structural tests for the assistant chat privacy controls (issue #428).
+
+These tests read the frontend source file and assert that the key privacy
+constructs are present without spinning up a browser.
+"""
+
+from pathlib import Path
+
+
+def _read_app() -> str:
+    repo = Path(__file__).resolve().parents[2]
+    return (repo / "frontend/src/legacy/App.tsx").read_text()
+
+
+def _read_privacy_doc() -> str:
+    repo = Path(__file__).resolve().parents[2]
+    return (repo / "docs/privacy.md").read_text()
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — "Save chat history" toggle defaults to OFF
+# ---------------------------------------------------------------------------
+
+def test_save_history_key_defined() -> None:
+    src = _read_app()
+    assert 'saveHistory: "assistant:saveHistory"' in src
+
+
+def test_save_history_defaults_false() -> None:
+    src = _read_app()
+    assert "lsGet(ASST_LS.saveHistory, false)" in src
+
+
+def test_save_history_checkbox_label() -> None:
+    src = _read_app()
+    assert '"Save chat history"' in src
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — Auto-clear after 24 h
+# ---------------------------------------------------------------------------
+
+def test_24h_ttl_constant_defined() -> None:
+    src = _read_app()
+    assert "ASST_HISTORY_TTL_MS" in src
+    assert "24 * 60 * 60 * 1000" in src
+
+
+def test_transcript_timestamp_key_defined() -> None:
+    src = _read_app()
+    assert 'transcriptTimestamp: "assistant:transcript:ts"' in src
+
+
+def test_ls_load_transcript_checks_expiry() -> None:
+    src = _read_app()
+    assert "lsLoadTranscript" in src
+    assert "ASST_HISTORY_TTL_MS" in src
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — docs/privacy.md exists and documents the feature
+# ---------------------------------------------------------------------------
+
+def test_privacy_doc_exists() -> None:
+    doc = _read_privacy_doc()
+    assert len(doc) > 0
+
+
+def test_privacy_doc_mentions_save_history_toggle() -> None:
+    doc = _read_privacy_doc()
+    assert "Save chat history" in doc
+
+
+def test_privacy_doc_mentions_24h_expiry() -> None:
+    doc = _read_privacy_doc()
+    assert "24" in doc
+
+
+# ---------------------------------------------------------------------------
+# AC 4 — "Clear chat history" button present in sidebar
+# ---------------------------------------------------------------------------
+
+def test_clear_chat_history_button_present() -> None:
+    src = _read_app()
+    assert '"Clear chat history"' in src
+
+
+def test_clear_button_removes_transcript_from_ls() -> None:
+    src = _read_app()
+    # The clear button handler must call localStorage.removeItem for the transcript key
+    assert "localStorage.removeItem(ASST_LS.transcript)" in src
+    assert "localStorage.removeItem(ASST_LS.transcriptTimestamp)" in src
+
+
+# ---------------------------------------------------------------------------
+# AC 5 — With toggle off, transcript NOT written to localStorage
+# ---------------------------------------------------------------------------
+
+def test_transcript_persist_guarded_by_save_history() -> None:
+    src = _read_app()
+    # The effect that persists the transcript must check saveHistory
+    assert "if (!saveHistory)" in src
+
+
+def test_transcript_not_loaded_when_save_history_off() -> None:
+    src = _read_app()
+    # Transcript initialised conditionally on saveHistory
+    assert "saveHistory ? lsLoadTranscript()" in src


### PR DESCRIPTION
## Summary

- **Default off:** `saveHistory` toggle defaults to `false`; on shared dev boxes the transcript is never written to `localStorage`.
- **Opt-in persistence:** Users can enable "Save chat history" in the assistant sidebar settings (⚙️); history is capped at 200 messages and auto-expired after **24 hours** via a companion timestamp key.
- **Clear button:** "Clear chat history" in the settings panel wipes both `assistant:transcript` and `assistant:transcript:ts` from localStorage immediately.
- **Privacy doc:** `docs/privacy.md` added explaining all keys and recommended practice for shared machines.

## Acceptance criteria checklist

- [x] AC 1 — "Save chat history" toggle (default off) in assistant sidebar header/settings
- [x] AC 2 — Auto-clear after 24 h (enforced on load via `lsLoadTranscript()` + `ASST_HISTORY_TTL_MS`)
- [x] AC 3 — Documented in `docs/privacy.md`
- [x] AC 4 — "Clear chat history" button in sidebar wipes immediately
- [x] AC 5 — With toggle off, transcript not written to localStorage (guarded in `useEffect`)

## Test plan

- [x] 13 new structural tests in `tests/frontend/test_assistant_chat_privacy.py` — all pass
- [x] Full test suite: 664 passed, 0 failures, 1 skipped, 1 xfailed
- [ ] Manual: open assistant sidebar → send a message → reload page → confirm transcript is gone (toggle off)
- [ ] Manual: enable "Save chat history" → send messages → reload → transcript restored
- [ ] Manual: click "Clear chat history" → transcript wiped, localStorage keys absent

## Files changed

| File | Change |
|------|--------|
| `frontend/src/legacy/App.tsx` | Privacy toggle, TTL helper, conditional persistence |
| `docs/privacy.md` | New — describes localStorage keys and shared-box guidance |
| `tests/frontend/test_assistant_chat_privacy.py` | New — 13 structural tests covering all 5 ACs |

Closes #428

https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT)_