### PR TITLE
feat(deploy): add backup_state() snapshot to maintenance script (#417)

### DIFF
--- a/deploy/scheduled-dashboard-maintenance.sh
+++ b/deploy/scheduled-dashboard-maintenance.sh
@@ -38,6 +38,10 @@ INSTALL_WINDOWS_WATCHDOG=1
 INSTALL_AUTOSCALER=0
 WINDOWS_USER="${WINDOWS_USER:-}"
 WSL_DISTRO="${WSL_DISTRO_NAME:-}"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/runner-dashboard}"
+BACKUP_RETENTION="${BACKUP_RETENTION:-30}"
+DRY_RUN=0
+BACKUP_ONLY=0
 
 usage() {
     cat <<'EOF'
@@ -59,6 +63,10 @@ Options:
   --install-autoscaler         Install/update runner-autoscaler.service after dashboard
   --windows-user NAME          Windows profile name for .wslconfig/watchdog path
   --distro NAME                WSL distribution name for Windows watchdog
+  --backup-dir PATH            Directory for state snapshots (default: /var/backups/runner-dashboard, env BACKUP_DIR)
+  --backup-retention N         Keep most recent N backups (default: 30, env BACKUP_RETENTION)
+  --backup-only                Run only backup_state and exit (useful with --dry-run)
+  --dry-run                    Print actions without making changes (currently honoured by backup_state)
   -h, --help                   Show this help
 
 Scheduled-agent example:
@@ -85,13 +93,19 @@ while [[ $# -gt 0 ]]; do
         --install-autoscaler) INSTALL_AUTOSCALER=1; shift ;;
         --windows-user) WINDOWS_USER="$2"; shift 2 ;;
         --distro) WSL_DISTRO="$2"; shift 2 ;;
+        --backup-dir) BACKUP_DIR="$2"; shift 2 ;;
+        --backup-retention) BACKUP_RETENTION="$2"; shift 2 ;;
+        --backup-only) BACKUP_ONLY=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) fail "Unknown option: $1" ;;
     esac
 done
 
-[[ -d "${REPO_ROOT}/.git" ]] || fail "Repo root is not a git checkout: ${REPO_ROOT}"
 [[ -d "${DASHBOARD_DIR}" ]] || fail "Dashboard source not found: ${DASHBOARD_DIR}"
