### PR TITLE
docs(runbooks): add 7 failure-mode runbooks (#397)

### DIFF
--- a/docs/runbooks/ci-failure-triage.md
+++ b/docs/runbooks/ci-failure-triage.md
@@ -1,0 +1,94 @@
+# Runbook: CI Failure Triage
+
+The CI Standard workflow (`.github/workflows/ci-standard.yml`) is failing on
+`main` or on a critical PR. This blocks merges and (if main is red) the next
+deploy.
+
+## Symptom
+
+- The CI Standard check is red on `main` after a merge.
+- Multiple PRs are failing the same job (`quality-gate`, `security-scan`,
+  or `tests`).
+- Spec Check (`ci-spec-check.yml`) flags backend changes without a
+  corresponding `SPEC.md` update.
+- Jules PR AutoFix is looping on a PR without making progress.
+
+## Severity
+
+**P1** if `main` is red and blocks the deploy pipeline.
+**P2** if a single PR is red but `main` is green.
+**P3** if only the non-blocking pip-audit warnings are firing.
+
+## Detection
+
+- The PR or commit page on GitHub shows a red X on "CI Standard".
+- `gh pr checks <pr-number>` lists failures.
+- The Workflows tab in the dashboard surfaces consecutive failures.
+- Slack/Discord agent channel messages from Jules Control Tower reporting
+  remediation in flight.
+
+## Diagnosis
+
+```bash
+# 1. List recent CI Standard runs and statuses.
+gh run list --workflow ci-standard.yml --limit 10
+
+# 2. Inspect the failing run (replace <run-id>).
+gh run view <run-id> --log-failed | head -200
+
+# 3. Reproduce the failing job locally — match the CI commands exactly:
+ruff check backend/
+ruff format --check backend/
+mypy backend/ --ignore-missing-imports --exclude 'backend/__pycache__' --no-implicit-optional
+bandit -r backend/ -ll -ii --exclude backend/__pycache__
+pytest tests/ -q --tb=short
+
+# 4. Spec-check failures: see which backend files changed without a SPEC.md
+#    bump on this branch.
+git diff --name-only origin/main...HEAD -- backend/ SPEC.md
+
+# 5. Confirm the failure is not a flake by re-running the failed jobs only.
+gh run rerun <run-id> --failed
+```
+
+## Mitigation
+
+```bash
+# A. For lint/format failures, auto-fix and push.
+ruff check backend/ --fix
+ruff format backend/
+git add -u && git commit -m "chore: ruff autofix" && git push
+
+# B. For spec-check failures on a legitimate exemption, apply the label.
+gh pr edit <pr-number> --add-label spec-exempt
+
+# C. For a flaky test, re-run only failed jobs.
+gh run rerun <run-id> --failed
+
+# D. If main is red and a quick fix is not possible, revert the offending
+#    merge to unblock the deploy pipeline.
+git revert <bad-merge-sha>
+git push origin main
+```
+
+If Jules PR AutoFix has been looping for >30 min without progress, comment
+on the PR to disengage it (`/jules pause` or remove the `claim:jules`
+label) and take it over manually.
+
+## Resolution
+
+- Land the real fix in a follow-up PR. If the failure was a flaky test,
+  add deterministic seeding and an `xfail` only as a last resort with an
+  explicit tracking issue.
+- Update `tests/api/` or `tests/frontend/` with the regression case so the
+  same failure cannot recur silently.
+- For repeated security-scan findings, upgrade the offending dependency in
+  `backend/requirements.txt` and pin to a known-good version.
+- For spec-check noise, document the exemption pattern in
+  `docs/issue-taxonomy.md` so future PRs know when `spec-exempt` is correct.
+- Update this runbook if a new CI job is added that operators commonly
+  encounter.
+
+## Postmortem Template
+
+[`postmortem-template.md`](./postmortem-template.md)

--- a/docs/runbooks/dashboard-down.md
+++ b/docs/runbooks/dashboard-down.md
@@ -1,0 +1,100 @@
+# Runbook: Dashboard Down
+
+The Runner Dashboard FastAPI service on port 8321 is unreachable or returning
+5xx for `/api/health`.
+
+## Symptom
+
+- Browser tab at `http://localhost:8321/` (or the Tailscale URL) shows
+  "connection refused", "502 Bad Gateway", or hangs indefinitely.
+- `/api/health` returns 5xx, never returns, or `curl` cannot connect.
+- Other operators report the dashboard is unreachable.
+- `docs/fleet-in-flight.md` and other dashboard-driven artifacts stop updating.
+
+## Severity
+
+**P1** — the dashboard is the primary operator console for the entire fleet.
+While it is down, operators cannot dispatch agents, monitor runners, or purge
+stale queues from the UI. CI and runners themselves may keep functioning, but
+visibility is lost.
+
+## Detection
+
+- `systemctl status runner-dashboard` reports `failed`, `inactive`, or
+  repeated `Restart=always` loops.
+- Browser monitoring or a teammate reports `localhost:8321` unreachable.
+- `curl -fsS http://localhost:8321/api/health` returns non-2xx or fails.
+- Push notifications subscribed to operator topics stop arriving.
+- `journalctl -u runner-dashboard` shows a Python traceback at the tail.
+
+## Diagnosis
+
+Run these in order on the host running the dashboard service:
+
+```bash
+# 1. Is the systemd unit running?
+sudo systemctl status runner-dashboard --no-pager
+
+# 2. What does the service log say (last 200 lines)?
+sudo journalctl -u runner-dashboard -n 200 --no-pager
+
+# 3. Is anything actually listening on port 8321?
+sudo ss -tlnp | grep 8321 || echo "nothing on 8321"
+
+# 4. Does the health endpoint respond locally?
+curl -fsS -m 5 http://localhost:8321/api/health || echo "health failed"
+
+# 5. Was the host recently updated? Check VERSION and last deploy.
+cat ~/actions-runners/dashboard/VERSION 2>/dev/null
+ls -dt ~/actions-runners/dashboard.bak.* 2>/dev/null | head -3
+
+# 6. Is the service env file readable and intact?
+sudo -u "$(whoami)" test -r ~/.config/runner-dashboard/env && echo "env ok" \
+  || echo "env missing or unreadable"
+```
+
+## Mitigation
+
+Stop-the-bleeding, in order of preference:
+
+```bash
+# A. Restart the service (works for transient crashes)
+sudo systemctl restart runner-dashboard
+sleep 3
+sudo systemctl is-active runner-dashboard && curl -fsS http://localhost:8321/api/health
+
+# B. If restart fails, roll back to the previous deployed snapshot.
+#    See deploy/rollback.sh; it auto-selects the most recent .bak.* directory.
+bash ~/actions-runners/dashboard/deploy/rollback.sh --list
+bash ~/actions-runners/dashboard/deploy/rollback.sh
+
+# C. If port 8321 is held by a stale process (no systemd entry), kill it
+#    and let systemd restart cleanly.
+sudo fuser -k 8321/tcp || true
+sudo systemctl start runner-dashboard
+```
+
+If the dashboard cannot recover, announce in the operator channel that the
+console is down and direct teammates to operate runners and CI directly via
+`gh` and `systemctl` until restored.
+
+## Resolution
+
+After mitigation, investigate the **root cause** before closing:
+
+- If `journalctl` shows a traceback, file a P1 issue with the trace and the
+  commit SHA from `~/actions-runners/dashboard/VERSION`. Revert the offending
+  change, then ship a forward fix with a regression test under `tests/api/`.
+- If the cause was an exhausted token (`GH_TOKEN` expired or revoked),
+  rotate via `deploy/refresh-token.sh` and update
+  `~/.config/runner-dashboard/env` (chmod 600).
+- If `/api/health` is now slow or flaky under load, add a backend test that
+  exercises the failing path and consider raising the upstream timeout in
+  `backend/middleware.py`.
+- Confirm `deploy/scheduled-dashboard-maintenance.sh` ran successfully in
+  cron; restore it if the cron entry was lost.
+- File a postmortem.
+
+## Postmortem Template
+
+[`postmortem-template.md`](./postmortem-template.md)

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -1,0 +1,100 @@
+# Runbook: Deploy Rollback
+
+A recent dashboard deploy introduced a regression — broken UI, failing
+endpoints, crash-looping service, or a known-bad change. Roll back to the
+prior deployed snapshot and stabilize before forward-fixing.
+
+## Symptom
+
+- The dashboard restarted after a deploy and is now crashing or returning
+  5xx.
+- A specific tab (Fleet, Maxwell, Queue Health, etc.) is throwing client-side
+  errors after a recent push.
+- `journalctl -u runner-dashboard` shows an `ImportError`, `SyntaxError`, or
+  pydantic validation failure not seen before the deploy.
+- The new `VERSION` is reported by `/api/version` but functionality is
+  degraded.
+
+## Severity
+
+**P1** — any regression in production deserves immediate rollback. The
+"Reversible" engineering principle in `CLAUDE.md` requires every deploy to
+ship a rollback marker. Use it.
+
+## Detection
+
+- Spike in dashboard 5xx after `update-deployed.sh` ran.
+- Operator reports correlated with the timestamp of `~/actions-runners/dashboard.bak.*`.
+- `systemctl status runner-dashboard` shows recent restart counter.
+- `git log -1 --format=%H ~/actions-runners/dashboard` (or VERSION file)
+  matches a commit landed in the last hour.
+
+## Diagnosis
+
+```bash
+# 1. Confirm the dashboard is running the recently-deployed code.
+cat ~/actions-runners/dashboard/VERSION
+
+# 2. List available rollback snapshots (created automatically by
+#    deploy/update-deployed.sh before each deploy).
+bash ~/actions-runners/dashboard/deploy/rollback.sh --list
+
+# 3. Inspect logs since the last restart for a single root cause.
+sudo journalctl -u runner-dashboard --since "30 minutes ago" --no-pager
+
+# 4. Compare the deployed tree against the previous snapshot.
+PREV=$(ls -dt ~/actions-runners/dashboard.bak.* | head -1)
+diff -ruN "$PREV/backend" ~/actions-runners/dashboard/backend | head -200
+
+# 5. Test the rollback non-destructively first.
+bash ~/actions-runners/dashboard/deploy/rollback.sh --dry-run
+```
+
+## Mitigation
+
+`deploy/rollback.sh` is the supported, reversible path. It rsyncs the most
+recent (or specified) `.bak.*` snapshot back over the deploy directory and
+restarts the systemd unit.
+
+```bash
+# A. Roll back to the most recent backup (the default).
+bash ~/actions-runners/dashboard/deploy/rollback.sh
+
+# B. Roll back to a specific older snapshot.
+bash ~/actions-runners/dashboard/deploy/rollback.sh \
+  --to ~/actions-runners/dashboard.bak.2026-04-29T18-00-00
+
+# C. Verify health after rollback.
+sudo systemctl is-active runner-dashboard
+curl -fsS http://localhost:8321/api/health
+curl -fsS http://localhost:8321/api/version
+```
+
+If rollback itself fails (no snapshots available, sync error), fall back to:
+
+```bash
+sudo systemctl stop runner-dashboard
+git -C /mnt/c/Users/<you>/Repositories/runner-dashboard checkout <last-known-good-sha>
+bash deploy/update-deployed.sh
+```
+
+## Resolution
+
+After the dashboard is stable on the rolled-back version:
+
+- Open a P1 issue with the failing log lines and the bad commit SHA.
+- Revert the offending PR (`git revert`) on `main` rather than amending,
+  per the project's commit policy.
+- Add a regression test under `tests/api/` (backend) or `tests/frontend/`
+  that fails on the bad change. Per the engineering principles in
+  `CLAUDE.md`, "new feature without a test is reverted, not 'followed up'."
+- Confirm the next deploy includes the test and passes CI before re-rolling
+  the original feature forward.
+- Audit `deploy/update-deployed.sh` to ensure it took a fresh `.bak.*`
+  snapshot — if not, fix the script's snapshot logic.
+- If the rollback succeeded but log rotation lost diagnostic data, raise
+  retention in `deploy/scheduled-dashboard-maintenance.sh`.
+
+## Postmortem Template
+
+[`postmortem-template.md`](./postmortem-template.md)

--- a/docs/runbooks/postmortem-template.md
+++ b/docs/runbooks/postmortem-template.md
@@ -1,0 +1,88 @@
+# Incident Postmortem Template
+
+> Copy this file to `docs/postmortems/YYYY-MM-DD-<short-slug>.md` after the
+> incident is resolved. Fill in every section. If a section is genuinely not
+> applicable, write `N/A` and explain why.
+
+## Summary
+
+One paragraph: what broke, who was affected, and how long it lasted.
+
+## Impact
+
+- **Severity:** P1 / P2 / P3
+- **Start (UTC):** `YYYY-MM-DD HH:MM`
+- **Detected (UTC):** `YYYY-MM-DD HH:MM`
+- **Mitigated (UTC):** `YYYY-MM-DD HH:MM`
+- **Resolved (UTC):** `YYYY-MM-DD HH:MM`
+- **Duration:** total / detection-to-mitigation / mitigation-to-resolution
+- **User-visible effect:** which dashboard tabs, runners, workflows, or
+  agents were degraded or unavailable.
+- **Data loss / safety implications:** none / describe.
+
+## Timeline (UTC)
+
+Event-by-event log with timestamps. Include detection signals, paging,
+hypotheses considered, commands run, and the moment user impact ended.
+
+```
+HH:MM  First alert / symptom observed
+HH:MM  Operator paged
+HH:MM  Mitigation applied
+HH:MM  User impact ends
+HH:MM  Root cause identified
+HH:MM  Permanent fix deployed
+```
+
+## Root Cause
+
+What actually caused the incident. Include the chain of contributing factors,
+not just the proximate trigger. Cite commits, config diffs, or upstream
+changes where relevant.
+
+## Detection
+
+How was the incident detected? Was the runbook's "Detection" section accurate?
+If not, what signal would have caught it earlier?
+
+## Resolution
+
+What was done to fully resolve the incident (not just mitigate). Link the PRs,
+commits, or config changes that constitute the permanent fix.
+
+## What Went Well
+
+Concrete things that helped. Tools, runbooks, alerts, or people that worked
+as intended.
+
+## What Went Poorly
+
+Concrete things that hurt. Missing alerts, slow detection, broken runbook
+steps, unclear ownership, manual toil, etc.
+
+## Action Items
+
+| # | Owner | Due | Description | Tracking issue |
+|---|-------|-----|-------------|----------------|
+| 1 |       |     |             |                |
+| 2 |       |     |             |                |
+
+Each action item must be:
+
+- assigned to a single owner,
+- have an explicit due date,
+- linked to a tracked issue in `D-sorganization/Runner_Dashboard` (or the
+  appropriate sibling repo).
+
+## Runbook Updates
+
+List every runbook in `docs/runbooks/` that should be updated based on this
+incident, and what specifically should change. If a new runbook is needed,
+add it here and open an issue.
+
+## Related Links
+
+- Incident channel transcript:
+- Affected PRs / commits:
+- Relevant dashboard screenshots:
+- Sibling-repo issues (`Repository_Management`, `Maxwell-Daemon`):

--- a/docs/runbooks/push-notifications-broken.md
+++ b/docs/runbooks/push-notifications-broken.md
@@ -1,0 +1,96 @@
+# Runbook: Push Notifications Broken
+
+The dashboard's web-push notification path (subscribe / send / test) is not
+delivering alerts. Operators stop receiving incident pings even though the
+dashboard itself appears healthy.
+
+## Symptom
+
+- A subscribed device stops receiving push notifications.
+- The "Send test push" button in the dashboard returns a non-2xx or returns
+  2xx but the device never receives the push.
+- `journalctl -u runner-dashboard` shows repeated push-related errors
+  (e.g. `UnconfiguredPushTransport`, `410 Gone`, `invalid VAPID`).
+- A new operator cannot subscribe a device — `POST /api/push/subscribe`
+  returns 4xx.
+
+## Severity
+
+**P2** by default (operators lose proactive paging but the dashboard UI
+still surfaces incidents).
+**P1** if push is the only paging path configured for an on-call rotation.
+
+## Detection
+
+- Operators report no test push received.
+- `curl -fsS http://localhost:8321/api/push/vapid-public-key` returns empty
+  or errors.
+- Backend logs show traffic to `backend/push.py` ending in non-2xx.
+- The push transport reports "unconfigured" — i.e. the
+  `UnconfiguredPushTransport` class in `backend/push.py` is in use.
+
+## Diagnosis
+
+```bash
+# 1. Confirm the public VAPID key is being served.
+curl -fsS http://localhost:8321/api/push/vapid-public-key | jq '.'
+
+# 2. Send a test push to a known subscription via the dashboard endpoint.
+#    (Replace <topic> with a valid topic the device is subscribed to.)
+curl -fsS -X POST http://localhost:8321/api/push/test \
+  -H 'Content-Type: application/json' \
+  -d '{"topic":"<topic>","title":"runbook test","body":"hello"}'
+
+# 3. Inspect the push subscription store (sqlite, path resolved by
+#    backend/push.py::_db_path()).
+SUBS_DB=$(python3 -c "from backend.push import _db_path; print(_db_path())")
+sqlite3 "$SUBS_DB" 'SELECT id, endpoint, topics, created_at FROM subscriptions LIMIT 10;'
+
+# 4. Tail recent push-related log lines.
+sudo journalctl -u runner-dashboard --since "1 hour ago" --no-pager \
+  | grep -Ei 'push|vapid|subscription|410|401'
+
+# 5. Confirm the configured transport is not the unconfigured stub.
+curl -fsS http://localhost:8321/api/health | jq '.push // .components.push'
+```
+
+## Mitigation
+
+```bash
+# A. If the VAPID keys are missing or rotated, rebuild and restart.
+#    Update the env file with VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY values.
+sudoedit ~/.config/runner-dashboard/env
+sudo systemctl restart runner-dashboard
+curl -fsS http://localhost:8321/api/push/vapid-public-key | jq '.'
+
+# B. If individual subscriptions return 410 Gone, the device unsubscribed.
+#    backend/push.py::_delete_stale_subscription removes them automatically;
+#    if it failed, prune manually:
+sqlite3 "$SUBS_DB" "DELETE FROM subscriptions WHERE last_error_code = 410;"
+
+# C. If the transport is the unconfigured stub, set a real one.
+#    In production, configure pywebpush via env, then:
+sudo systemctl restart runner-dashboard
+
+# D. Re-subscribe affected devices (tap "Enable notifications" again in
+#    the dashboard UI). The browser will issue a fresh subscription.
+```
+
+## Resolution
+
+- If VAPID keys leaked or expired, treat as a credential rotation
+  (cross-reference `secrets-compromise.md`) and re-issue subscriptions.
+- If the bug is in `backend/push.py`, add a pydantic-validated regression
+  test under `tests/api/test_push.py` that exercises the failing path
+  (subscribe, send, validate stale-pruning).
+- If browsers return 410 in bursts, confirm `_delete_stale_subscription` is
+  wired into the failure path and adds telemetry on prune count.
+- If the transport is silently `UnconfiguredPushTransport` in production,
+  add a startup health check that fails fast when push is required but
+  unconfigured.
+- Update operator docs to confirm browser permissions and device-side
+  notification settings as a first triage step.
+
+## Postmortem Template
+
+[`postmortem-template.md`](./postmortem-template.md)

--- a/docs/runbooks/queue-stuck.md
+++ b/docs/runbooks/queue-stuck.md
@@ -1,0 +1,95 @@
+# Runbook: Queue Stuck
+
+GitHub Actions queue depth is growing without draining; workflow runs are
+stuck in `queued` or `in_progress` long past their normal duration.
+
+## Symptom
+
+- Queue Health tab shows persistent or growing `queued_count` /
+  `in_progress_count`.
+- Dashboard's `/api/queue` returns runs older than the configured stale
+  threshold (default driven by `backend/queue_cleanup.py`).
+- Workflow_dispatch agent jobs never start, even with idle runners visible.
+- "Stale runs" badge appears in the Queue Health tab.
+
+## Severity
+
+**P1** if no work is draining at all (full queue stall).
+**P2** if some labels drain but a specific subset is stuck and CI work
+is partially blocked.
+**P3** if a single old run is stuck but the rest of the queue flows.
+
+## Detection
+
+- Queue Health tab highlights stale runs.
+- `curl -fsS http://localhost:8321/api/queue/stale` returns a non-empty list
+  (this endpoint is backed by `backend/queue_cleanup.find_stale_runs`).
+- `curl -fsS http://localhost:8321/api/queue/diagnose` shows runs older than
+  the threshold.
+- `gh run list --status queued --limit 50` shows runs older than ~30 min.
+- Operators on slack/Discord report jobs not starting.
+
+## Diagnosis
+
+```bash
+# 1. Get the dashboard's view of stale runs (uses queue_cleanup.py helpers).
+curl -fsS http://localhost:8321/api/queue/stale | jq '.'
+
+# 2. Drill into queue diagnostics for cross-repo summary.
+curl -fsS http://localhost:8321/api/queue/diagnose | jq '.'
+
+# 3. Direct GitHub query for any queued/in-progress runs older than 30 min.
+gh api -X GET 'repos/D-sorganization/Runner_Dashboard/actions/runs' \
+  -f status=queued --jq '.workflow_runs[] | {id,name,created_at,status}'
+
+# 4. Are runners idle while jobs queue? (label mismatch is the usual cause.)
+gh api orgs/D-sorganization/actions/runners \
+  --jq '.runners[] | {name, status, busy, labels: [.labels[].name]}'
+
+# 5. Inspect recent dashboard logs for cancellation failures.
+sudo journalctl -u runner-dashboard -n 200 --no-pager | grep -i 'queue\|cancel\|stale'
+```
+
+## Mitigation
+
+```bash
+# A. Use the dashboard's bulk purge (calls queue_cleanup.purge_stale_runs).
+#    The Queue Health tab "Purge stale" button calls the same endpoint.
+curl -fsS -X POST http://localhost:8321/api/queue/purge-stale | jq '.'
+
+# B. Cancel a single specific run via the dashboard.
+curl -fsS -X POST \
+  http://localhost:8321/api/runs/<repo>/cancel/<run_id>
+
+# C. Cancel directly via gh as a fallback.
+gh run cancel <run_id> --repo D-sorganization/<repo>
+
+# D. If the stall is caused by missing label coverage, scale runners up.
+sudo systemctl restart runner-autoscaler
+# or manually start an idle runner unit
+sudo systemctl start 'actions.runner.D-sorganization-<repo>.<runner>.service'
+```
+
+The hourly `deploy/scheduled-dashboard-maintenance.sh` cron also performs
+stale-queue purges; if cron was disabled, re-enable it.
+
+## Resolution
+
+- Tune the staleness threshold in `backend/queue_cleanup.py` if real long
+  jobs are being false-positived as stale.
+- If a workflow consistently produces stuck runs, add a `timeout-minutes:`
+  cap to the job and a regression test in `tests/api/` covering the cancel
+  path.
+- Confirm `deploy/scheduled-dashboard-maintenance.sh` is in cron and ran in
+  the last hour:
+  ```bash
+  crontab -l | grep scheduled-dashboard-maintenance
+  ls -lt ~/.cache/runner-dashboard/maintenance.log | head -3
+  ```
+- If a label-mismatch caused the stall, fix workflow `runs-on:` or update
+  `backend/machine_registry.yml` so dispatch targets a label that exists.
+- File a postmortem if the stall affected more than one repo.
+
+## Postmortem Template
+
+[`postmortem-template.md`](./postmortem-template.md)

--- a/docs/runbooks/runner-offline.md
+++ b/docs/runbooks/runner-offline.md
@@ -1,0 +1,97 @@
+# Runbook: Runner Offline
+
+One or more self-hosted GitHub Actions runners in the D-sorganization fleet
+are reporting `offline` to GitHub or are not picking up jobs.
+
+## Symptom
+
+- The Fleet tab in the dashboard shows runners with red/offline status.
+- GitHub repo settings page shows runners as `Offline`.
+- Workflow runs sit `queued` indefinitely with no assignment.
+- Operators report jobs that should match a runner label never start.
+- `journalctl` for `actions.runner.*` reports auth errors or missing token.
+
+## Severity
+
+**P1** if the entire fleet (or the only runner servicing a critical label)
+is offline — CI is fully blocked.
+**P2** if at least one runner per required label is still online and queue
+depth is bounded.
+
+## Detection
+
+- Dashboard Fleet tab marks the row red and surfaces the last-seen timestamp.
+- `gh api orgs/D-sorganization/actions/runners` shows `status: "offline"`.
+- Queue Health tab shows growing `queued` count without a matching
+  `in_progress` increase.
+- `systemctl status 'actions.runner.*'` on the host reports `failed` or
+  `inactive`.
+
+## Diagnosis
+
+Run on the host that owns the affected runner(s):
+
+```bash
+# 1. Which runner units exist and what state are they in?
+systemctl list-units 'actions.runner.*' --all --no-pager
+
+# 2. Tail logs for the unhealthy runner (replace name accordingly).
+sudo journalctl -u 'actions.runner.D-sorganization-*.service' -n 200 --no-pager
+
+# 3. Cross-check what GitHub thinks of the fleet.
+gh api orgs/D-sorganization/actions/runners \
+  --jq '.runners[] | {name, status, busy, labels: [.labels[].name]}'
+
+# 4. Confirm the host can reach GitHub.
+curl -fsS -m 5 https://api.github.com/zen
+
+# 5. Check the dashboard's view of fleet health.
+curl -fsS http://localhost:8321/api/health
+curl -fsS http://localhost:8321/api/fleet/runners | jq '.[] | {name,status,busy}'
+
+# 6. If autoscaler is in use, confirm it is running.
+sudo systemctl status runner-autoscaler --no-pager
+```
+
+## Mitigation
+
+```bash
+# A. Restart the offending runner unit (most common fix).
+sudo systemctl restart 'actions.runner.D-sorganization-<repo>.<runner>.service'
+
+# B. If the unit is missing or auth is broken, re-register the runner.
+#    Pull a fresh registration token via gh, then run the runner's config.sh.
+gh api -X POST orgs/D-sorganization/actions/runners/registration-token \
+  --jq .token
+cd ~/actions-runners/<runner-dir>
+./config.sh remove --token <removal-token>   # if previously registered
+./config.sh --url https://github.com/D-sorganization \
+  --token <registration-token> \
+  --labels <labels> --unattended --replace
+sudo systemctl restart 'actions.runner.*'
+
+# C. If multiple runners are offline simultaneously, suspect token/network.
+#    Refresh the dashboard token and confirm Tailscale is up.
+bash ~/actions-runners/dashboard/deploy/refresh-token.sh
+tailscale status | head
+```
+
+If runners cannot be brought back quickly, announce a CI freeze in the
+operator channel and pause merges that depend on the affected labels.
+
+## Resolution
+
+- If the cause was an expired PAT, rotate the org-level token, store it in
+  `~/.config/runner-dashboard/env` (chmod 600), and update any per-runner
+  registration tokens. Add a calendar reminder for the next rotation.
+- If a deploy or OS update removed the runner unit, restore via
+  `deploy/setup.sh` and re-register the runner.
+- If runners drop offline repeatedly, capture the failure window from
+  `journalctl` and open a P2 issue. Consider adding a watchdog in
+  `backend/runner_autoscaler.py` to detect and respawn.
+- Update `backend/machine_registry.yml` if a node is permanently retired.
+- File a postmortem when more than one runner went offline simultaneously.
+
+## Postmortem Template
+
+[`postmortem-template.md`](./postmortem-template.md)

--- a/docs/runbooks/secrets-compromise.md
+++ b/docs/runbooks/secrets-compromise.md
@@ -1,0 +1,107 @@
+# Runbook: Secrets Compromise
+
+A token, PAT, VAPID key, or other credential used by the dashboard or fleet
+has been (or is suspected of being) leaked. Treat this as time-critical.
+
+## Symptom
+
+- A `GH_TOKEN`, `GITHUB_TOKEN`, registration token, VAPID private key, or
+  similar credential appears in a public commit, log, screenshot, issue, or
+  external paste.
+- GitHub Secret Scanning fires on a push to any D-sorganization repo.
+- Unexpected API activity is observed in `gh api /audit-log` or in
+  `journalctl -u runner-dashboard` (e.g. requests from unfamiliar IPs).
+- A teammate, contractor, or vendor with credential access has departed
+  without a credential rotation having been performed.
+
+## Severity
+
+**P1** — every suspected leak is treated as a real leak. Rotate first,
+investigate second.
+
+## Detection
+
+- `gh secret list` and `gh api /repos/D-sorganization/Runner_Dashboard/secret-scanning/alerts`
+  for native secret scanning alerts.
+- `mcp__github__run_secret_scanning` (or the same endpoint via gh) on the
+  affected repo.
+- Anomalies in the dashboard's recent action feed.
+- Out-of-band reports from contributors.
+
+## Diagnosis
+
+```bash
+# 1. Confirm the leak: check the commit, paste, or log directly.
+gh api repos/D-sorganization/Runner_Dashboard/secret-scanning/alerts \
+  --jq '.[] | {number,state,secret_type,created_at,html_url}'
+
+# 2. Identify what the credential touches. For GH_TOKEN, check scopes:
+gh auth status
+
+# 3. Inspect recent dashboard env file metadata (do NOT print contents).
+ls -la ~/.config/runner-dashboard/env
+stat ~/.config/runner-dashboard/env
+
+# 4. Look for anomalous use in dashboard logs (last 6 hours).
+sudo journalctl -u runner-dashboard --since "6 hours ago" --no-pager \
+  | grep -Ei 'denied|401|403|unauthor|invalid token'
+
+# 5. Audit org actions for unexpected dispatches in the last 24h.
+gh api -X GET 'orgs/D-sorganization/actions/runs' \
+  --paginate --jq '.workflow_runs[] | select(.created_at > (now - 86400 | todate))
+                  | {repo: .repository.full_name, name, actor: .actor.login, created_at}'
+```
+
+## Mitigation
+
+Rotate immediately, then contain. Do all of the following, in order:
+
+```bash
+# A. Revoke the leaked credential at the source.
+#    - For a GitHub PAT: revoke at https://github.com/settings/tokens
+#    - For a fine-grained token: revoke under Settings → Developer settings.
+#    - For an org-installation token: rotate the GitHub App's webhook secret.
+#    - For VAPID keys: regenerate via deploy script and re-issue subscriptions.
+
+# B. Replace the credential everywhere it is consumed.
+#    Dashboard env file (chmod 600 always):
+sudo install -m 600 -o "$USER" -g "$USER" /dev/null \
+  ~/.config/runner-dashboard/env.new
+# edit ~/.config/runner-dashboard/env.new with the new GH_TOKEN
+mv ~/.config/runner-dashboard/env.new ~/.config/runner-dashboard/env
+sudo systemctl restart runner-dashboard
+
+# C. Refresh runner registration tokens if a registration token leaked.
+gh api -X POST orgs/D-sorganization/actions/runners/registration-token
+
+# D. Force-purge any in-memory caches that may hold the stale token.
+sudo systemctl restart runner-dashboard
+sudo systemctl restart runner-autoscaler
+
+# E. If the leak was in a public commit, scrub history with care.
+#    Prefer rotating the secret and leaving history intact unless the
+#    secret cannot be revoked. Forced history rewrites are last-resort.
+```
+
+Notify the security owner via the operator channel; do not announce the
+leaked value publicly.
+
+## Resolution
+
+- File a P1 issue (private repo if the leak is sensitive) capturing what
+  leaked, where, when, the rotation evidence, and follow-up actions.
+- Add a pre-commit hook locally and verify `gitleaks` / `bandit` would
+  have caught the pattern; tighten if not.
+- Confirm `bandit` rules and `pip-audit` step in `ci-standard.yml` did not
+  miss anything obvious.
+- Update `deploy/refresh-token.sh` if its rotation cadence is too long.
+- Audit who has access to `~/.config/runner-dashboard/env` on every fleet
+  host; revoke as needed.
+- Schedule a follow-up rotation reminder (calendar event) within the
+  credential's natural rotation window.
+- File a postmortem and assign action items to a single owner with
+  due dates.
+
+## Postmortem Template
+
+[`postmortem-template.md`](./postmortem-template.md)


### PR DESCRIPTION
## Summary

Adds 7 operational runbooks under `docs/runbooks/` for the most common dashboard failure modes:

- `ci-failure-triage.md`
- `dashboard-down.md`
- `deploy-rollback.md`
- `push-notifications-broken.md`
- `queue-stuck.md`
- `runner-offline.md`
- `secrets-compromise.md`

Plus `postmortem-template.md` for follow-up writeups.

Each runbook follows the standard shape: **Symptom → Severity → Detection → Diagnosis → Mitigation → Resolution → Postmortem template link**, with concrete commands grounded in real dashboard endpoints, systemd units, and workflow files.

Does not touch the existing `dev-environment.md` runbook from PR #438.

Closes #397

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMid1Kh97BsHj6FggNW5vJ)_