### PR TITLE
refactor: split runners.py to fix ci-health-check 500-line cap (unblocks all PRs)

### DIFF
--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -27,9 +27,7 @@ async def csrf_check(request: Request, call_next: Any) -> Any:
             return await call_next(request)
         # Allow health / static routes without the header so monitoring tools
         # (e.g. curl health checks) still work.  Only enforce on /api/* paths.
-        if request.url.path.startswith("/api/") and not request.url.path.startswith(
-            "/api/linear/webhook"
-        ):
+        if request.url.path.startswith("/api/") and not request.url.path.startswith("/api/linear/webhook"):
             if request.headers.get("X-Requested-With") != "XMLHttpRequest":
                 return JSONResponse(
                     {"error": "CSRF check failed: missing X-Requested-With header"},

--- a/backend/routers/remediation.py
+++ b/backend/routers/remediation.py
@@ -27,9 +27,7 @@ from system_utils import run_cmd
 
 _remediation_history_lock: asyncio.Lock = asyncio.Lock()
 
-REPO_ROOT = Path(
-    os.environ.get("RUNNER_DASHBOARD_REPO_ROOT", Path(__file__).parents[2])
-)
+REPO_ROOT = Path(os.environ.get("RUNNER_DASHBOARD_REPO_ROOT", Path(__file__).parents[2]))
 
 
 def _normalize_repository_input(value: str) -> tuple[str, str]:
@@ -59,14 +57,8 @@ async def get_agent_remediation_config() -> dict:
     return {
         "schema_version": agent_remediation.SCHEMA_VERSION,
         "policy": policy.to_dict(),
-        "providers": {
-            provider_id: provider.to_dict()
-            for provider_id, provider in agent_remediation.PROVIDERS.items()
-        },
-        "availability": {
-            provider_id: status.to_dict()
-            for provider_id, status in availability.items()
-        },
+        "providers": {provider_id: provider.to_dict() for provider_id, provider in agent_remediation.PROVIDERS.items()},
+        "availability": {provider_id: status.to_dict() for provider_id, status in availability.items()},
     }
 
 
@@ -93,33 +85,23 @@ async def update_agent_remediation_config(
         payload.get("workflow_type_rules")
     )
     policy = agent_remediation.RemediationPolicy(
-        auto_dispatch_on_failure=bool(
-            payload.get("auto_dispatch_on_failure", current.auto_dispatch_on_failure)
-        ),
-        require_failure_summary=bool(
-            payload.get("require_failure_summary", current.require_failure_summary)
-        ),
+        auto_dispatch_on_failure=bool(payload.get("auto_dispatch_on_failure", current.auto_dispatch_on_failure)),
+        require_failure_summary=bool(payload.get("require_failure_summary", current.require_failure_summary)),
         require_non_protected_branch=bool(
             payload.get(
                 "require_non_protected_branch",
                 current.require_non_protected_branch,
             )
         ),
-        max_same_failure_attempts=int(
-            payload.get("max_same_failure_attempts", current.max_same_failure_attempts)
-        ),
-        attempt_window_hours=int(
-            payload.get("attempt_window_hours", current.attempt_window_hours)
-        ),
+        max_same_failure_attempts=int(payload.get("max_same_failure_attempts", current.max_same_failure_attempts)),
+        attempt_window_hours=int(payload.get("attempt_window_hours", current.attempt_window_hours)),
         provider_order=agent_remediation._as_tuple_strings(  # noqa: SLF001
             payload.get("provider_order"), fallback=current.provider_order
         ),
         enabled_providers=agent_remediation._as_tuple_strings(  # noqa: SLF001
             payload.get("enabled_providers"), fallback=current.enabled_providers
         ),
-        default_provider=str(
-            payload.get("default_provider") or current.default_provider
-        ),
+        default_provider=str(payload.get("default_provider") or current.default_provider),
         workflow_type_rules=workflow_type_rules,
     )
     agent_remediation.save_policy(policy)
@@ -127,14 +109,8 @@ async def update_agent_remediation_config(
     return {
         "schema_version": agent_remediation.SCHEMA_VERSION,
         "policy": policy.to_dict(),
-        "providers": {
-            provider_id: provider.to_dict()
-            for provider_id, provider in agent_remediation.PROVIDERS.items()
-        },
-        "availability": {
-            provider_id: status.to_dict()
-            for provider_id, status in availability.items()
-        },
+        "providers": {provider_id: provider.to_dict() for provider_id, provider in agent_remediation.PROVIDERS.items()},
+        "availability": {provider_id: status.to_dict() for provider_id, status in availability.items()},
     }
 
 
@@ -199,31 +175,20 @@ async def plan_agent_remediation(
         attempts_payload = []
     if not isinstance(attempts_payload, list):
         raise HTTPException(status_code=422, detail="attempts must be a list")
-    attempts = [
-        agent_remediation.AttemptRecord.from_dict(item)
-        for item in attempts_payload
-        if isinstance(item, dict)
-    ]
+    attempts = [agent_remediation.AttemptRecord.from_dict(item) for item in attempts_payload if isinstance(item, dict)]
     availability = agent_remediation.probe_provider_availability()
     decision = agent_remediation.plan_dispatch(
         context,
         policy=agent_remediation.load_policy(),
         availability=availability,
         attempts=attempts,
-        provider_override=(
-            str(body.get("provider_override")).strip()
-            if body.get("provider_override")
-            else None
-        ),
+        provider_override=(str(body.get("provider_override")).strip() if body.get("provider_override") else None),
         dispatch_origin="manual",
     )
     return {
         "context": {**context.to_dict(), "full_repository": full_repository},
         "decision": decision.to_dict(),
-        "availability": {
-            provider_id: status.to_dict()
-            for provider_id, status in availability.items()
-        },
+        "availability": {provider_id: status.to_dict() for provider_id, status in availability.items()},
     }
 
 
@@ -243,9 +208,7 @@ async def dispatch_agent_remediation(
     context = agent_remediation.FailureContext.from_dict(body)
 
     # Wave 3: Quota and Fair Sharing
-    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(
-        principal, estimated_cost=0.10
-    )
+    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(principal, estimated_cost=0.10)
     if not allowed:
         raise HTTPException(status_code=403, detail=f"Quota exceeded: {reason}")
 
@@ -262,18 +225,12 @@ async def dispatch_agent_remediation(
         source=context.source,
     )
     provider_id = str(
-        body.get("provider")
-        or body.get("provider_override")
-        or agent_remediation.load_policy().default_provider
+        body.get("provider") or body.get("provider_override") or agent_remediation.load_policy().default_provider
     ).strip()
     attempts_payload = body.get("attempts", [])
     if attempts_payload is None:
         attempts_payload = []
-    attempts = [
-        agent_remediation.AttemptRecord.from_dict(item)
-        for item in attempts_payload
-        if isinstance(item, dict)
-    ]
+    attempts = [agent_remediation.AttemptRecord.from_dict(item) for item in attempts_payload if isinstance(item, dict)]
 
     if context.run_id and not context.log_excerpt.strip():
         from server import _fetch_failed_log_excerpt
@@ -419,14 +376,10 @@ async def api_quick_dispatch(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     if len(req.prompt.strip()) < 10:
-        raise HTTPException(
-            status_code=400, detail="prompt must be at least 10 characters"
-        )
+        raise HTTPException(status_code=400, detail="prompt must be at least 10 characters")
 
     # Wave 3: Quota and Fair Sharing
-    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(
-        principal, estimated_cost=0.10
-    )
+    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(principal, estimated_cost=0.10)
     if not allowed:
         raise HTTPException(status_code=403, detail=f"Quota exceeded: {reason}")
 
@@ -460,9 +413,7 @@ async def api_quick_dispatch(
             )
         if reason.startswith("prompt_too_short"):
             raise HTTPException(status_code=400, detail=reason)
-        raise HTTPException(
-            status_code=409, detail={"accepted": False, "reason": reason}
-        )
+        raise HTTPException(status_code=409, detail={"accepted": False, "reason": reason})
     return resp.model_dump()
 
 
@@ -486,9 +437,7 @@ async def api_dispatch_to_prs(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     # Wave 3: Quota and Fair Sharing
-    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(
-        principal, estimated_cost=0.10
-    )
+    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(principal, estimated_cost=0.10)
     if not allowed:
         raise HTTPException(status_code=403, detail=f"Quota exceeded: {reason}")
 
@@ -500,9 +449,7 @@ async def api_dispatch_to_prs(
         normalize_repository_fn=_normalize_repository_input,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(
-            status_code=result.get("status_code", 400), detail=result["error"]
-        )
+        raise HTTPException(status_code=result.get("status_code", 400), detail=result["error"])
     if isinstance(result, agent_dispatch_router.BulkDispatchResponse):
         return result.model_dump()
     return dict(result)
@@ -525,9 +472,7 @@ async def api_dispatch_to_issues(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     # Wave 3: Quota and Fair Sharing
-    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(
-        principal, estimated_cost=0.10
-    )
+    allowed, reason = quota_enforcement.quota_enforcement.check_dispatch_quota(principal, estimated_cost=0.10)
     if not allowed:
         raise HTTPException(status_code=403, detail=f"Quota exceeded: {reason}")
 
@@ -539,9 +484,7 @@ async def api_dispatch_to_issues(
         normalize_repository_fn=_normalize_repository_input,
     )
     if isinstance(result, dict) and "error" in result:
-        raise HTTPException(
-            status_code=result.get("status_code", 400), detail=result["error"]
-        )
+        raise HTTPException(status_code=result.get("status_code", 400), detail=result["error"])
     if isinstance(result, agent_dispatch_router.BulkDispatchResponse):
         return result.model_dump()
     return dict(result)
@@ -561,9 +504,7 @@ async def _append_remediation_history(entry: dict) -> None:
             history: list[dict] = []
             if _REMEDIATION_HISTORY_PATH.exists():
                 try:
-                    history = json.loads(
-                        _REMEDIATION_HISTORY_PATH.read_text(encoding="utf-8")
-                    )
+                    history = json.loads(_REMEDIATION_HISTORY_PATH.read_text(encoding="utf-8"))
                 except Exception:  # noqa: BLE001
                     history = []
             history.append(entry)
@@ -590,9 +531,7 @@ async def dispatch_jules_workflow(
         raise HTTPException(status_code=422, detail="workflow_file required")
     endpoint = f"/repos/{ORG}/Repository_Management/actions/workflows/{workflow_file}/dispatches"
     payload = {"ref": ref, "inputs": inputs}
-    with tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8", suffix=".json", delete=False
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".json", delete=False) as f:
         json.dump(payload, f)
         pf = f.name
     try:
@@ -627,9 +566,7 @@ async def get_remediation_history() -> dict:
     return {"history": list(reversed(history[-100:]))}  # newest first
 
 
-_PROVIDERS_WITH_MODEL_SELECTION: frozenset[str] = frozenset(
-    {"claude_code_cli", "codex_cli", "gemini_cli"}
-)
+_PROVIDERS_WITH_MODEL_SELECTION: frozenset[str] = frozenset({"claude_code_cli", "codex_cli", "gemini_cli"})
 
 
 @router.get("/api/agents/providers")
@@ -637,9 +574,7 @@ async def get_agent_providers() -> dict:
     """Return available agent providers and their availability status."""
     availability = agent_remediation.probe_provider_availability()
     return {
-        "providers": {
-            pid: p.to_dict() for pid, p in agent_remediation.PROVIDERS.items()
-        },
+        "providers": {pid: p.to_dict() for pid, p in agent_remediation.PROVIDERS.items()},
         "availability": {pid: s.to_dict() for pid, s in availability.items()},
         "providers_with_model_selection": sorted(_PROVIDERS_WITH_MODEL_SELECTION),
     }

--- a/backend/routers/runner_diagnostics.py
+++ b/backend/routers/runner_diagnostics.py
@@ -1,0 +1,378 @@
+"""Runner diagnostics and fleet capacity routes.
+
+Extracted from runners.py to keep modules under the 500-line cap.
+Handles diagnostics summaries, per-runner diagnostics, and fleet capacity.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt_mod
+import logging
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from gh_utils import gh_api_admin
+from identity import Principal, require_scope
+from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
+
+from .runner_helpers import UTC, run_runner_svc, runner_health_check, runner_num_from_id
+
+log = logging.getLogger("dashboard.runners")
+router = APIRouter(tags=["runners"])
+
+# Lazy-loaded system metrics snapshot function (set by server.py via runners.py)
+_get_system_metrics_snapshot = None
+
+
+@router.get("/api/runners/diagnostics/summary")
+async def get_runners_diagnostics_summary(request: Request) -> dict[str, Any]:
+    """Get a comprehensive diagnostics summary for all runners.
+
+    Includes health checks, connectivity status, and resource utilization overview.
+
+    Args:
+        request: HTTP request.
+
+    Returns:
+        Dict with runner counts by status, health issues, and recommendations.
+    """
+    try:
+        if should_proxy_fleet_to_hub(request):
+            return await proxy_to_hub(request)
+
+        from dashboard_config import ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        runners = data.get("runners", []) or []
+
+        online_count = sum(1 for r in runners if r.get("status") == "online")
+        offline_count = sum(1 for r in runners if r.get("status") != "online")
+        busy_count = sum(1 for r in runners if r.get("busy"))
+        idle_count = online_count - busy_count
+
+        # Collect health issues
+        issues = []
+        for runner in runners:
+            health = runner_health_check(runner)
+            if health["issues"]:
+                issues.append({"runner": health["runner_name"], "issues": health["issues"]})
+
+        recommendations = []
+        if offline_count > 0:
+            recommendations.append(f"Check offline runners ({offline_count}): restart svc or check system status")
+        if idle_count == 0 and online_count > 0:
+            recommendations.append("All online runners are busy; consider scaling up fleet capacity")
+
+        summary = {
+            "total_runners": len(runners),
+            "online": online_count,
+            "offline": offline_count,
+            "busy": busy_count,
+            "idle": idle_count,
+            "health_issues": issues,
+            "recommendations": recommendations,
+            "generated_at": _dt_mod.datetime.now(UTC).isoformat(),
+        }
+        log.info(
+            "get_runners_diagnostics_summary: total=%d, online=%d, offline=%d",
+            len(runners),
+            online_count,
+            offline_count,
+        )
+        return summary
+    except Exception as exc:
+        log.error("get_runners_diagnostics_summary: error: %s", exc)
+        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
+
+
+@router.post("/api/runners/{runner_id}/diagnostics")
+async def get_runner_diagnostics(request: Request, runner_id: int) -> dict[str, Any]:
+    """Get detailed diagnostics for a specific runner.
+
+    Includes service status, recent activity, and potential troubleshooting info.
+
+    Args:
+        request: HTTP request.
+        runner_id: GitHub runner ID.
+
+    Returns:
+        Dict with detailed diagnostics and troubleshooting info.
+
+    Raises:
+        HTTPException: If runner not found.
+    """
+    try:
+        from dashboard_config import ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        runners = data.get("runners", [])
+
+        runner = next((r for r in runners if r.get("id") == runner_id), None)
+
+        if runner is None:
+            log.warning("get_runner_diagnostics: runner_id=%d not found", runner_id)
+            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found")
+
+        num = runner_num_from_id(runner_id, runners)
+
+        diagnostics: dict[str, Any] = {
+            "runner_id": runner_id,
+            "runner_name": runner.get("name"),
+            "runner_num": num,
+            "status": runner.get("status"),
+            "busy": runner.get("busy"),
+            "health": runner_health_check(runner),
+            "labels": [lbl.get("name") for lbl in runner.get("labels", []) if isinstance(lbl, dict)],
+            "accessed_at": runner.get("accessed_at"),
+            "created_at": runner.get("created_at"),
+        }
+
+        # Try to read svc status if local runner number found
+        if num is not None:
+            code, stdout, _ = await run_runner_svc(num, "status")
+            diagnostics["svc_status"] = {"exit_code": code, "output": stdout.strip()}
+
+        # Troubleshooting suggestions
+        troubleshooting = []
+        if runner.get("status") != "online":
+            troubleshooting.append("Runner offline: check system status, network, and service logs")
+            if num is not None:
+                troubleshooting.append(f"Try: restart service runner-{num} via dashboard or SSH")
+        if not runner.get("labels"):
+            troubleshooting.append("No labels: add labels to runner in GitHub Actions settings")
+        if runner.get("busy"):
+            accessed_str = runner.get("accessed_at", "2000-01-01T00:00:00Z").replace("Z", "+00:00")
+            accessed_dt = _dt_mod.datetime.fromisoformat(accessed_str)
+            time_diff = time.time() - time.mktime(accessed_dt.timetuple())
+            if time_diff > 3600:
+                troubleshooting.append("Runner busy for over 1 hour: may be stuck, consider manual restart")
+
+        diagnostics["troubleshooting_suggestions"] = troubleshooting
+        log.debug("get_runner_diagnostics: runner_id=%d", runner_id)
+        return diagnostics
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("get_runner_diagnostics: error for runner_id=%d: %s", runner_id, exc)
+        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
+
+
+@router.get("/api/runners/fleet/capacity")
+async def get_fleet_capacity(request: Request) -> dict[str, Any]:
+    """Get fleet capacity and scheduling information.
+
+    Provides current utilization, available capacity, and recommendations for scaling.
+
+    Args:
+        request: HTTP request.
+
+    Returns:
+        Dict with capacity metrics and scheduling recommendations.
+    """
+    try:
+        if should_proxy_fleet_to_hub(request):
+            return await proxy_to_hub(request)
+
+        from dashboard_config import HOSTNAME, ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        runners = data.get("runners", []) or []
+
+        online = sum(1 for r in runners if r.get("status") == "online")
+        busy = sum(1 for r in runners if r.get("busy"))
+        idle = online - busy
+        total = len(runners)
+
+        # Get system metrics if available
+        system_metrics = None
+        if _get_system_metrics_snapshot:
+            try:
+                system_metrics = await _get_system_metrics_snapshot()  # type: ignore
+            except Exception as e:
+                log.debug("Failed to get system metrics for capacity: %s", e)
+
+        utilization_percent = int((busy / online * 100) if online > 0 else 0)
+
+        # Scaling recommendations
+        recommendations = []
+        if utilization_percent > 80:
+            recommendations.append("HIGH utilization: consider scaling up fleet")
+        elif utilization_percent > 60:
+            recommendations.append("MODERATE utilization: monitor for growth")
+        if idle == 0 and online > 0:
+            recommendations.append("No idle runners: all capacity in use")
+
+        capacity = {
+            "total_runners": total,
+            "online_runners": online,
+            "offline_runners": total - online,
+            "busy_runners": busy,
+            "idle_runners": idle,
+            "utilization_percent": utilization_percent,
+            "hostname": HOSTNAME,
+            "recommendations": recommendations,
+            "generated_at": _dt_mod.datetime.now(UTC).isoformat(),
+        }
+
+        if system_metrics:
+            capacity["system_health"] = {
+                "cpu_percent": system_metrics.get("cpu_percent"),
+                "memory_percent": system_metrics.get("memory_percent"),
+                "disk_pressure": system_metrics.get("disk_pressure"),
+            }
+
+        log.info(
+            "get_fleet_capacity: total=%d, online=%d, busy=%d, util=%d%%",
+            total,
+            online,
+            busy,
+            utilization_percent,
+        )
+        return capacity
+    except Exception as exc:
+        log.error("get_fleet_capacity: error: %s", exc)
+        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
+
+
+@router.post("/api/runners/fleet/schedule-scale")
+async def schedule_fleet_scale(
+    request: Request,
+    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
+) -> dict[str, Any]:
+    """Schedule automatic fleet scaling based on current utilization.
+
+    Analyzes current utilization and recommends scaling actions.
+
+    Args:
+        request: HTTP request with optional body containing scale directives.
+        principal: Authenticated principal.
+
+    Returns:
+        Dict with scheduled scaling actions and results.
+    """
+    try:
+        from dashboard_config import ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        runners = data.get("runners", []) or []
+
+        online = sum(1 for r in runners if r.get("status") == "online")
+        busy = sum(1 for r in runners if r.get("busy"))
+        idle = online - busy
+        utilization_percent = int((busy / online * 100) if online > 0 else 0)
+
+        scheduled_actions = []
+
+        # Simple autoscaling logic
+        if utilization_percent > 80 and idle == 0:
+            # Try to start one idle runner if available
+            for runner in runners:
+                if runner.get("status") != "online":
+                    num = runner_num_from_id(runner.get("id"), runners)
+                    if num is not None:
+                        code, _, _ = await run_runner_svc(num, "start")
+                        scheduled_actions.append(
+                            {
+                                "action": "start",
+                                "runner_id": runner.get("id"),
+                                "runner_num": num,
+                                "success": code == 0,
+                            }
+                        )
+                        break
+
+        log.info(
+            "schedule_fleet_scale: util=%d%%, scheduled=%d actions (principal=%s)",
+            utilization_percent,
+            len(scheduled_actions),
+            principal.user_id,
+        )
+        return {
+            "utilization_percent": utilization_percent,
+            "scheduled_actions": scheduled_actions,
+            "total_actions": len(scheduled_actions),
+        }
+    except Exception as exc:
+        log.error("schedule_fleet_scale: error: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc
+
+
+@router.post("/api/runners/{runner_id}/troubleshoot")
+async def troubleshoot_runner(
+    request: Request,
+    runner_id: int,
+    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
+) -> dict[str, Any]:
+    """Perform automated troubleshooting on a runner.
+
+    Runs diagnostics and attempts automatic fixes for common issues.
+
+    Args:
+        request: HTTP request.
+        runner_id: GitHub runner ID.
+        principal: Authenticated principal.
+
+    Returns:
+        Dict with troubleshooting steps and results.
+
+    Raises:
+        HTTPException: If runner not found.
+    """
+    try:
+        from dashboard_config import ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        runners = data.get("runners", [])
+
+        runner = next((r for r in runners if r.get("id") == runner_id), None)
+
+        if runner is None:
+            log.warning("troubleshoot_runner: runner_id=%d not found (principal=%s)", runner_id, principal.user_id)
+            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found")
+
+        num = runner_num_from_id(runner_id, runners)
+        steps: list[dict[str, Any]] = []
+
+        # Step 1: Check current status
+        steps.append({"step": "Check status", "status": "pending"})
+        if runner.get("status") != "online":
+            steps.append({"step": "Attempt restart", "status": "pending"})
+            if num is not None:
+                code, stdout, stderr = await run_runner_svc(num, "restart")
+                result_dict: dict[str, Any] = {
+                    "exit_code": code,
+                    "output": stdout.strip() if code == 0 else stderr.strip(),
+                }
+                steps[-1]["result"] = result_dict  # type: ignore
+                steps[-1]["status"] = "success" if code == 0 else "failed"  # type: ignore
+
+        # Step 2: Verify online after restart
+        if num is not None:
+            code, stdout, _ = await run_runner_svc(num, "status")
+            result_dict = {"exit_code": code, "output": stdout.strip()}
+            steps.append(
+                {
+                    "step": "Verify status after restart",
+                    "result": result_dict,
+                    "status": "success" if code == 0 else "failed",
+                }
+            )
+
+        log.info(
+            "troubleshoot_runner: runner_id=%d (runner_num=%s, principal=%s)",
+            runner_id,
+            num,
+            principal.user_id,
+        )
+        return {
+            "runner_id": runner_id,
+            "runner_num": num,
+            "troubleshooting_steps": steps,
+            "success": all(s["status"] in ("success", "pending") for s in steps),
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("troubleshoot_runner: error for runner_id=%d: %s", runner_id, exc)
+        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc

--- a/backend/routers/runner_groups.py
+++ b/backend/routers/runner_groups.py
@@ -1,0 +1,186 @@
+"""Runner group management routes.
+
+Extracted from runners.py to keep modules under the 500-line cap.
+Handles label-based runner group operations.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from gh_utils import gh_api_admin
+from identity import Principal, require_scope
+from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
+
+from .runner_helpers import run_runner_svc, runner_num_from_id, runner_sort_key
+
+log = logging.getLogger("dashboard.runners")
+router = APIRouter(tags=["runners"])
+
+
+@router.get("/api/runners/groups/{group_label}")
+async def get_runner_group(request: Request, group_label: str) -> dict[str, Any]:
+    """Get runners filtered by a specific label/group.
+
+    Args:
+        request: HTTP request.
+        group_label: Label name to filter by.
+
+    Returns:
+        Dict with grouped runners and summary stats.
+
+    Raises:
+        HTTPException: If GitHub API fails.
+    """
+    try:
+        if should_proxy_fleet_to_hub(request):
+            return await proxy_to_hub(request)
+
+        from dashboard_config import ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        all_runners = data.get("runners", [])
+
+        # Filter runners with the specified label
+        grouped = [
+            runner
+            for runner in all_runners
+            if group_label in [lbl.get("name", "") for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
+        ]
+        grouped = sorted(grouped, key=runner_sort_key)
+
+        result = {
+            "group_label": group_label,
+            "runners": grouped,
+            "total": len(grouped),
+            "online": sum(1 for r in grouped if r.get("status") == "online"),
+            "busy": sum(1 for r in grouped if r.get("busy")),
+            "offline": sum(1 for r in grouped if r.get("status") != "online"),
+        }
+        log.debug("get_runner_group: label=%s (count=%d)", group_label, len(grouped))
+        return result
+    except Exception as exc:
+        log.error("get_runner_group: error for label=%s: %s", group_label, exc)
+        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
+
+
+@router.post("/api/runners/groups/{group_label}/start-all")
+async def start_runner_group(
+    request: Request,
+    group_label: str,
+    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
+) -> dict[str, Any]:
+    """Start all runners in a specific group/label.
+
+    Requires the 'runners.control' scope.
+
+    Args:
+        request: HTTP request.
+        group_label: Label name identifying the group.
+        principal: Authenticated principal.
+
+    Returns:
+        Dict with results for each runner in the group.
+    """
+    try:
+        from dashboard_config import ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        all_runners = data.get("runners", [])
+
+        grouped = [
+            runner
+            for runner in all_runners
+            if group_label in [lbl.get("name", "") for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
+        ]
+
+        results = []
+        for runner in grouped:
+            runner_id = runner.get("id")
+            num = runner_num_from_id(runner_id, all_runners)
+            if num is None:
+                results.append({"runner_id": runner_id, "success": False, "error": "Local runner number not found"})
+                continue
+
+            code, stdout, stderr = await run_runner_svc(num, "start")
+            results.append(
+                {
+                    "runner_id": runner_id,
+                    "runner_num": num,
+                    "success": code == 0,
+                    "output": stdout.strip() if code == 0 else stderr.strip(),
+                }
+            )
+
+        log.info(
+            "start_runner_group: label=%s (total=%d, principal=%s)",
+            group_label,
+            len(grouped),
+            principal.user_id,
+        )
+        return {"group_label": group_label, "results": results, "successful": sum(1 for r in results if r["success"])}
+    except Exception as exc:
+        log.error("start_runner_group: error for label=%s: %s", group_label, exc)
+        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc
+
+
+@router.post("/api/runners/groups/{group_label}/stop-all")
+async def stop_runner_group(
+    request: Request,
+    group_label: str,
+    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
+) -> dict[str, Any]:
+    """Stop all runners in a specific group/label.
+
+    Requires the 'runners.control' scope.
+
+    Args:
+        request: HTTP request.
+        group_label: Label name identifying the group.
+        principal: Authenticated principal.
+
+    Returns:
+        Dict with results for each runner in the group.
+    """
+    try:
+        from dashboard_config import ORG
+
+        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+        all_runners = data.get("runners", [])
+
+        grouped = [
+            runner
+            for runner in all_runners
+            if group_label in [lbl.get("name", "") for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
+        ]
+
+        results = []
+        for runner in grouped:
+            runner_id = runner.get("id")
+            num = runner_num_from_id(runner_id, all_runners)
+            if num is None:
+                results.append({"runner_id": runner_id, "success": False, "error": "Local runner number not found"})
+                continue
+
+            code, stdout, stderr = await run_runner_svc(num, "stop")
+            results.append(
+                {
+                    "runner_id": runner_id,
+                    "runner_num": num,
+                    "success": code == 0,
+                    "output": stdout.strip() if code == 0 else stderr.strip(),
+                }
+            )
+
+        log.info(
+            "stop_runner_group: label=%s (total=%d, principal=%s)",
+            group_label,
+            len(grouped),
+            principal.user_id,
+        )
+        return {"group_label": group_label, "results": results, "successful": sum(1 for r in results if r["success"])}
+    except Exception as exc:
+        log.error("stop_runner_group: error for label=%s: %s", group_label, exc)
+        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc

--- a/backend/routers/runner_helpers.py
+++ b/backend/routers/runner_helpers.py
@@ -1,0 +1,155 @@
+"""Shared helper utilities for runner routes.
+
+Extracted from runners.py to keep modules under the 500-line cap.
+Provides utility functions used across all runner sub-routers.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt_mod
+import logging
+from pathlib import Path
+from typing import Any
+
+from dashboard_config import RUNNER_BASE_DIR
+from system_utils import run_cmd
+
+# Python 3.10+ has UTC; fall back to timezone.utc for earlier versions
+try:
+    UTC = _dt_mod.UTC  # type: ignore
+except AttributeError:
+    UTC = _dt_mod.UTC  # type: ignore
+
+log = logging.getLogger("dashboard.runners")
+
+
+def runner_svc_path(runner_num: int) -> Path:
+    """Return the path to a runner's svc.sh script.
+
+    Args:
+        runner_num: Local 1-based runner index.
+
+    Returns:
+        Path object pointing to the service script.
+    """
+    return RUNNER_BASE_DIR / f"runner-{runner_num}" / "svc.sh"
+
+
+async def run_runner_svc(runner_num: int, action: str, timeout: int = 30) -> tuple[int, str, str]:
+    """Execute ./svc.sh <action> for a runner.
+
+    Args:
+        runner_num: Local 1-based runner index.
+        action: Action to execute (start, stop, etc.).
+        timeout: Command timeout in seconds.
+
+    Returns:
+        Tuple of (exit_code, stdout, stderr).
+    """
+    svc_path = runner_svc_path(runner_num)
+    if not svc_path.exists():
+        return 1, "", f"Service script not found: {svc_path}"
+    # Use sudo if required, or run directly if permissions allow
+    cmd = ["sudo", "-n", str(svc_path), action]
+    return await run_cmd(cmd, timeout=timeout)
+
+
+def runner_num_from_id(runner_id: int, runners: list[dict]) -> int | None:
+    """Extract local 1-based runner index from a GitHub runner dict's name.
+
+    Args:
+        runner_id: GitHub runner ID.
+        runners: List of runner dicts from GitHub API.
+
+    Returns:
+        Local runner number (1-based), or None if not found.
+    """
+    for r in runners:
+        if r.get("id") == runner_id:
+            name = r.get("name", "")
+            # Expecting names like "d-sorg-fleet-runner-1"
+            if "runner-" in name:
+                try:
+                    return int(name.split("runner-")[-1])
+                except (ValueError, IndexError):
+                    pass
+    return None
+
+
+def runner_sort_key(runner: dict) -> tuple[str, int, str]:
+    """Sort key for runners: status (online first), then local index, then name.
+
+    Args:
+        runner: Runner dict from GitHub API.
+
+    Returns:
+        Tuple for sorting (status_rank, runner_number, name).
+    """
+    status_rank = "0" if runner.get("status") == "online" else "1"
+    name = runner.get("name", "")
+    try:
+        num = int(name.split("-")[-1]) if "-" in name else 0
+    except (ValueError, IndexError):
+        num = 0
+    return (status_rank, num, name)
+
+
+def is_matlab_runner(runner: dict) -> bool:
+    """Check if runner has MATLAB installed by examining labels.
+
+    Args:
+        runner: Runner dict from GitHub API.
+
+    Returns:
+        True if MATLAB label is present.
+    """
+    labels = [lbl.get("name", "").lower() for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
+    return "matlab" in labels or "windows-matlab" in labels
+
+
+def matlab_runner_summary(runner: dict) -> dict[str, Any]:
+    """Extract summary for MATLAB runners.
+
+    Args:
+        runner: Runner dict from GitHub API.
+
+    Returns:
+        Simplified runner dict with key fields.
+    """
+    return {
+        "id": runner.get("id"),
+        "name": runner.get("name"),
+        "status": runner.get("status"),
+        "busy": runner.get("busy"),
+        "labels": [lbl.get("name") for lbl in runner.get("labels", []) if isinstance(lbl, dict)],
+    }
+
+
+def runner_health_check(runner: dict, system_metrics: dict | None = None) -> dict[str, Any]:
+    """Compute health status for a runner.
+
+    Args:
+        runner: Runner dict from GitHub API.
+        system_metrics: Optional system metrics snapshot.
+
+    Returns:
+        Health check result dict.
+    """
+    health_status = "healthy"
+    issues = []
+
+    if runner.get("status") != "online":
+        health_status = "offline"
+        issues.append(f"runner offline ({runner.get('status')})")
+
+    labels = runner.get("labels", [])
+    if not labels:
+        issues.append("no labels assigned")
+
+    return {
+        "runner_id": runner.get("id"),
+        "runner_name": runner.get("name"),
+        "status": health_status,
+        "issues": issues,
+        "last_check": _dt_mod.datetime.now(UTC).isoformat(),
+    }

--- a/backend/routers/runners.py
+++ b/backend/routers/runners.py
@@ -1,12 +1,14 @@
 """Runner control and status routes.
 
-Comprehensive runner service management including:
+Core runner lifecycle management:
+- Runner listing and status queries
 - Runner lifecycle control (start, stop, restart)
-- Runner group management and labeling
-- Fleet capacity scheduling and autoscaling
-- MATLAB support and specialized runner detection
-- Health monitoring and diagnostics
-- Troubleshooting and state inspection endpoints
+- MATLAB runner health
+
+Extended functionality is split into sub-modules:
+- runner_groups: label-based group operations
+- runner_diagnostics: diagnostics, fleet capacity, autoscaling, troubleshooting
+- runner_helpers: shared utility functions
 
 All operations are logged and authorized through the identity module.
 """
@@ -14,28 +16,27 @@ All operations are logged and authorized through the identity module.
 from __future__ import annotations
 
 import asyncio
-import datetime as _dt_mod
 import logging
-import time
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from cache_utils import cache_get, cache_set
-from dashboard_config import HOSTNAME, ORG, RUNNER_BASE_DIR
+from dashboard_config import ORG
 from fastapi import APIRouter, Depends, HTTPException, Request
 from gh_utils import gh_api_admin
 from identity import Principal, require_scope
 from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
-from system_utils import run_cmd
+
+from .runner_helpers import (
+    is_matlab_runner,
+    matlab_runner_summary,
+    run_runner_svc,
+    runner_health_check,
+    runner_num_from_id,
+    runner_sort_key,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-# Python 3.10+ has UTC; fall back to timezone.utc for earlier versions
-try:
-    UTC = _dt_mod.UTC  # type: ignore
-except AttributeError:
-    UTC = _dt_mod.timezone.utc  # type: ignore
 
 log = logging.getLogger("dashboard.runners")
 router = APIRouter(tags=["runners"])
@@ -49,163 +50,6 @@ def set_system_metrics_getter(getter: Callable[[], dict[str, Any]]) -> None:
     """Register the system metrics snapshot getter (called from server.py)."""
     global _get_system_metrics_snapshot
     _get_system_metrics_snapshot = getter
-
-
-def runner_svc_path(runner_num: int) -> Path:
-    """Return the path to a runner's svc.sh script.
-
-    Args:
-        runner_num: Local 1-based runner index.
-
-    Returns:
-        Path object pointing to the service script.
-    """
-    return RUNNER_BASE_DIR / f"runner-{runner_num}" / "svc.sh"
-
-
-async def run_runner_svc(runner_num: int, action: str, timeout: int = 30) -> tuple[int, str, str]:
-    """Execute ./svc.sh <action> for a runner.
-
-    Args:
-        runner_num: Local 1-based runner index.
-        action: Action to execute (start, stop, etc.).
-        timeout: Command timeout in seconds.
-
-    Returns:
-        Tuple of (exit_code, stdout, stderr).
-    """
-    svc_path = runner_svc_path(runner_num)
-    if not svc_path.exists():
-        return 1, "", f"Service script not found: {svc_path}"
-    # Use sudo if required, or run directly if permissions allow
-    cmd = ["sudo", "-n", str(svc_path), action]
-    return await run_cmd(cmd, timeout=timeout)
-
-
-def runner_num_from_id(runner_id: int, runners: list[dict]) -> int | None:
-    """Extract local 1-based runner index from a GitHub runner dict's name.
-
-    Args:
-        runner_id: GitHub runner ID.
-        runners: List of runner dicts from GitHub API.
-
-    Returns:
-        Local runner number (1-based), or None if not found.
-    """
-    for r in runners:
-        if r.get("id") == runner_id:
-            name = r.get("name", "")
-            # Expecting names like "d-sorg-fleet-runner-1"
-            if "runner-" in name:
-                try:
-                    return int(name.split("runner-")[-1])
-                except (ValueError, IndexError):
-                    pass
-    return None
-
-
-def _runner_sort_key(runner: dict) -> tuple[str, int, str]:
-    """Sort key for runners: status (online first), then local index, then name.
-
-    Args:
-        runner: Runner dict from GitHub API.
-
-    Returns:
-        Tuple for sorting (status_rank, runner_number, name).
-    """
-    status_rank = "0" if runner.get("status") == "online" else "1"
-    name = runner.get("name", "")
-    try:
-        num = int(name.split("-")[-1]) if "-" in name else 0
-    except (ValueError, IndexError):
-        num = 0
-    return (status_rank, num, name)
-
-
-def _is_matlab_runner(runner: dict) -> bool:
-    """Check if runner has MATLAB installed by examining labels.
-
-    Args:
-        runner: Runner dict from GitHub API.
-
-    Returns:
-        True if MATLAB label is present.
-    """
-    labels = [lbl.get("name", "").lower() for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
-    return "matlab" in labels or "windows-matlab" in labels
-
-
-def _matlab_runner_summary(runner: dict) -> dict[str, Any]:
-    """Extract summary for MATLAB runners.
-
-    Args:
-        runner: Runner dict from GitHub API.
-
-    Returns:
-        Simplified runner dict with key fields.
-    """
-    return {
-        "id": runner.get("id"),
-        "name": runner.get("name"),
-        "status": runner.get("status"),
-        "busy": runner.get("busy"),
-        "labels": [lbl.get("name") for lbl in runner.get("labels", []) if isinstance(lbl, dict)],
-    }
-
-
-def _runner_group_by_label(runners: list[dict], label: str) -> dict[str, list[dict]]:
-    """Group runners by a specific label.
-
-    Args:
-        runners: List of runner dicts.
-        label: Label name to group by.
-
-    Returns:
-        Dict mapping label values to lists of runners.
-    """
-    groups: dict[str, list[dict]] = {}
-    for runner in runners:
-        labels = [lbl.get("name", "") for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
-        if label in labels:
-            key = label
-            if key not in groups:
-                groups[key] = []
-            groups[key].append(runner)
-    return groups
-
-
-def _runner_health_check(runner: dict, system_metrics: dict | None = None) -> dict[str, Any]:
-    """Compute health status for a runner.
-
-    Args:
-        runner: Runner dict from GitHub API.
-        system_metrics: Optional system metrics snapshot.
-
-    Returns:
-        Health check result dict.
-    """
-    health_status = "healthy"
-    issues = []
-
-    if runner.get("status") != "online":
-        health_status = "offline"
-        issues.append(f"runner offline ({runner.get('status')})")
-
-    if runner.get("busy"):
-        # Runner is busy, which is normal but good to track
-        pass
-
-    labels = runner.get("labels", [])
-    if not labels:
-        issues.append("no labels assigned")
-
-    return {
-        "runner_id": runner.get("id"),
-        "runner_name": runner.get("name"),
-        "status": health_status,
-        "issues": issues,
-        "last_check": _dt_mod.datetime.now(UTC).isoformat(),
-    }
 
 
 @router.get("/api/runners")
@@ -229,13 +73,13 @@ async def get_runners(request: Request) -> dict[str, Any]:
 
     cached = cache_get("runners", 60.0)
     if cached is not None:
-        cached["runners"] = sorted(cached.get("runners", []), key=_runner_sort_key)
+        cached["runners"] = sorted(cached.get("runners", []), key=runner_sort_key)
         log.debug("returning cached runners list (count=%d)", len(cached.get("runners", [])))
         return cached
 
     try:
         data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        data["runners"] = sorted(data.get("runners", []), key=_runner_sort_key)
+        data["runners"] = sorted(data.get("runners", []), key=runner_sort_key)
         cache_set("runners", data)
         log.info("fetched runners list from GitHub API (count=%d)", len(data.get("runners", [])))
         return data
@@ -256,6 +100,10 @@ async def get_matlab_runner_health(request: Request) -> dict[str, Any]:
     Returns:
         Dict with runner list, totals, and generated timestamp.
     """
+    import datetime as _dt_mod
+
+    from .runner_helpers import UTC
+
     if should_proxy_fleet_to_hub(request):
         return await proxy_to_hub(request)
 
@@ -271,8 +119,8 @@ async def get_matlab_runner_health(request: Request) -> dict[str, Any]:
         log.warning("failed to fetch runners for MATLAB health check: %s", exc)
         all_runners = []
 
-    matlab = [r for r in all_runners if _is_matlab_runner(r)]
-    summaries = [_matlab_runner_summary(r) for r in matlab]
+    matlab = [r for r in all_runners if is_matlab_runner(r)]
+    summaries = [matlab_runner_summary(r) for r in matlab]
 
     res = {
         "runners": summaries,
@@ -457,18 +305,14 @@ async def get_runner_status(request: Request, runner_id: int) -> dict[str, Any]:
         data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
         runners = data.get("runners", [])
 
-        runner = None
-        for r in runners:
-            if r.get("id") == runner_id:
-                runner = r
-                break
+        runner = next((r for r in runners if r.get("id") == runner_id), None)
 
         if runner is None:
             log.warning("get_runner_status: runner_id=%d not found", runner_id)
             raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found")
 
         num = runner_num_from_id(runner_id, runners)
-        health = _runner_health_check(runner)
+        health = runner_health_check(runner)
 
         response = {
             "id": runner.get("id"),
@@ -490,515 +334,3 @@ async def get_runner_status(request: Request, runner_id: int) -> dict[str, Any]:
     except Exception as exc:
         log.error("get_runner_status: error for runner_id=%d: %s", runner_id, exc)
         raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
-
-
-@router.get("/api/runners/groups/{group_label}")
-async def get_runner_group(request: Request, group_label: str) -> dict[str, Any]:
-    """Get runners filtered by a specific label/group.
-
-    Args:
-        request: HTTP request.
-        group_label: Label name to filter by.
-
-    Returns:
-        Dict with grouped runners and summary stats.
-
-    Raises:
-        HTTPException: If GitHub API fails.
-    """
-    try:
-        if should_proxy_fleet_to_hub(request):
-            return await proxy_to_hub(request)
-
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        all_runners = data.get("runners", [])
-
-        # Filter runners with the specified label
-        grouped = []
-        for runner in all_runners:
-            labels = [lbl.get("name", "") for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
-            if group_label in labels:
-                grouped.append(runner)
-
-        grouped = sorted(grouped, key=_runner_sort_key)
-
-        result = {
-            "group_label": group_label,
-            "runners": grouped,
-            "total": len(grouped),
-            "online": sum(1 for r in grouped if r.get("status") == "online"),
-            "busy": sum(1 for r in grouped if r.get("busy")),
-            "offline": sum(1 for r in grouped if r.get("status") != "online"),
-        }
-        log.debug("get_runner_group: label=%s (count=%d)", group_label, len(grouped))
-        return result
-    except Exception as exc:
-        log.error("get_runner_group: error for label=%s: %s", group_label, exc)
-        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
-
-
-@router.post("/api/runners/groups/{group_label}/start-all")
-async def start_runner_group(
-    request: Request,
-    group_label: str,
-    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
-) -> dict[str, Any]:
-    """Start all runners in a specific group/label.
-
-    Requires the 'runners.control' scope.
-
-    Args:
-        request: HTTP request.
-        group_label: Label name identifying the group.
-        principal: Authenticated principal.
-
-    Returns:
-        Dict with results for each runner in the group.
-    """
-    try:
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        all_runners = data.get("runners", [])
-
-        # Filter runners with the specified label
-        grouped = []
-        for runner in all_runners:
-            labels = [lbl.get("name", "") for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
-            if group_label in labels:
-                grouped.append(runner)
-
-        results = []
-        for runner in grouped:
-            runner_id = runner.get("id")
-            num = runner_num_from_id(runner_id, all_runners)
-            if num is None:
-                results.append({"runner_id": runner_id, "success": False, "error": "Local runner number not found"})
-                continue
-
-            code, stdout, stderr = await run_runner_svc(num, "start")
-            results.append(
-                {
-                    "runner_id": runner_id,
-                    "runner_num": num,
-                    "success": code == 0,
-                    "output": stdout.strip() if code == 0 else stderr.strip(),
-                }
-            )
-
-        log.info(
-            "start_runner_group: label=%s (total=%d, principal=%s)",
-            group_label,
-            len(grouped),
-            principal.user_id,
-        )
-        return {"group_label": group_label, "results": results, "successful": sum(1 for r in results if r["success"])}
-    except Exception as exc:
-        log.error("start_runner_group: error for label=%s: %s", group_label, exc)
-        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc
-
-
-@router.post("/api/runners/groups/{group_label}/stop-all")
-async def stop_runner_group(
-    request: Request,
-    group_label: str,
-    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
-) -> dict[str, Any]:
-    """Stop all runners in a specific group/label.
-
-    Requires the 'runners.control' scope.
-
-    Args:
-        request: HTTP request.
-        group_label: Label name identifying the group.
-        principal: Authenticated principal.
-
-    Returns:
-        Dict with results for each runner in the group.
-    """
-    try:
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        all_runners = data.get("runners", [])
-
-        # Filter runners with the specified label
-        grouped = []
-        for runner in all_runners:
-            labels = [lbl.get("name", "") for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
-            if group_label in labels:
-                grouped.append(runner)
-
-        results = []
-        for runner in grouped:
-            runner_id = runner.get("id")
-            num = runner_num_from_id(runner_id, all_runners)
-            if num is None:
-                results.append({"runner_id": runner_id, "success": False, "error": "Local runner number not found"})
-                continue
-
-            code, stdout, stderr = await run_runner_svc(num, "stop")
-            results.append(
-                {
-                    "runner_id": runner_id,
-                    "runner_num": num,
-                    "success": code == 0,
-                    "output": stdout.strip() if code == 0 else stderr.strip(),
-                }
-            )
-
-        log.info(
-            "stop_runner_group: label=%s (total=%d, principal=%s)",
-            group_label,
-            len(grouped),
-            principal.user_id,
-        )
-        return {"group_label": group_label, "results": results, "successful": sum(1 for r in results if r["success"])}
-    except Exception as exc:
-        log.error("stop_runner_group: error for label=%s: %s", group_label, exc)
-        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc
-
-
-@router.get("/api/runners/diagnostics/summary")
-async def get_runners_diagnostics_summary(request: Request) -> dict[str, Any]:
-    """Get a comprehensive diagnostics summary for all runners.
-
-    Includes health checks, connectivity status, and resource utilization overview.
-
-    Args:
-        request: HTTP request.
-
-    Returns:
-        Dict with runner counts by status, health issues, and recommendations.
-    """
-    try:
-        if should_proxy_fleet_to_hub(request):
-            return await proxy_to_hub(request)
-
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        runners = data.get("runners", []) or []
-
-        online_count = sum(1 for r in runners if r.get("status") == "online")
-        offline_count = sum(1 for r in runners if r.get("status") != "online")
-        busy_count = sum(1 for r in runners if r.get("busy"))
-        idle_count = online_count - busy_count
-
-        # Collect health issues
-        issues = []
-        for runner in runners:
-            health = _runner_health_check(runner)
-            if health["issues"]:
-                issues.append({"runner": health["runner_name"], "issues": health["issues"]})
-
-        recommendations = []
-        if offline_count > 0:
-            recommendations.append(f"Check offline runners ({offline_count}): restart svc or check system status")
-        if idle_count == 0 and online_count > 0:
-            recommendations.append("All online runners are busy; consider scaling up fleet capacity")
-
-        summary = {
-            "total_runners": len(runners),
-            "online": online_count,
-            "offline": offline_count,
-            "busy": busy_count,
-            "idle": idle_count,
-            "health_issues": issues,
-            "recommendations": recommendations,
-            "generated_at": _dt_mod.datetime.now(UTC).isoformat(),
-        }
-        log.info(
-            "get_runners_diagnostics_summary: total=%d, online=%d, offline=%d",
-            len(runners),
-            online_count,
-            offline_count,
-        )
-        return summary
-    except Exception as exc:
-        log.error("get_runners_diagnostics_summary: error: %s", exc)
-        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
-
-
-@router.post("/api/runners/{runner_id}/diagnostics")
-async def get_runner_diagnostics(request: Request, runner_id: int) -> dict[str, Any]:
-    """Get detailed diagnostics for a specific runner.
-
-    Includes service status, recent activity, and potential troubleshooting info.
-
-    Args:
-        request: HTTP request.
-        runner_id: GitHub runner ID.
-
-    Returns:
-        Dict with detailed diagnostics and troubleshooting info.
-
-    Raises:
-        HTTPException: If runner not found.
-    """
-    try:
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        runners = data.get("runners", [])
-
-        runner = None
-        for r in runners:
-            if r.get("id") == runner_id:
-                runner = r
-                break
-
-        if runner is None:
-            log.warning("get_runner_diagnostics: runner_id=%d not found", runner_id)
-            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found")
-
-        num = runner_num_from_id(runner_id, runners)
-
-        diagnostics: dict[str, Any] = {
-            "runner_id": runner_id,
-            "runner_name": runner.get("name"),
-            "runner_num": num,
-            "status": runner.get("status"),
-            "busy": runner.get("busy"),
-            "health": _runner_health_check(runner),
-            "labels": [lbl.get("name") for lbl in runner.get("labels", []) if isinstance(lbl, dict)],
-            "accessed_at": runner.get("accessed_at"),
-            "created_at": runner.get("created_at"),
-        }
-
-        # Try to read svc status if local runner number found
-        if num is not None:
-            code, stdout, _ = await run_runner_svc(num, "status")
-            diagnostics["svc_status"] = {"exit_code": code, "output": stdout.strip()}
-
-        # Troubleshooting suggestions
-        troubleshooting = []
-        if runner.get("status") != "online":
-            troubleshooting.append("Runner offline: check system status, network, and service logs")
-            if num is not None:
-                troubleshooting.append(f"Try: restart service runner-{num} via dashboard or SSH")
-        if not runner.get("labels"):
-            troubleshooting.append("No labels: add labels to runner in GitHub Actions settings")
-        if runner.get("busy"):
-            accessed_str = runner.get("accessed_at", "2000-01-01T00:00:00Z").replace("Z", "+00:00")
-            accessed_dt = _dt_mod.datetime.fromisoformat(accessed_str)
-            time_diff = time.time() - time.mktime(accessed_dt.timetuple())
-            if time_diff > 3600:
-                troubleshooting.append("Runner busy for over 1 hour: may be stuck, consider manual restart")
-
-        diagnostics["troubleshooting_suggestions"] = troubleshooting
-        log.debug("get_runner_diagnostics: runner_id=%d", runner_id)
-        return diagnostics
-    except HTTPException:
-        raise
-    except Exception as exc:
-        log.error("get_runner_diagnostics: error for runner_id=%d: %s", runner_id, exc)
-        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
-
-
-@router.get("/api/runners/fleet/capacity")
-async def get_fleet_capacity(request: Request) -> dict[str, Any]:
-    """Get fleet capacity and scheduling information.
-
-    Provides current utilization, available capacity, and recommendations for scaling.
-
-    Args:
-        request: HTTP request.
-
-    Returns:
-        Dict with capacity metrics and scheduling recommendations.
-    """
-    try:
-        if should_proxy_fleet_to_hub(request):
-            return await proxy_to_hub(request)
-
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        runners = data.get("runners", []) or []
-
-        online = sum(1 for r in runners if r.get("status") == "online")
-        busy = sum(1 for r in runners if r.get("busy"))
-        idle = online - busy
-        total = len(runners)
-
-        # Get system metrics if available
-        system_metrics = None
-        if _get_system_metrics_snapshot:
-            try:
-                system_metrics = await _get_system_metrics_snapshot()  # type: ignore
-            except Exception as e:
-                log.debug("Failed to get system metrics for capacity: %s", e)
-
-        utilization_percent = int((busy / online * 100) if online > 0 else 0)
-
-        # Scaling recommendations
-        recommendations = []
-        if utilization_percent > 80:
-            recommendations.append("HIGH utilization: consider scaling up fleet")
-        elif utilization_percent > 60:
-            recommendations.append("MODERATE utilization: monitor for growth")
-        if idle == 0 and online > 0:
-            recommendations.append("No idle runners: all capacity in use")
-
-        capacity = {
-            "total_runners": total,
-            "online_runners": online,
-            "offline_runners": total - online,
-            "busy_runners": busy,
-            "idle_runners": idle,
-            "utilization_percent": utilization_percent,
-            "hostname": HOSTNAME,
-            "recommendations": recommendations,
-            "generated_at": _dt_mod.datetime.now(UTC).isoformat(),
-        }
-
-        if system_metrics:
-            capacity["system_health"] = {
-                "cpu_percent": system_metrics.get("cpu_percent"),
-                "memory_percent": system_metrics.get("memory_percent"),
-                "disk_pressure": system_metrics.get("disk_pressure"),
-            }
-
-        log.info(
-            "get_fleet_capacity: total=%d, online=%d, busy=%d, util=%d%%",
-            total,
-            online,
-            busy,
-            utilization_percent,
-        )
-        return capacity
-    except Exception as exc:
-        log.error("get_fleet_capacity: error: %s", exc)
-        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
-
-
-@router.post("/api/runners/fleet/schedule-scale")
-async def schedule_fleet_scale(
-    request: Request,
-    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
-) -> dict[str, Any]:
-    """Schedule automatic fleet scaling based on current utilization.
-
-    Analyzes current utilization and recommends scaling actions.
-
-    Args:
-        request: HTTP request with optional body containing scale directives.
-        principal: Authenticated principal.
-
-    Returns:
-        Dict with scheduled scaling actions and results.
-    """
-    try:
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        runners = data.get("runners", []) or []
-
-        online = sum(1 for r in runners if r.get("status") == "online")
-        busy = sum(1 for r in runners if r.get("busy"))
-        idle = online - busy
-        utilization_percent = int((busy / online * 100) if online > 0 else 0)
-
-        scheduled_actions = []
-
-        # Simple autoscaling logic
-        if utilization_percent > 80 and idle == 0:
-            # Try to start one idle runner if available
-            for runner in runners:
-                if runner.get("status") != "online":
-                    num = runner_num_from_id(runner.get("id"), runners)
-                    if num is not None:
-                        code, _, _ = await run_runner_svc(num, "start")
-                        scheduled_actions.append(
-                            {
-                                "action": "start",
-                                "runner_id": runner.get("id"),
-                                "runner_num": num,
-                                "success": code == 0,
-                            }
-                        )
-                        break
-
-        log.info(
-            "schedule_fleet_scale: util=%d%%, scheduled=%d actions (principal=%s)",
-            utilization_percent,
-            len(scheduled_actions),
-            principal.user_id,
-        )
-        return {
-            "utilization_percent": utilization_percent,
-            "scheduled_actions": scheduled_actions,
-            "total_actions": len(scheduled_actions),
-        }
-    except Exception as exc:
-        log.error("schedule_fleet_scale: error: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc
-
-
-@router.post("/api/runners/{runner_id}/troubleshoot")
-async def troubleshoot_runner(
-    request: Request,
-    runner_id: int,
-    principal: Principal = Depends(require_scope("runners.control")),  # noqa: B008
-) -> dict[str, Any]:
-    """Perform automated troubleshooting on a runner.
-
-    Runs diagnostics and attempts automatic fixes for common issues.
-
-    Args:
-        request: HTTP request.
-        runner_id: GitHub runner ID.
-        principal: Authenticated principal.
-
-    Returns:
-        Dict with troubleshooting steps and results.
-
-    Raises:
-        HTTPException: If runner not found.
-    """
-    try:
-        data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        runners = data.get("runners", [])
-
-        runner = None
-        for r in runners:
-            if r.get("id") == runner_id:
-                runner = r
-                break
-
-        if runner is None:
-            log.warning("troubleshoot_runner: runner_id=%d not found (principal=%s)", runner_id, principal.user_id)
-            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found")
-
-        num = runner_num_from_id(runner_id, runners)
-        steps: list[dict[str, Any]] = []
-
-        # Step 1: Check current status
-        steps.append({"step": "Check status", "status": "pending"})
-        if runner.get("status") != "online":
-            steps.append({"step": "Attempt restart", "status": "pending"})
-            if num is not None:
-                code, stdout, stderr = await run_runner_svc(num, "restart")
-                result_dict: dict[str, Any] = {
-                    "exit_code": code,
-                    "output": stdout.strip() if code == 0 else stderr.strip(),
-                }
-                steps[-1]["result"] = result_dict  # type: ignore
-                steps[-1]["status"] = "success" if code == 0 else "failed"  # type: ignore
-
-        # Step 2: Verify online after restart
-        if num is not None:
-            code, stdout, _ = await run_runner_svc(num, "status")
-            result_dict = {"exit_code": code, "output": stdout.strip()}
-            steps.append({
-                "step": "Verify status after restart",
-                "result": result_dict,
-                "status": "success" if code == 0 else "failed",
-            })
-
-        log.info(
-            "troubleshoot_runner: runner_id=%d (runner_num=%s, principal=%s)",
-            runner_id,
-            num,
-            principal.user_id,
-        )
-        return {
-            "runner_id": runner_id,
-            "runner_num": num,
-            "troubleshooting_steps": steps,
-            "success": all(s["status"] in ("success", "pending") for s in steps),
-        }
-    except HTTPException:
-        raise
-    except Exception as exc:
-        log.error("troubleshoot_runner: error for runner_id=%d: %s", runner_id, exc)
-        raise HTTPException(status_code=502, detail=f"Error: {exc}") from exc

--- a/backend/routers/runners.py
+++ b/backend/routers/runners.py
@@ -33,7 +33,20 @@ from .runner_helpers import (
     runner_health_check,
     runner_num_from_id,
     runner_sort_key,
+    runner_svc_path,
 )
+
+# Re-export private helper names expected by existing test suite
+_is_matlab_runner = is_matlab_runner
+_runner_sort_key = runner_sort_key
+
+__all__ = [
+    "run_runner_svc",
+    "runner_num_from_id",
+    "runner_svc_path",
+    "_is_matlab_runner",
+    "_runner_sort_key",
+]
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as _dt
 import logging
 import os
 import platform
@@ -26,11 +27,10 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 # Python 3.10+ has UTC; fall back to timezone.utc for earlier versions
-import datetime as _dt
 try:
-    UTC = _dt.UTC  # noqa: UP017
+    UTC = _dt.UTC  # type: ignore[attr-defined]
 except AttributeError:
-    UTC = _dt.timezone.utc  # type: ignore
+    UTC = _dt.UTC  # type: ignore[assignment]
 
 log = logging.getLogger("dashboard.system")
 router = APIRouter(tags=["system"])

--- a/backend/server.py
+++ b/backend/server.py
@@ -95,6 +95,8 @@ from routers import linear_webhook as _linear_webhook_router  # noqa: E402
 from routers import queue as _queue_router  # noqa: E402
 from routers import queue_diagnostics as _queue_diagnostics_router  # noqa: E402
 from routers import remediation as _remediation_router  # noqa: E402
+from routers import runner_diagnostics as _runner_diagnostics_router  # noqa: E402
+from routers import runner_groups as _runner_groups_router  # noqa: E402
 from routers import runners as _runners_router  # noqa: E402
 from routers import runs_workflows as _runs_workflows_router  # noqa: E402
 from routers import system as _system_router  # noqa: E402
@@ -130,11 +132,7 @@ def _load_or_generate_api_key() -> str:
     if key_from_env:
         return key_from_env
     # Try to read from persistent file
-    key_file = (
-        Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
-        / "runner-dashboard"
-        / "api_key.txt"
-    )
+    key_file = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "runner-dashboard" / "api_key.txt"
     try:
         if key_file.exists():
             stored = key_file.read_text(encoding="utf-8").strip()
@@ -149,9 +147,7 @@ def _load_or_generate_api_key() -> str:
         key_file.write_text(new_key, encoding="utf-8")
         key_file.chmod(0o600)
         log.warning("Generated new API key; saved to %s", key_file)
-        log.warning(
-            "Add header 'Authorization: Bearer %s' to all API requests.", new_key
-        )
+        log.warning("Add header 'Authorization: Bearer %s' to all API requests.", new_key)
     except OSError as exc:
         log.warning("Could not persist API key to %s: %s", key_file, exc)
     return new_key
@@ -234,42 +230,23 @@ DISK_WARN_PERCENT = float(os.environ.get("DASHBOARD_DISK_WARN_PERCENT", "85"))
 DISK_CRITICAL_PERCENT = float(os.environ.get("DASHBOARD_DISK_CRITICAL_PERCENT", "92"))
 DISK_MIN_FREE_GB = float(os.environ.get("DASHBOARD_DISK_MIN_FREE_GB", "25"))
 PORT = int(os.environ.get("DASHBOARD_PORT", "8321"))
-_DASHBOARD_CONFIG_DIR = (
-    Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
-    / "runner-dashboard"
-)
+_DASHBOARD_CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "runner-dashboard"
 HOSTNAME = os.environ.get("DISPLAY_NAME") or platform.node()
 RUN_JOB_ENRICHMENT_LIMIT = int(os.environ.get("RUN_JOB_ENRICHMENT_LIMIT", "50"))
-RUNNER_ALIASES = [
-    item.strip()
-    for item in os.environ.get("RUNNER_ALIASES", "").split(",")
-    if item.strip()
-]
+RUNNER_ALIASES = [item.strip() for item in os.environ.get("RUNNER_ALIASES", "").split(",") if item.strip()]
 RUNNER_SCHEDULE_CONFIG = Path(
     os.environ.get(
         "RUNNER_SCHEDULE_CONFIG",
         str(Path.home() / ".config" / "runner-dashboard" / "runner-schedule.json"),
     )
 ).expanduser()
-RUNNER_SCHEDULER_BIN = os.environ.get(
-    "RUNNER_SCHEDULER_BIN", "/usr/local/bin/runner-scheduler"
-)
-RUNNER_SCHEDULER_SERVICE = os.environ.get(
-    "RUNNER_SCHEDULER_SERVICE", "runner-scheduler.service"
-)
+RUNNER_SCHEDULER_BIN = os.environ.get("RUNNER_SCHEDULER_BIN", "/usr/local/bin/runner-scheduler")
+RUNNER_SCHEDULER_SERVICE = os.environ.get("RUNNER_SCHEDULER_SERVICE", "runner-scheduler.service")
 RUNNER_SCHEDULER_APPLY_CMD = os.environ.get("RUNNER_SCHEDULER_APPLY_CMD", "")
-SYSTEMCTL_BIN = (
-    os.environ.get("SYSTEMCTL_BIN") or shutil.which("systemctl") or "/usr/bin/systemctl"
-)
-RUNNER_SCHEDULER_STATE = Path(
-    os.environ.get("RUNNER_SCHEDULER_STATE", "/var/lib/runner-scheduler/state.json")
-)
-WSL_KEEPALIVE_SERVICE = os.environ.get(
-    "WSL_KEEPALIVE_SERVICE", "wsl-runner-keepalive.service"
-)
-WSL_KEEPALIVE_TASK_NAME = os.environ.get(
-    "WSL_KEEPALIVE_TASK_NAME", "WSL-Runner-KeepAlive"
-)
+SYSTEMCTL_BIN = os.environ.get("SYSTEMCTL_BIN") or shutil.which("systemctl") or "/usr/bin/systemctl"
+RUNNER_SCHEDULER_STATE = Path(os.environ.get("RUNNER_SCHEDULER_STATE", "/var/lib/runner-scheduler/state.json"))
+WSL_KEEPALIVE_SERVICE = os.environ.get("WSL_KEEPALIVE_SERVICE", "wsl-runner-keepalive.service")
+WSL_KEEPALIVE_TASK_NAME = os.environ.get("WSL_KEEPALIVE_TASK_NAME", "WSL-Runner-KeepAlive")
 DEPLOYMENT_FILE = Path(
     os.environ.get(
         "RUNNER_DASHBOARD_DEPLOYMENT_FILE",
@@ -334,18 +311,14 @@ REPORTS_DIR = Path(os.environ.get("REPORTS_DIR", str(_default_reports_dir)))
 HEAVY_TEST_REPOS = {
     "Repository_Management": {
         "workflow_file": "ci-heavy-integration-tests.yml",
-        "description": (
-            "Heavy Integration Suite — Self-hosted Runner Control Tower tests"
-        ),
+        "description": ("Heavy Integration Suite — Self-hosted Runner Control Tower tests"),
         "docker_compose": "docker-compose.yml",
         "python_versions": ["3.11", "3.12"],
         "default_python": "3.12",
     },
     "UpstreamDrift": {
         "workflow_file": "heavy-tests-opt-in.yml",
-        "description": (
-            "Heavy Integration Tests (live_simulation marker) — MuJoCo, Drake, Pinocchio, Biomechanics"
-        ),
+        "description": ("Heavy Integration Tests (live_simulation marker) — MuJoCo, Drake, Pinocchio, Biomechanics"),
         "docker_compose": "docker-compose.yml",
         "python_versions": ["3.10", "3.11", "3.12"],
         "default_python": "3.11",
@@ -358,9 +331,7 @@ app = FastAPI(
     description="Monitor and control self-hosted GitHub Actions runners",
 )
 
-_PROCESSED_ENVELOPES_PATH = (
-    Path.home() / "actions-runners" / "dashboard" / "processed_envelopes.json"
-)
+_PROCESSED_ENVELOPES_PATH = Path.home() / "actions-runners" / "dashboard" / "processed_envelopes.json"
 _processed_envelopes_lock: asyncio.Lock = asyncio.Lock()
 
 
@@ -388,9 +359,7 @@ async def _is_envelope_replay(envelope_id: str) -> bool:
         return False
 
 
-async def _record_processed_envelope(
-    envelope_id: str, ttl_seconds: int = 86400
-) -> None:
+async def _record_processed_envelope(envelope_id: str, ttl_seconds: int = 86400) -> None:
     """Record that envelope_id has been processed (for replay detection)."""
     async with _processed_envelopes_lock:
         processed = _load_processed_envelopes()
@@ -433,6 +402,8 @@ app.include_router(_fleet_router.router)
 app.include_router(_queue_router.router)
 app.include_router(_queue_diagnostics_router.router)
 app.include_router(_runners_router.router)
+app.include_router(_runner_groups_router.router)
+app.include_router(_runner_diagnostics_router.router)
 app.include_router(_runs_workflows_router.router)
 app.include_router(_assistant_router.router)
 app.include_router(_feature_requests_router.router)
@@ -562,11 +533,7 @@ async def proxy_to_hub(request: Request):
             req = client.build_request(
                 request.method,
                 url,
-                headers={
-                    k: v
-                    for k, v in request.headers.items()
-                    if k.lower() not in ("host", "content-length")
-                },
+                headers={k: v for k, v in request.headers.items() if k.lower() not in ("host", "content-length")},
                 content=await request.body(),
             )
             resp = await client.send(req)
@@ -596,9 +563,7 @@ def _should_proxy_fleet_to_hub(request: Request) -> bool:
     return local_value not in {"1", "true", "yes", "local"} and scope_value != "local"
 
 
-async def run_cmd(
-    cmd: list[str], timeout: int = 30, cwd: Path | None = None
-) -> tuple[int, str, str]:
+async def run_cmd(cmd: list[str], timeout: int = 30, cwd: Path | None = None) -> tuple[int, str, str]:
     """Run a shell command asynchronously."""
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -640,9 +605,7 @@ gh_api_admin = gh_api
 
 async def gh_api_raw(endpoint: str) -> str:
     """Call the GitHub API via gh CLI and return the raw body text."""
-    code, stdout, stderr = await run_cmd(
-        ["gh", "api", "-H", "Accept: application/vnd.github.raw", endpoint]
-    )
+    code, stdout, stderr = await run_cmd(["gh", "api", "-H", "Accept: application/vnd.github.raw", endpoint])
     if code != 0:
         raise HTTPException(status_code=502, detail=f"GitHub API error: {stderr}")
     return stdout
@@ -668,10 +631,7 @@ async def _expected_dashboard_version_from_hub() -> str | None:
 
 async def _read_expected_dashboard_version() -> str:
     """Return the hub expected VERSION, falling back to this checkout."""
-    return (
-        await _expected_dashboard_version_from_hub()
-        or deployment_drift.read_expected_version(EXPECTED_VERSION_FILE)
-    )
+    return await _expected_dashboard_version_from_hub() or deployment_drift.read_expected_version(EXPECTED_VERSION_FILE)
 
 
 def _node_deployment_info(node: dict) -> dict:
@@ -709,9 +669,7 @@ def _machine_deployment_state(node: dict, expected_version: str) -> dict:
     if not node.get("online"):
         rollout_state = "offline"
         rollout_label = "Offline"
-        rollout_detail = (
-            node.get("offline_detail") or node.get("error") or "Node is offline."
-        )
+        rollout_detail = node.get("offline_detail") or node.get("error") or "Node is offline."
     elif status.dirty:
         rollout_state = "dirty"
         rollout_label = "Dirty"
@@ -723,10 +681,7 @@ def _machine_deployment_state(node: dict, expected_version: str) -> dict:
     elif node.get("offline_reason") == "resource_monitoring":
         rollout_state = "degraded"
         rollout_label = "Degraded"
-        rollout_detail = (
-            node.get("offline_detail")
-            or "Resource pressure is blocking the usual rollout cadence."
-        )
+        rollout_detail = node.get("offline_detail") or "Resource pressure is blocking the usual rollout cadence."
     elif status.current == "unknown":
         rollout_state = "unknown"
         rollout_label = "Unknown"
@@ -760,9 +715,7 @@ def _build_deployment_state(nodes: list[dict], expected_version: str) -> dict:
     local_drift = deployment_drift.evaluate_drift(deployment, expected_version)
     machines = [_machine_deployment_state(node, expected_version) for node in nodes]
     attention_states = {"offline", "dirty", "drifted", "degraded", "unknown"}
-    alerting = [
-        machine for machine in machines if machine["rollout_state"] in attention_states
-    ]
+    alerting = [machine for machine in machines if machine["rollout_state"] in attention_states]
     online = sum(1 for machine in machines if machine["online"])
     steady = sum(1 for machine in machines if machine["rollout_state"] == "steady")
     dirty = sum(1 for machine in machines if machine["rollout_state"] == "dirty")
@@ -975,9 +928,7 @@ async def _enrich_run_with_job_placement(run: dict) -> dict:
     return item
 
 
-def _classify_node_offline(
-    exc: Exception | None = None, *, status_code: int | None = None
-) -> dict:
+def _classify_node_offline(exc: Exception | None = None, *, status_code: int | None = None) -> dict:
     """Classify why a fleet node is not fully reachable."""
     message = str(exc) if exc else ""
     lower = message.lower()
@@ -1061,8 +1012,7 @@ def _node_visibility_snapshot(node: dict) -> dict:
             "visibility_state": "degraded",
             "visibility_label": "Degraded",
             "visibility_tone": "yellow",
-            "visibility_detail": node.get("offline_detail")
-            or "Resource pressure is high enough to warrant attention.",
+            "visibility_detail": node.get("offline_detail") or "Resource pressure is high enough to warrant attention.",
         }
 
     if online and dashboard_reachable and has_system_metrics:
@@ -1070,9 +1020,7 @@ def _node_visibility_snapshot(node: dict) -> dict:
             "visibility_state": "full_telemetry",
             "visibility_label": "Full telemetry",
             "visibility_tone": "green",
-            "visibility_detail": (
-                "Runner status and system metrics are both available."
-            ),
+            "visibility_detail": ("Runner status and system metrics are both available."),
         }
 
     if online:
@@ -1080,9 +1028,7 @@ def _node_visibility_snapshot(node: dict) -> dict:
             "visibility_state": "runners_only",
             "visibility_label": "Runners only",
             "visibility_tone": "orange",
-            "visibility_detail": (
-                "Runner registrations are healthy, but dashboard telemetry is unavailable."
-            ),
+            "visibility_detail": ("Runner registrations are healthy, but dashboard telemetry is unavailable."),
         }
 
     if dashboard_reachable:
@@ -1090,18 +1036,14 @@ def _node_visibility_snapshot(node: dict) -> dict:
             "visibility_state": "dashboard_only",
             "visibility_label": "Dashboard only",
             "visibility_tone": "blue",
-            "visibility_detail": (
-                "Dashboard is reachable, but runner registrations are offline."
-            ),
+            "visibility_detail": ("Dashboard is reachable, but runner registrations are offline."),
         }
 
     return {
         "visibility_state": "offline",
         "visibility_label": "Offline",
         "visibility_tone": "red",
-        "visibility_detail": node.get("offline_detail")
-        or node.get("error")
-        or "No live telemetry from this machine.",
+        "visibility_detail": node.get("offline_detail") or node.get("error") or "No live telemetry from this machine.",
     }
 
 
@@ -1109,14 +1051,10 @@ def runner_svc_path(runner_num: int) -> Path:
     return RUNNER_BASE_DIR / f"runner-{runner_num}" / "svc.sh"
 
 
-async def run_runner_svc(
-    runner_num: int, action: str, timeout: int = 30
-) -> tuple[int, str, str]:
+async def run_runner_svc(runner_num: int, action: str, timeout: int = 30) -> tuple[int, str, str]:
     """Run a generated GitHub runner svc.sh from its own runner directory."""
     svc_path = runner_svc_path(runner_num)
-    return await run_cmd(
-        ["sudo", str(svc_path), action], timeout=timeout, cwd=svc_path.parent
-    )
+    return await run_cmd(["sudo", str(svc_path), action], timeout=timeout, cwd=svc_path.parent)
 
 
 def runner_num_from_id(runner_id: int, runners: list[dict]) -> int | None:
@@ -1161,9 +1099,7 @@ def get_runner_service_name(runner_num: int) -> str | None:
 DEFAULT_RUNNER_SCHEDULE = {
     "enabled": True,
     "timezone": os.environ.get("RUNNER_SCHEDULE_TIMEZONE", "America/Los_Angeles"),
-    "default_count": min(
-        NUM_RUNNERS, int(os.environ.get("RUNNER_SCHEDULE_DEFAULT", "4"))
-    ),
+    "default_count": min(NUM_RUNNERS, int(os.environ.get("RUNNER_SCHEDULE_DEFAULT", "4"))),
     "schedules": [
         {
             "name": "day",
@@ -1206,9 +1142,7 @@ def _validate_runner_schedule(config: dict) -> dict:
     sanitized: dict[str, Any] = {
         "enabled": bool(config.get("enabled", True)),
         "timezone": str(config.get("timezone") or "America/Los_Angeles"),
-        "default_count": max(
-            0, min(_runner_limit(), int(config.get("default_count", 1)))
-        ),
+        "default_count": max(0, min(_runner_limit(), int(config.get("default_count", 1)))),
         "schedules": [],
     }
     schedules = config.get("schedules", [])
@@ -1325,9 +1259,7 @@ def get_runner_capacity_snapshot() -> dict:
         "aliases": RUNNER_ALIASES,
         "configured_runners": NUM_RUNNERS,
         "default_runners": DEFAULT_NUM_RUNNERS,
-        "installed_runners": sum(
-            1 for path in RUNNER_BASE_DIR.glob("runner-*") if path.is_dir()
-        ),
+        "installed_runners": sum(1 for path in RUNNER_BASE_DIR.glob("runner-*") if path.is_dir()),
         "max_runners": _runner_limit(),
         "config_path": str(RUNNER_SCHEDULE_CONFIG),
         "state_path": str(RUNNER_SCHEDULER_STATE),
@@ -1506,9 +1438,7 @@ def _probe_detail(probe: dict, fallback: str) -> str:
     return str(probe.get("detail") or probe.get("error") or fallback)
 
 
-def _detect_legacy_keepalive(
-    actions: list[dict], startup_vbs_files: list[str]
-) -> tuple[bool, str | None]:
+def _detect_legacy_keepalive(actions: list[dict], startup_vbs_files: list[str]) -> tuple[bool, str | None]:
     """Detect the old VBS/fire-and-forget keepalive pattern."""
     if startup_vbs_files:
         return True, f"Legacy VBS file(s) still present: {', '.join(startup_vbs_files)}"
@@ -1552,10 +1482,7 @@ async def _inspect_systemd_keepalive() -> dict:
 
     if code != 0:
         lower = f"{stdout}\n{stderr}".lower()
-        if (
-            "system has not been booted with systemd" in lower
-            or "failed to connect to bus" in lower
-        ):
+        if "system has not been booted with systemd" in lower or "failed to connect to bus" in lower:
             return {
                 "status": "unsupported",
                 "service": WSL_KEEPALIVE_SERVICE,
@@ -1630,7 +1557,9 @@ async def _inspect_windows_keepalive() -> dict:
         "@(Get-ChildItem -Path $startup -Filter 'wsl-keepalive.vbs'"
         " -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)"
     )
-    _ps_get_actions = "@($task.Actions | ForEach-Object { [pscustomobject]@{ Execute = $_.Execute; Arguments = $_.Arguments } })"  # noqa: E501
+    _ps_get_actions = (
+        "@($task.Actions | ForEach-Object { [pscustomobject]@{ Execute = $_.Execute; Arguments = $_.Arguments } })"  # noqa: E501
+    )
     script = f"""
 $ErrorActionPreference = 'Stop'
 $startup = [Environment]::GetFolderPath('Startup')
@@ -1684,9 +1613,7 @@ $result | ConvertTo-Json -Depth 5
             "actions": [],
             "startup_vbs_files": [],
             "legacy_vbs_detected": False,
-            "detail": stderr.strip()
-            or stdout.strip()
-            or "Scheduled task query failed.",
+            "detail": stderr.strip() or stdout.strip() or "Scheduled task query failed.",
         }
 
     try:
@@ -1770,35 +1697,22 @@ async def _watchdog_status_impl() -> dict:
             "machine": HOSTNAME,
             "layer": "Windows scheduled task",
             "status": windows["status"],
-            "detail": _probe_detail(
-                windows, "Windows scheduled task status unavailable."
-            ),
+            "detail": _probe_detail(windows, "Windows scheduled task status unavailable."),
         },
     ]
-    issue_details = [
-        check for check in checks if check["status"] not in {"healthy", "unsupported"}
-    ]
+    issue_details = [check for check in checks if check["status"] not in {"healthy", "unsupported"}]
     issues: list[str] = []
     for check in issue_details:
-        issues.append(
-            f"{check['machine']} {check['layer']} ({check['status']}): {check['detail']}"
-        )
+        issues.append(f"{check['machine']} {check['layer']} ({check['status']}): {check['detail']}")
 
     for check in (wslconfig, systemd, windows):
         if check["status"] not in {"healthy", "unsupported"}:
             check["machine"] = HOSTNAME
 
-    if (
-        wslconfig["status"] == "healthy"
-        and systemd["status"] == "healthy"
-        and windows["status"] == "healthy"
-    ):
+    if wslconfig["status"] == "healthy" and systemd["status"] == "healthy" and windows["status"] == "healthy":
         overall = "healthy"
         summary = f"{HOSTNAME}: all WSL keepalive layers are in place."
-    elif all(
-        check["status"] in {"missing", "unknown", "unsupported"}
-        for check in (wslconfig, systemd, windows)
-    ):
+    elif all(check["status"] in {"missing", "unknown", "unsupported"} for check in (wslconfig, systemd, windows)):
         overall = "unknown"
         summary = f"{HOSTNAME}: WSL keepalive status could not be fully verified."
     elif not issue_details:
@@ -1806,9 +1720,7 @@ async def _watchdog_status_impl() -> dict:
         summary = f"{HOSTNAME}: WSL keepalive checks are healthy or unsupported."
     else:
         overall = "degraded"
-        summary = (
-            f"{HOSTNAME}: {len(issue_details)} WSL keepalive check(s) need attention."
-        )
+        summary = f"{HOSTNAME}: {len(issue_details)} WSL keepalive check(s) need attention."
 
     result = {
         "status": overall,
@@ -1844,11 +1756,7 @@ async def _collect_live_fleet_nodes() -> list[dict]:
                     client.get(f"{url}/api/health"),
                 )
             if sys_r.status_code != 200 or health_r.status_code != 200:
-                status_code = (
-                    sys_r.status_code
-                    if sys_r.status_code != 200
-                    else health_r.status_code
-                )
+                status_code = sys_r.status_code if sys_r.status_code != 200 else health_r.status_code
                 reason = _classify_node_offline(status_code=status_code)
                 return {
                     "name": name,
@@ -1878,12 +1786,8 @@ async def _collect_live_fleet_nodes() -> list[dict]:
                 "health": health_r.json(),
                 "last_seen": datetime.now(UTC).isoformat(),
                 "error": None,
-                "offline_reason": (
-                    resource_reason["offline_reason"] if resource_reason else None
-                ),
-                "offline_detail": (
-                    resource_reason["offline_detail"] if resource_reason else None
-                ),
+                "offline_reason": (resource_reason["offline_reason"] if resource_reason else None),
+                "offline_detail": (resource_reason["offline_detail"] if resource_reason else None),
             }
         except Exception as exc:  # noqa: BLE001
             reason = _classify_node_offline(exc)
@@ -1918,23 +1822,13 @@ async def _collect_live_fleet_nodes() -> list[dict]:
             "health": local_health,
             "last_seen": datetime.now(UTC).isoformat(),
             "error": None,
-            "offline_reason": (
-                local_resource_reason["offline_reason"]
-                if local_resource_reason
-                else None
-            ),
-            "offline_detail": (
-                local_resource_reason["offline_detail"]
-                if local_resource_reason
-                else None
-            ),
+            "offline_reason": (local_resource_reason["offline_reason"] if local_resource_reason else None),
+            "offline_detail": (local_resource_reason["offline_detail"] if local_resource_reason else None),
         }
     ]
 
     if FLEET_NODES:
-        remote = await asyncio.gather(
-            *[fetch_node(name, url) for name, url in FLEET_NODES.items()]
-        )
+        remote = await asyncio.gather(*[fetch_node(name, url) for name, url in FLEET_NODES.items()])
         nodes.extend(remote)
 
     return nodes
@@ -2184,12 +2078,7 @@ async def fleet_control(
     node_results = [local_node_result]
 
     if should_fan_out:
-        remotes = await asyncio.gather(
-            *[
-                _remote_fleet_control(name, url, action)
-                for name, url in FLEET_NODES.items()
-            ]
-        )
+        remotes = await asyncio.gather(*[_remote_fleet_control(name, url, action) for name, url in FLEET_NODES.items()])
         node_results.extend(remotes)
 
     return {
@@ -2222,9 +2111,7 @@ async def update_runner_schedule(
     """Update this machine's local runner capacity schedule."""
     body = await request.json()
     if not isinstance(body, dict):
-        raise HTTPException(
-            status_code=400, detail="schedule payload must be an object"
-        )
+        raise HTTPException(status_code=400, detail="schedule payload must be an object")
     try:
         config = _validate_runner_schedule(body.get("schedule", body))
     except (TypeError, ValueError) as exc:
@@ -2496,9 +2383,7 @@ async def get_issues(
     elif source in {"linear", "unified"}:
         linear_config = _linear_router.load_linear_config()
         if not _linear_router.has_configured_linear_key(linear_config):
-            raise HTTPException(
-                status_code=503, detail=_linear_router.LINEAR_NOT_CONFIGURED_DETAIL
-            )
+            raise HTTPException(status_code=503, detail=_linear_router.LINEAR_NOT_CONFIGURED_DETAIL)
         linear_client = _linear_router.build_linear_client(linear_config)
         try:
             if source == "linear":
@@ -2530,9 +2415,7 @@ async def get_issues(
         finally:
             await linear_client.aclose()
     else:
-        raise HTTPException(
-            status_code=422, detail="source must be one of github, linear, unified"
-        )
+        raise HTTPException(status_code=422, detail="source must be one of github, linear, unified")
 
     # Wave 3: Sync GitHub leases with internal state
     sync_items = issues if isinstance(issues, list) else issues.get("items", [])
@@ -2561,15 +2444,9 @@ async def list_reports():
                     "filename": f.name,
                     "date": date_str,
                     "size_kb": round(stat.st_size / 1024, 1),
-                    "modified": datetime.fromtimestamp(
-                        stat.st_mtime, tz=UTC
-                    ).isoformat(),
+                    "modified": datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
                     "has_chart": chart_path.exists(),
-                    "chart_filename": (
-                        f"assessment_scores_{date_str}.png"
-                        if chart_path.exists()
-                        else None
-                    ),
+                    "chart_filename": (f"assessment_scores_{date_str}.png" if chart_path.exists() else None),
                 }
             )
     return {"reports": reports, "reports_dir": str(REPORTS_DIR), "total": len(reports)}
@@ -2645,9 +2522,7 @@ async def get_heavy_test_repos():
                             "html_url": run.get("html_url"),
                             "head_branch": run.get("head_branch"),
                             "run_number": run.get("run_number"),
-                            "triggering_actor": run.get("triggering_actor", {}).get(
-                                "login"
-                            ),
+                            "triggering_actor": run.get("triggering_actor", {}).get("login"),
                         }
                     )
             except (json.JSONDecodeError, ValueError):
@@ -2730,9 +2605,7 @@ async def dispatch_heavy_test(
         "workflow": workflow_file,
         "python_version": python_version,
         "ref": ref,
-        "message": (
-            f"Heavy test workflow dispatched for {repo_name}. Check the Actions tab for progress."
-        ),
+        "message": (f"Heavy test workflow dispatched for {repo_name}. Check the Actions tab for progress."),
     }
 
 
@@ -2754,9 +2627,7 @@ async def run_docker_heavy_test(
         )
 
     config = HEAVY_TEST_REPOS[repo_name]
-    _default_repos_base = str(
-        Path("/mnt/c") / "Users" / os.environ.get("USER", "diete") / "Repositories"
-    )
+    _default_repos_base = str(Path("/mnt/c") / "Users" / os.environ.get("USER", "diete") / "Repositories")
     _repos_base = Path(os.environ.get("HEAVY_TEST_REPOS_BASE", _default_repos_base))
     repo_path = _repos_base / repo_name
 
@@ -2886,9 +2757,7 @@ async def get_tests_ci_results() -> dict:
 
 
 @app.post("/api/tests/rerun")
-async def rerun_ci_test(
-    request: Request, *, principal: Principal = Depends(require_scope("tests.rerun"))
-) -> dict:  # noqa: B008
+async def rerun_ci_test(request: Request, *, principal: Principal = Depends(require_scope("tests.rerun"))) -> dict:  # noqa: B008
     """Re-run a failed GitHub Actions workflow run (failed jobs only)."""
     body = await request.json()
     repo_name = body.get("repo", "")
@@ -2935,9 +2804,7 @@ async def get_stats(request: Request):
     runners = runners_data.get("runners", [])
 
     repos = await _get_recent_org_repos(limit=30)
-    all_runs_nested = await asyncio.gather(
-        *[_fetch_repo_runs(repo["name"], per_page=10) for repo in repos[:20]]
-    )
+    all_runs_nested = await asyncio.gather(*[_fetch_repo_runs(repo["name"], per_page=10) for repo in repos[:20]])
     runs = [run for repo_runs in all_runs_nested for run in repo_runs]
     runs.sort(key=lambda r: r.get("created_at", ""), reverse=True)
     runs = runs[:100]
@@ -2973,9 +2840,7 @@ async def get_stats(request: Request):
         "org_open_prs": org_open_prs,
         "machines_total": fleet_data.get("count", 0),
         "machines_online": fleet_data.get("online_count", 0),
-        "machines_offline": max(
-            0, fleet_data.get("count", 0) - fleet_data.get("online_count", 0)
-        ),
+        "machines_offline": max(0, fleet_data.get("count", 0) - fleet_data.get("online_count", 0)),
         "repos_sampled": len(repos[:20]),
     }
     _cache_set("stats", result)
@@ -2992,9 +2857,7 @@ async def get_usage_monitoring(request: Request) -> dict:
     if cached is not None:
         return cached
 
-    summary = usage_monitoring.normalize_usage_summary(
-        usage_monitoring.load_usage_sources_config()
-    )
+    summary = usage_monitoring.normalize_usage_summary(usage_monitoring.load_usage_sources_config())
     _cache_set("usage_monitoring", summary)
     return summary
 
@@ -3024,12 +2887,8 @@ async def get_fleet_hardware(request: Request) -> dict:
     machines = []
     for node in fleet.get("nodes", []):
         registry = node.get("registry") or {}
-        specs = node.get("hardware_specs") or node.get("system", {}).get(
-            "hardware_specs", {}
-        )
-        capacity = node.get("workload_capacity") or node.get("system", {}).get(
-            "workload_capacity", {}
-        )
+        specs = node.get("hardware_specs") or node.get("system", {}).get("hardware_specs", {})
+        capacity = node.get("workload_capacity") or node.get("system", {}).get("workload_capacity", {})
         machines.append(
             {
                 "name": node.get("name"),
@@ -3210,9 +3069,7 @@ DASHBOARD_FAQ: dict[str, str] = {
         "The Feature Requests tab dispatches AI agents to implement new features"
         " with standards injection (TDD, DbC, DRY, LoD)."
     ),
-    "maxwell": (
-        "The Maxwell tab shows Maxwell-Daemon status and lets you start/stop the service with confirmation."
-    ),
+    "maxwell": ("The Maxwell tab shows Maxwell-Daemon status and lets you start/stop the service with confirmation."),
     "queue": "The Queue tab shows live queued and in-progress workflows with auto-refresh every 15 seconds.",
     "history": "The History tab shows recent workflow runs across all repos, filterable by status.",
     "machines": "The Machines tab shows hardware telemetry for each fleet node.",
@@ -3308,17 +3165,11 @@ async def maxwell_control(
     action = str(body.get("action", "")).strip()
     approved_by = str(body.get("approved_by", "")).strip()
     if action not in ("start", "stop", "restart"):
-        raise HTTPException(
-            status_code=422, detail="action must be start, stop, or restart"
-        )
+        raise HTTPException(status_code=422, detail="action must be start, stop, or restart")
     if not approved_by:
-        raise HTTPException(
-            status_code=422, detail="approved_by required for privileged action"
-        )
+        raise HTTPException(status_code=422, detail="approved_by required for privileged action")
 
-    code, out, stderr = await run_cmd(
-        ["systemctl", action, "maxwell-daemon"], timeout=15, cwd=REPO_ROOT
-    )
+    code, out, stderr = await run_cmd(["systemctl", action, "maxwell-daemon"], timeout=15, cwd=REPO_ROOT)
     log.info(
         "maxwell_control: action=%s approved_by=%s exit_code=%d",
         sanitize_log_value(action),
@@ -3339,10 +3190,7 @@ async def maxwell_control(
 
 def _maxwell_base_url() -> str:
     """Return the Maxwell-Daemon base URL from env."""
-    return (
-        os.environ.get("MAXWELL_URL", "")
-        or f"http://localhost:{int(os.environ.get('MAXWELL_PORT', 8322))}"
-    )
+    return os.environ.get("MAXWELL_URL", "") or f"http://localhost:{int(os.environ.get('MAXWELL_PORT', 8322))}"
 
 
 @app.get("/api/maxwell/version")
@@ -3464,9 +3312,7 @@ async def maxwell_chat(
     async def stream_daemon_response() -> Any:
         try:
             async with httpx.AsyncClient(timeout=None) as client:
-                async with client.stream(
-                    "POST", f"{_maxwell_base_url()}{path}", json=payload
-                ) as resp:
+                async with client.stream("POST", f"{_maxwell_base_url()}{path}", json=payload) as resp:
                     log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
                     if resp.status_code >= 400:
                         yield f"Maxwell chat failed with HTTP {resp.status_code}."
@@ -3478,9 +3324,7 @@ async def maxwell_chat(
             log.info("maxwell_proxy: path=%s status=%s", path, "error")
             yield f"Maxwell-Daemon is unreachable: {str(e)[:120]}"
 
-    return StreamingResponse(
-        stream_daemon_response(), media_type="text/plain; charset=utf-8"
-    )
+    return StreamingResponse(stream_daemon_response(), media_type="text/plain; charset=utf-8")
 
 
 @app.post("/api/maxwell/pipeline-control/{action}")
@@ -3492,9 +3336,7 @@ async def maxwell_pipeline_control(
 ) -> dict:
     """Proxy POST /api/control/{action} to Maxwell-Daemon."""
     if action not in ("pause", "resume", "abort"):
-        raise HTTPException(
-            status_code=422, detail="action must be pause, resume, or abort"
-        )
+        raise HTTPException(status_code=422, detail="action must be pause, resume, or abort")
     path = f"/api/control/{action}"
     resp = None
     try:
@@ -3516,9 +3358,7 @@ async def maxwell_pipeline_control(
 
 
 @app.post("/api/help/chat")
-async def help_chat(
-    request: Request, *, principal: Principal = Depends(require_scope("operator"))
-) -> dict:  # noqa: B008
+async def help_chat(request: Request, *, principal: Principal = Depends(require_scope("operator"))) -> dict:  # noqa: B008
     """Answer a dashboard help question. Uses local FAQ first, falls back to Claude API if available."""
     body = await request.json()
     question = str(body.get("question", "")).strip()
@@ -3604,11 +3444,8 @@ async def get_assessment_scores() -> dict:
                         "file": str(score_file.relative_to(REPO_ROOT)),
                         "repo": data.get("repository") or score_file.parent.name,
                         "score": data.get("score") or data.get("overall_score"),
-                        "date": data.get("date")
-                        or data.get("timestamp")
-                        or score_file.stat().st_mtime,
-                        "summary": data.get("summary")
-                        or data.get("description", "")[:200],
+                        "date": data.get("date") or data.get("timestamp") or score_file.stat().st_mtime,
+                        "summary": data.get("summary") or data.get("description", "")[:200],
                         "provider": data.get("provider") or data.get("agent", ""),
                     }
                 )
@@ -3646,9 +3483,7 @@ async def dispatch_assessment(
         "ref": "main",
         "inputs": {"target_repository": f"{ORG}/{repo}", "provider": provider},
     }
-    with tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8", suffix=".json", delete=False
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", suffix=".json", delete=False) as f:
         json.dump(payload, f)
         pf = f.name
     try:
@@ -3661,9 +3496,7 @@ async def dispatch_assessment(
         with contextlib.suppress(OSError):
             Path(pf).unlink()
     if code != 0:
-        log.warning(
-            "assessment dispatch failed: repo=%s stderr=%s", repo, stderr.strip()[:300]
-        )
+        log.warning("assessment dispatch failed: repo=%s stderr=%s", repo, stderr.strip()[:300])
         raise HTTPException(
             status_code=502,
             detail="Assessment dispatch failed",
@@ -3673,15 +3506,11 @@ async def dispatch_assessment(
 
 # ─── Fleet Orchestration Control Plane ───────────────────────────────────────
 
-_ORCHESTRATION_AUDIT_PATH = (
-    Path.home() / "actions-runners" / "dashboard" / "orchestration_audit.json"
-)
+_ORCHESTRATION_AUDIT_PATH = Path.home() / "actions-runners" / "dashboard" / "orchestration_audit.json"
 _DEPLOY_ACTIONS = {"sync_workflows", "restart_runner", "update_config"}
 
 
-def _load_orchestration_audit(
-    limit: int = 50, principal: str | None = None
-) -> list[dict]:
+def _load_orchestration_audit(limit: int = 50, principal: str | None = None) -> list[dict]:
     """Load recent orchestration audit entries from disk."""
     if not _ORCHESTRATION_AUDIT_PATH.exists():
         return []
@@ -3751,9 +3580,7 @@ async def get_fleet_audit_log(
         return []
 
     if FLEET_NODES:
-        remotes = await asyncio.gather(
-            *[fetch_remote_audit(n, u) for n, u in FLEET_NODES.items()]
-        )
+        remotes = await asyncio.gather(*[fetch_remote_audit(n, u) for n, u in FLEET_NODES.items()])
         for r_entries in remotes:
             all_entries.extend(r_entries)
 
@@ -3793,9 +3620,7 @@ async def get_fleet_orchestration(request: Request) -> dict:
         system_info = live.get("system", {}) if live else {}
         runners_info = live.get("runners", []) if live else []
         runner_count = len(runners_info) if isinstance(runners_info, list) else 0
-        busy_count = (
-            sum(1 for r in runners_info if r.get("busy")) if runner_count else 0
-        )
+        busy_count = sum(1 for r in runners_info if r.get("busy")) if runner_count else 0
         machines.append(
             {
                 "name": name,
@@ -3915,9 +3740,7 @@ async def fleet_orchestration_dispatch(
         dispatch_payload: dict = {"ref": ref}
         if inputs:
             dispatch_payload["inputs"] = inputs
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as pf_obj:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as pf_obj:
             json.dump(dispatch_payload, pf_obj)
             pf = pf_obj.name
         try:
@@ -4123,9 +3946,7 @@ async def get_diagnostics_summary() -> dict:
                 capture_output=True,
                 timeout=10,
             )
-            summary["wsl_status"] = wsl_result_raw.stdout.decode(
-                "utf-16-le", errors="replace"
-            ).strip()
+            summary["wsl_status"] = wsl_result_raw.stdout.decode("utf-16-le", errors="replace").strip()
             summary["wsl_available"] = wsl_result_raw.returncode == 0
         except Exception:  # noqa: BLE001
             summary["wsl_status"] = "WSL not available"
@@ -4224,9 +4045,7 @@ async def generate_launchers(
     launchers_created.append(str(restart))
 
     diag = output_dir / "Open-Diagnostics.ps1"
-    diag.write_text(
-        'Start-Process "http://localhost:8321/#diagnostics"\n', encoding="utf-8"
-    )
+    diag.write_text('Start-Process "http://localhost:8321/#diagnostics"\n', encoding="utf-8")
     launchers_created.append(str(diag))
 
     log.info("Generated %d launcher scripts in %s", len(launchers_created), output_dir)
@@ -4269,9 +4088,7 @@ async def _run_runner_audit() -> None:
         try:
             violations = await _fetch_hosted_runner_violations()
             _runner_audit_cache["violations"] = violations
-            _runner_audit_cache["last_checked"] = (
-                datetime.now(UTC).isoformat().replace("+00:00", "Z")
-            )
+            _runner_audit_cache["last_checked"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
             _runner_audit_cache["error"] = None
             if violations:
                 log.warning(
@@ -4326,10 +4143,7 @@ async def _fetch_hosted_runner_violations() -> list[dict[str, Any]]:
                     for job in jobs_resp.json().get("jobs", []):
                         runner_name = job.get("runner_name") or ""
                         runner_group = job.get("runner_group_name") or ""
-                        if (
-                            HOSTED_RUNNER_PATTERNS.match(runner_name)
-                            or runner_group == "GitHub Actions"
-                        ):
+                        if HOSTED_RUNNER_PATTERNS.match(runner_name) or runner_group == "GitHub Actions":
                             violations.append(
                                 {
                                     "repo": repo_name,

--- a/scripts/check_local_only_workflows.py
+++ b/scripts/check_local_only_workflows.py
@@ -35,15 +35,10 @@ def main() -> int:
         for line_number, line in enumerate(text.splitlines(), start=1):
             for token in BANNED:
                 if token in line:
-                    failures.append(
-                        f"{path}:{line_number}: banned hosted-runner token {token!r}"
-                    )
+                    failures.append(f"{path}:{line_number}: banned hosted-runner token {token!r}")
 
     if failures:
-        print(
-            "GitHub-hosted runner routing is forbidden. "
-            "Use local self-hosted runners only."
-        )
+        print("GitHub-hosted runner routing is forbidden. Use local self-hosted runners only.")
         print("\n".join(failures))
         return 1
 

--- a/tests/api/test_push.py
+++ b/tests/api/test_push.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import sys
 from pathlib import Path
 

--- a/tests/api/test_push.py
+++ b/tests/api/test_push.py
@@ -187,9 +187,11 @@ def test_payload_rejects_oversized_body() -> None:
 def test_principal_import_keeps_auth_dependency_available() -> None:
     assert Principal(id="test", type="bot", name="Test").id == "test"
 
+
 @pytest.mark.asyncio
 async def test_vapid_public_key_returns_key() -> None:
     import os
+
     old = os.environ.pop("VAPID_PUBLIC_KEY", None)
     try:
         resp = await push.get_vapid_public_key()

--- a/tests/api/test_routers_linear.py
+++ b/tests/api/test_routers_linear.py
@@ -51,9 +51,7 @@ def test_get_workspaces_auth_status_missing_env_when_key_unset(
     assert response.json()["workspaces"][0]["auth_status"] == "missing_env"
 
 
-def test_get_workspaces_auth_status_auth_failed_on_401(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_get_workspaces_auth_status_auth_failed_on_401(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     config = {"workspaces": [{"id": "personal"}], "mappings": {}}
     monkeypatch.setattr(linear_router, "load_linear_config", lambda: config)
     monkeypatch.setenv("LINEAR_API_KEY", "lin_api_test")

--- a/tests/api/test_routers_runners.py
+++ b/tests/api/test_routers_runners.py
@@ -24,9 +24,9 @@ if str(_BACKEND) not in sys.path:
 os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
 
 import server  # noqa: E402
-from routers import runners as runners_router  # noqa: E402
-from routers import runner_groups as groups_router  # noqa: E402
 from routers import runner_diagnostics as diagnostics_router  # noqa: E402
+from routers import runner_groups as groups_router  # noqa: E402
+from routers import runners as runners_router  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/api/test_routers_runners.py
+++ b/tests/api/test_routers_runners.py
@@ -25,6 +25,8 @@ os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
 
 import server  # noqa: E402
 from routers import runners as runners_router  # noqa: E402
+from routers import runner_groups as groups_router  # noqa: E402
+from routers import runner_diagnostics as diagnostics_router  # noqa: E402
 
 
 @pytest.fixture
@@ -89,7 +91,9 @@ def mock_gh_api_admin(monkeypatch: pytest.MonkeyPatch):
             }
         return {}
 
-    monkeypatch.setattr(runners_router, "gh_api_admin", mock_api)
+    monkeypatch.setattr(runners_router, "gh_api_admin", mock_api, raising=False)
+    monkeypatch.setattr(groups_router, "gh_api_admin", mock_api, raising=False)
+    monkeypatch.setattr(diagnostics_router, "gh_api_admin", mock_api, raising=False)
     return mock_api
 
 
@@ -108,7 +112,9 @@ def mock_run_runner_svc(monkeypatch: pytest.MonkeyPatch):
             return 0, "runner restarted", ""
         return 1, "", "unknown action"
 
-    monkeypatch.setattr(runners_router, "run_runner_svc", mock_svc)
+    monkeypatch.setattr(runners_router, "run_runner_svc", mock_svc, raising=False)
+    monkeypatch.setattr(groups_router, "run_runner_svc", mock_svc, raising=False)
+    monkeypatch.setattr(diagnostics_router, "run_runner_svc", mock_svc, raising=False)
     return mock_svc
 
 
@@ -123,8 +129,12 @@ def mock_cache(monkeypatch: pytest.MonkeyPatch):
     def mock_set(key: str, value):
         cache_store[key] = value
 
-    monkeypatch.setattr(runners_router, "cache_get", mock_get)
-    monkeypatch.setattr(runners_router, "cache_set", mock_set)
+    monkeypatch.setattr(runners_router, "cache_get", mock_get, raising=False)
+    monkeypatch.setattr(runners_router, "cache_set", mock_set, raising=False)
+    monkeypatch.setattr(groups_router, "cache_get", mock_get, raising=False)
+    monkeypatch.setattr(groups_router, "cache_set", mock_set, raising=False)
+    monkeypatch.setattr(diagnostics_router, "cache_get", mock_get, raising=False)
+    monkeypatch.setattr(diagnostics_router, "cache_set", mock_set, raising=False)
     return cache_store
 
 

--- a/tests/frontend/test_fleet_mobile.py
+++ b/tests/frontend/test_fleet_mobile.py
@@ -1,4 +1,3 @@
-
 """Tests for Fleet mobile components.
 
 These tests verify the Fleet mobile page renders correct markup for all four

--- a/tests/test_auth_webauthn.py
+++ b/tests/test_auth_webauthn.py
@@ -53,9 +53,7 @@ def test_complete_endpoints_fail_closed(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert assertion.status_code == 501
 
 
-def test_assert_begin_requires_active_registered_credential(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_assert_begin_requires_active_registered_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     client = _client(monkeypatch, tmp_path)
 
     response = client.post("/api/auth/webauthn/assert/begin", json={})
@@ -64,9 +62,7 @@ def test_assert_begin_requires_active_registered_credential(
     assert response.json()["detail"] == "No active WebAuthn credential registered for this user"
 
 
-def test_list_and_revoke_only_current_user_credentials(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_list_and_revoke_only_current_user_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     import auth_webauthn
 
     credential_path = tmp_path / "webauthn_credentials.json"

--- a/tests/test_dashboard_config.py
+++ b/tests/test_dashboard_config.py
@@ -4,10 +4,7 @@ import importlib  # noqa: E402
 import os  # noqa: E402
 from pathlib import Path  # noqa: E402
 
-import pytest  # noqa: E402
-
 import dashboard_config  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Paths

--- a/tests/test_frontend_integrity.py
+++ b/tests/test_frontend_integrity.py
@@ -418,12 +418,12 @@ def test_touch_primitives_foundation_contract_is_static_guarded() -> None:
     )
 
     assert 'data-touch-primitive="TouchButton"' in touch_button
-    assert 'aria-pressed={pressed}' in touch_button
+    assert "aria-pressed={pressed}" in touch_button
     assert 'type = "button"' in touch_button
     assert 'data-touch-primitive="SegmentedControl"' in segmented
     assert 'role="radiogroup"' in segmented
     assert 'role="radio"' in segmented
-    assert 'aria-checked={option.value === value}' in segmented
+    assert "aria-checked={option.value === value}" in segmented
     assert "ArrowRight" in segmented and "ArrowLeft" in segmented
     assert 'export { TouchButton } from "./TouchButton";' in exports
     assert 'export { SegmentedControl } from "./SegmentedControl";' in exports

--- a/tests/test_health_module.py
+++ b/tests/test_health_module.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 _BACKEND_DIR = Path(__file__).parent.parent / "backend"
 sys.path.insert(0, str(_BACKEND_DIR))
 

--- a/tests/test_linear_taxonomy_utils.py
+++ b/tests/test_linear_taxonomy_utils.py
@@ -18,7 +18,6 @@ sys.path.insert(0, str(_BACKEND_DIR))
 
 import linear_taxonomy_map as ltm  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -173,7 +172,7 @@ def test_derived_labels_passthrough_applied() -> None:
 def test_derived_labels_default_judgement_added_when_none() -> None:
     issue = {}
     labels = ltm.derived_labels(issue, MINIMAL_MAPPING)
-    assert any(l.startswith("judgement:") for l in labels)
+    assert any(label.startswith("judgement:") for label in labels)
     assert "judgement:objective" in labels
 
 

--- a/tests/test_linear_taxonomy_utils.py
+++ b/tests/test_linear_taxonomy_utils.py
@@ -113,9 +113,7 @@ def test_load_mapping_config_workspace_unknown_mapping_ref(tmp_path: Path) -> No
 def test_load_mapping_config_wrong_auth_kind(tmp_path: Path) -> None:
     bad_config = {
         **MINIMAL_CONFIG,
-        "workspaces": [
-            {**MINIMAL_CONFIG["workspaces"][0], "auth": {"kind": "oauth", "env": "MY_ENV"}}
-        ],
+        "workspaces": [{**MINIMAL_CONFIG["workspaces"][0], "auth": {"kind": "oauth", "env": "MY_ENV"}}],
     }
     path = tmp_path / "cfg.json"
     path.write_text(json.dumps(bad_config), encoding="utf-8")
@@ -200,7 +198,18 @@ def test_derived_labels_unknown_labels_ignored() -> None:
 def test_apply_mapping_returns_mapping_result_keys() -> None:
     issue = {"priority": 1, "estimate": 3}
     result = ltm.apply_mapping(issue, MINIMAL_MAPPING)
-    for key in ("type", "complexity", "effort", "judgement", "quick_win", "panel_review", "domains", "wave", "derived_labels", "source_signals"):
+    for key in (
+        "type",
+        "complexity",
+        "effort",
+        "judgement",
+        "quick_win",
+        "panel_review",
+        "domains",
+        "wave",
+        "derived_labels",
+        "source_signals",
+    ):
         assert key in result
 
 

--- a/tests/test_metrics_module.py
+++ b/tests/test_metrics_module.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 _BACKEND_DIR = Path(__file__).parent.parent / "backend"
 sys.path.insert(0, str(_BACKEND_DIR))
 

--- a/tests/test_mobile_test_harness.py
+++ b/tests/test_mobile_test_harness.py
@@ -66,8 +66,7 @@ def test_mobile_smoke_page_contract_targets_existing_frontend_markers() -> None:
         assert page["requiredMarkers"], f"{page['name']} must include static frontend markers"
         for marker in page["requiredMarkers"]:
             assert marker in html or marker in js, (
-                f"{page['name']} marker {marker!r} is missing from "
-                "frontend/index.html or frontend/src/legacy/App.tsx"
+                f"{page['name']} marker {marker!r} is missing from frontend/index.html or frontend/src/legacy/App.tsx"
             )
 
 

--- a/tests/test_push_module.py
+++ b/tests/test_push_module.py
@@ -49,7 +49,9 @@ def _make_keys(p256dh: str = "AAAA" * 30, auth: str = "BBBB" * 10) -> PushKeys:
     return PushKeys(p256dh=p256dh, auth=auth)
 
 
-def _upsert(db: Path, endpoint: str = "https://push.example.com/sub/1", topics: list[str] | None = None) -> PushSubscription:
+def _upsert(
+    db: Path, endpoint: str = "https://push.example.com/sub/1", topics: list[str] | None = None
+) -> PushSubscription:
     return upsert_subscription(
         user_id="user-1",
         endpoint=endpoint,

--- a/tests/test_push_module.py
+++ b/tests/test_push_module.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +31,6 @@ from push import (  # noqa: E402
     send_push,
     upsert_subscription,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -78,7 +76,7 @@ def test_push_subscription_request_valid() -> None:
 
 
 def test_push_subscription_request_rejects_http_non_loopback() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         PushSubscriptionRequest(
             endpoint="http://evil.example.com/sub/1",
             keys=PushKeys(p256dh="A" * 20, auth="B" * 10),
@@ -105,7 +103,7 @@ def test_push_subscription_request_allows_loopback_127() -> None:
 
 
 def test_push_subscription_request_rejects_unknown_topic() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         PushSubscriptionRequest(
             endpoint="https://push.example.com/sub/1",
             keys=PushKeys(p256dh="A" * 20, auth="B" * 10),
@@ -148,12 +146,12 @@ def test_push_test_request_valid_custom_topic() -> None:
 
 
 def test_push_test_request_rejects_unknown_topic() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         PushTestRequest(topic="not.a.real.topic")
 
 
 def test_push_test_request_rejects_non_internal_deep_link() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         PushTestRequest(deep_link="https://evil.com/page")
 
 

--- a/tests/test_remote_logout.py
+++ b/tests/test_remote_logout.py
@@ -116,7 +116,7 @@ def test_logout_endpoint_revokes_current_session(monkeypatch: pytest.MonkeyPatch
     client = _client(monkeypatch, tmp_path)
     import session_management as sm
 
-    sid = sm.register_session("human:test", user_agent="A", ip_address="1.1.1.1")
+    _ = sm.register_session("human:test", user_agent="A", ip_address="1.1.1.1")
 
     # The endpoint works even without session in request.session because it falls back gracefully
     response = client.post("/api/auth/logout")

--- a/tests/test_report_files.py
+++ b/tests/test_report_files.py
@@ -1,9 +1,6 @@
 from __future__ import annotations  # noqa: E402
 
-import pytest  # noqa: E402
-
 import report_files  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # sanitize_report_date

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -211,6 +211,7 @@ def test_check_dispatch_rate_exceeds_limit(monkeypatch) -> None:
 
     # FastAPI HTTPException is raised
     from fastapi import HTTPException
+
     assert isinstance(exc_info.value, HTTPException)
     assert exc_info.value.status_code == 429
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -4,9 +4,7 @@ import time
 from pathlib import Path  # noqa: E402
 
 import pytest  # noqa: E402
-
 import security  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # sanitize_log_value

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -6,19 +6,15 @@ import time
 from pathlib import Path
 
 import pytest
-
 from session_management import (
-    _load_sessions,
-    _prune_expired_sessions,
-    _save_sessions,
     generate_session_id,
+    hash_session_id,
     is_session_active,
     list_sessions_for_principal,
     register_session,
     revoke_all_sessions_for_principal,
     revoke_session,
     session_count_for_principal,
-    hash_session_id,
 )
 
 

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -8,17 +8,13 @@ These are all pure (or near-pure) functions with no external I/O.
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
-
-import pytest
 
 _BACKEND_DIR = Path(__file__).parent.parent / "backend"
 sys.path.insert(0, str(_BACKEND_DIR))
 
 import system_utils  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # get_workload_capacity_from_specs


### PR DESCRIPTION
## Problem

unners.py grew to 1004 lines after the batch-2 router extractions, breaking the ci-health-check '500-line soft cap' gate. This blocks **all** PR pipelines because quality-gate, security-scan, and 	ests all 
eed: ci-health-check.

## Solution

Split unners.py into focused sub-modules:

| Module | Lines | Responsibility |
|--------|-------|----------------|
| unner_helpers.py | 155 | Shared utility functions |
| unner_groups.py | 186 | Label-based group operations |
| unner_diagnostics.py | 376 | Diagnostics, fleet capacity, autoscaling, troubleshoot |
| unners.py | 336 | Core lifecycle routes (list, start, stop, restart, status) |

Also fixes pre-existing ruff I001/UP017 in outers/system.py.

## Impact

Restores ci-health-check to passing, which unblocks the entire PR queue.