+if [[ "${BACKUP_ONLY}" != "1" ]]; then
+    [[ -d "${REPO_ROOT}/.git" ]] || fail "Repo root is not a git checkout: ${REPO_ROOT}"
+fi
 
 sync_repo() {
     if [[ "$SKIP_GIT" == "1" ]]; then
@@ -280,6 +294,77 @@ purge_stale_queue() {
         warn "Dashboard not reachable; skipping stale queue purge (will retry next run)"
     fi
 }
+
+backup_state() {
+    # Snapshot dashboard state for disaster recovery (issue #417).
+    #
+    # Inputs (env-overridable):
+    #   BACKUP_DIR        target dir, default /var/backups/runner-dashboard
+    #   BACKUP_RETENTION  count of recent backups to keep, default 30
+    #   DRY_RUN           when 1, print plan but do not write
+    #
+    # Snapshots (silently skipped if absent via tar --ignore-failed-read):
+    #   - <DASHBOARD_DIR>/config/         (agent_remediation.json, principals.yml, etc.)
+    #   - <DEPLOY_DIR>/config/            (deployed-host config, when present)
+    #   - $HOME/.config/runner-dashboard/ (env, session_secret, runner-schedule.json)
+    #   - $HOME/.dashboard-logs/          (recent operator logs)
+    #   - /var/log/runner-dashboard/      (recent service logs, when present)
+    local timestamp tarball
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    tarball="${BACKUP_DIR}/runner-dashboard-state-${timestamp}.tar.gz"
+
+    # Candidate paths — tar will skip missing entries via --ignore-failed-read.
+    local -a candidates=()
+    [[ -d "${DASHBOARD_DIR}/config" ]] && candidates+=("${DASHBOARD_DIR}/config")
+    [[ -d "${DEPLOY_DIR}/config" ]] && candidates+=("${DEPLOY_DIR}/config")
+    [[ -d "${HOME}/.config/runner-dashboard" ]] && candidates+=("${HOME}/.config/runner-dashboard")
+    [[ -d "${HOME}/.dashboard-logs" ]] && candidates+=("${HOME}/.dashboard-logs")
+    [[ -d "/var/log/runner-dashboard" ]] && candidates+=("/var/log/runner-dashboard")
+
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        info "[DRY-RUN] backup_state would write: ${tarball}"
+        info "[DRY-RUN] would archive these existing paths:"
+        if (( ${#candidates[@]} == 0 )); then
+            warn "[DRY-RUN] no state paths exist on this host yet"
+        else
+            local p
+            for p in "${candidates[@]}"; do
+                echo "  - ${p}"
+            done
+        fi
+        info "[DRY-RUN] retention: keep most recent ${BACKUP_RETENTION} backups in ${BACKUP_DIR}"
+        return 0
+    fi
+
+    if (( ${#candidates[@]} == 0 )); then
+        warn "No state paths exist; skipping backup_state"
+        return 0
+    fi
+
+    info "Snapshotting dashboard state to ${tarball}"
+    if ! mkdir -p "${BACKUP_DIR}" 2>/dev/null; then
+        if ! sudo mkdir -p "${BACKUP_DIR}" || ! sudo chown "$(id -u):$(id -g)" "${BACKUP_DIR}"; then
+            warn "Cannot create ${BACKUP_DIR}; skipping backup_state"
+            return 0
+        fi
+    fi
+
+    if tar --ignore-failed-read -czf "${tarball}" "${candidates[@]}" 2>/dev/null; then
+        ok "Wrote state snapshot ${tarball}"
+    else
+        warn "tar reported errors while writing ${tarball} (continuing)"
+    fi
+
+    # Retention: keep the most recent BACKUP_RETENTION snapshots.
+    local keep="${BACKUP_RETENTION}"
+    local skip=$((keep + 1))
+    # shellcheck disable=SC2012  # ls -t is fine here; filenames are timestamped and we control them.
+    ls -1t "${BACKUP_DIR}"/runner-dashboard-state-*.tar.gz 2>/dev/null \
+        | tail -n "+${skip}" \
+        | xargs -r rm -f
+    ok "Backup retention: kept most recent ${keep} snapshots in ${BACKUP_DIR}"
+}
+
 main() {
     info "Runner dashboard scheduled maintenance"
     echo "Repo:       ${REPO_ROOT}"
@@ -288,6 +373,13 @@ main() {
     echo "Machine:    ${MACHINE_NAME}"
     echo "Role:       ${ROLE}"
     echo "Port:       ${PORT}"
+    echo "BackupDir:  ${BACKUP_DIR}"
+
+    if [[ "${BACKUP_ONLY}" == "1" ]]; then
+        backup_state
+        ok "Backup-only run complete"
+        return 0
+    fi
 
     sync_repo
     if [[ "${SKIP_WSL_KEEPALIVE}" != "1" ]]; then
@@ -298,6 +390,7 @@ main() {
     install_autoscaler_if_requested
     verify_dashboard
     purge_stale_queue
+    backup_state
     ok "Scheduled dashboard maintenance complete"
 }
 

--- a/tests/test_backup_state.py
+++ b/tests/test_backup_state.py
@@ -1,0 +1,106 @@
+"""Tests for the backup_state step in scheduled-dashboard-maintenance.sh.
+
+Issue #417: dry-run mode must list the paths that would be archived
+without actually creating the tarball, and BACKUP_DIR must be overridable
+via environment variable.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+_SCRIPT = _ROOT / "deploy" / "scheduled-dashboard-maintenance.sh"
+
+
+def test_script_exists() -> None:
+    assert _SCRIPT.is_file(), f"missing {_SCRIPT}"
+
+
+def test_script_passes_bash_syntax_check() -> None:
+    result = subprocess.run(
+        ["bash", "-n", str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_script_defines_backup_state_function() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "backup_state()" in text or "backup_state ()" in text, (
+        "scheduled-dashboard-maintenance.sh must define a backup_state function"
+    )
+
+
+def test_script_uses_default_backup_dir() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "/var/backups/runner-dashboard" in text, (
+        "default BACKUP_DIR must be /var/backups/runner-dashboard"
+    )
+
+
+def test_script_retains_thirty_backups() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    # Either +31 (skip first 30) or +$((BACKUP_RETENTION+1)) — accept the literal default.
+    assert "+31" in text or "BACKUP_RETENTION" in text, (
+        "retention policy must keep the most recent 30 backups"
+    )
+
+
+def test_script_calls_backup_state_in_main() -> None:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    # Backup must be invoked from main() so cron picks it up.
+    main_section = text.split("main()", 1)[-1]
+    assert "backup_state" in main_section, (
+        "main() must invoke backup_state so cron triggers it"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash unavailable")
+def test_dry_run_lists_paths_and_creates_no_tarball(tmp_path: Path) -> None:
+    """Run the script with --dry-run and a tmp BACKUP_DIR, assert no tarball."""
+
+    backup_dir = tmp_path / "backups"
+    fake_repo = tmp_path / "repo"
+    fake_dashboard = fake_repo / "runner-dashboard"
+    (fake_repo / ".git").mkdir(parents=True)
+    fake_dashboard.mkdir(parents=True)
+    # Copy the maintenance script into the fake dashboard so its path discovery works.
+    shutil.copytree(_ROOT / "deploy", fake_dashboard / "deploy")
+
+    env = dict(os.environ)
+    env["BACKUP_DIR"] = str(backup_dir)
+    env["HOME"] = str(tmp_path / "home")
+    (tmp_path / "home").mkdir()
+    (tmp_path / "home" / ".config" / "runner-dashboard").mkdir(parents=True)
+
+    script = fake_dashboard / "deploy" / "scheduled-dashboard-maintenance.sh"
+    result = subprocess.run(
+        ["bash", str(script), "--dry-run", "--backup-only"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        cwd=str(fake_dashboard),
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, f"dry-run failed: {combined}"
+    assert "DRY-RUN" in combined or "dry-run" in combined.lower()
+    # Lists what it would archive
+    assert "config" in combined
+    assert "runner-dashboard" in combined
+    # Mentions the would-be tarball name
+    assert "runner-dashboard-state-" in combined
+    assert ".tar.gz" in combined
+    # No actual tarball was created
+    if backup_dir.exists():
+        produced = list(backup_dir.glob("runner-dashboard-state-*.tar.gz"))
+        assert produced == [], f"dry-run should not create tarballs, got {produced}"


### PR DESCRIPTION
## Summary

- Adds `backup_state()` to `deploy/scheduled-dashboard-maintenance.sh` that snapshots `config/`, `~/.config/runner-dashboard/` (session_secret, env), `principals.yml` (under `config/`), and recent operator/service logs to a timestamped tarball at `${BACKUP_DIR}/runner-dashboard-state-YYYYMMDDTHHMMSSZ.tar.gz`.
- `BACKUP_DIR` defaults to `/var/backups/runner-dashboard` and is overridable via env var or `--backup-dir`. Retention keeps the most recent 30 archives (`BACKUP_RETENTION` / `--backup-retention`).
- New `--dry-run` flag prints the planned tarball path and the existing source paths without writing anything; new `--backup-only` runs just the backup step (safe from cron, no git pull / no service restart).
- `backup_state` is invoked from `main()` so the existing hourly cron entry now also produces snapshots — no crontab changes required on deployed hosts.
- Uses `tar --ignore-failed-read` so missing optional paths (e.g. `/var/log/runner-dashboard` on machines without a syslog sink) do not abort the snapshot.

## Test plan

- [x] `bash -n deploy/scheduled-dashboard-maintenance.sh` clean
- [x] `pytest tests/test_backup_state.py -v` (7 tests pass) — includes a real `--dry-run --backup-only` invocation in `tmp_path` that asserts the planned paths are listed and no tarball is written
- [x] `pytest tests/test_deploy_hardening.py tests/test_backup_state.py -q` (11 tests pass) — no regression in existing deploy hardening checks
- [x] Manual smoke: `BACKUP_DIR=/tmp/rd-backup-test bash deploy/scheduled-dashboard-maintenance.sh --dry-run --backup-only` prints expected plan, leaves `/tmp/rd-backup-test` uncreated

Closes #417

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMid1Kh97BsHj6FggNW5vJ)_