### PR TITLE
feat(ux): Badge and Pill primitives, replace 5+ ad-hoc usages (#422)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 ﻿# SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.13
+**Spec Version:** 2.5.14
 **Application Version:** 4.1.0 (see `VERSION`)
 **Last Updated:** 2026-04-30T00:00:00Z
 **Status:** Active
@@ -174,6 +174,8 @@ mobile-only read surface for runner monitoring cards over the existing runner,
 run, and machine telemetry payloads; desktop machine and runner tables remain
 the canonical wide-screen surface.
 
+
+Reusable UI primitives live in `frontend/src/primitives/`. Issue #422 introduces `Badge.tsx` (`tone` in `success | warning | danger | info | neutral`, `size` in `sm | md`) and `Pill.tsx` (with a `selected` boolean prop) so that the previously ad-hoc `.section-badge`, `.runner-status-badge`, `.conclusion-badge`, `.subtab-badge`, and `.fleet-status-pill` styles share a single token-driven implementation backed by `--badge-*-bg` / `--badge-*-fg` CSS variables in `frontend/src/design/tokens.ts`.
 
 PushSettings (issue #192) is a mobile-friendly React component for per-topic Web Push subscription management. It is located at `frontend/src/pages/PushSettings.tsx` and uses `GET /api/push/vapid-public-key` to fetch the VAPID key before subscribing to selected push topics via `POST /api/push/subscribe`.
 The Vite entrypoint in `frontend/src/main.tsx` includes a minimal tracer-bullet route shim for `/settings/push`: when the browser pathname resolves to that route, it renders `PushSettings` directly; all other paths continue to render the main dashboard app. This keeps the PushSettings work isolated while the Vite migration remains in progress.

--- a/frontend/src/design/index.ts
+++ b/frontend/src/design/index.ts
@@ -2,6 +2,7 @@
 // All tokens, primitives, and theme utilities are reachable from here.
 
 export {
+  badgeTokens,
   colorTokens,
   surfaceTokens,
   spacingTokens,

--- a/frontend/src/design/tokens.ts
+++ b/frontend/src/design/tokens.ts
@@ -20,6 +20,22 @@ export const colorTokens = {
   accentOrange: "#f0883e",
 } as const;
 
+// Badge tints — paired background + foreground colours used by
+// the <Badge /> primitive. Each tone has a low-alpha tinted background
+// and a saturated foreground colour matching the same accent family.
+export const badgeTokens = {
+  successBg: "rgba(63, 185, 80, 0.15)",
+  successFg: "#3fb950",
+  warningBg: "rgba(210, 153, 34, 0.15)",
+  warningFg: "#d29922",
+  dangerBg: "rgba(248, 81, 73, 0.15)",
+  dangerFg: "#f85149",
+  infoBg: "rgba(88, 166, 255, 0.15)",
+  infoFg: "#58a6ff",
+  neutralBg: "rgba(110, 118, 129, 0.15)",
+  neutralFg: "#8b949e",
+} as const;
+
 export const surfaceTokens = {
   glassBg: "rgba(28, 33, 51, 0.7)",
   glassBorder: "rgba(255, 255, 255, 0.1)",
@@ -74,6 +90,17 @@ export const cssVariableMap = {
   "--accent-yellow": colorTokens.accentYellow,
   "--accent-purple": colorTokens.accentPurple,
   "--accent-orange": colorTokens.accentOrange,
+
+  "--badge-success-bg": badgeTokens.successBg,
+  "--badge-success-fg": badgeTokens.successFg,
+  "--badge-warning-bg": badgeTokens.warningBg,
+  "--badge-warning-fg": badgeTokens.warningFg,
+  "--badge-danger-bg": badgeTokens.dangerBg,
+  "--badge-danger-fg": badgeTokens.dangerFg,
+  "--badge-info-bg": badgeTokens.infoBg,
+  "--badge-info-fg": badgeTokens.infoFg,
+  "--badge-neutral-bg": badgeTokens.neutralBg,
+  "--badge-neutral-fg": badgeTokens.neutralFg,
 
   "--glass-bg": surfaceTokens.glassBg,
   "--glass-border": surfaceTokens.glassBorder,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,6 +16,19 @@
   --accent-purple: #bc8cff;
   --accent-orange: #f0883e;
   --mobile-hit-target: 44px;
+
+  /* Badge tints — paired bg/fg colours used by <Badge /> primitive.
+     Mirror of badgeTokens in frontend/src/design/tokens.ts. */
+  --badge-success-bg: rgba(63, 185, 80, 0.15);
+  --badge-success-fg: #3fb950;
+  --badge-warning-bg: rgba(210, 153, 34, 0.15);
+  --badge-warning-fg: #d29922;
+  --badge-danger-bg: rgba(248, 81, 73, 0.15);
+  --badge-danger-fg: #f85149;
+  --badge-info-bg: rgba(88, 166, 255, 0.15);
+  --badge-info-fg: #58a6ff;
+  --badge-neutral-bg: rgba(110, 118, 129, 0.15);
+  --badge-neutral-fg: #8b949e;
   
   /* Glassmorphism Tokens */
   --glass-bg: rgba(28, 33, 51, 0.7);

--- a/frontend/src/legacy/App.tsx
+++ b/frontend/src/legacy/App.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import { AgentDispatchPage } from "../pages/AgentDispatch"
 import { QueueTab } from "../pages/Queue"
+import { Badge } from "../primitives/Badge"
+import { Pill } from "../primitives/Pill"
 import { marked } from "marked"
 import DOMPurify from "dompurify"
 
@@ -432,7 +434,7 @@ function Collapse(p) {
         p.icon,
         p.title,
         p.badge
-          ? h("span", { className: "section-badge" }, p.badge)
+          ? h(Badge, { tone: "neutral" }, p.badge)
           : null,
       ),
       h(
@@ -485,7 +487,7 @@ function SubTabs(p) {
           },
           tab.label,
           tab.badge != null
-            ? h("span", { className: "subtab-badge" }, tab.badge)
+            ? h(Badge, { tone: activeKey === tab.key ? "info" : "neutral", size: "sm" }, tab.badge)
             : null,
         );
       }),
@@ -1219,12 +1221,8 @@ function FleetTab(p) {
                 "td",
                 null,
                 h(
-                  "span",
-                  {
-                    className:
-                      "runner-status-badge " +
-                      (n.online ? "online" : "offline"),
-                  },
+                  Badge,
+                  { tone: n.online ? "success" : "danger" },
                   n.online ? "online" : "offline",
                 ),
               ),
@@ -1329,20 +1327,18 @@ function FleetTab(p) {
             { key: "offline", label: "Offline", count: offline, dot: "red" },
           ].map(function (item) {
             return h(
-              "button",
+              Pill,
               {
                 key: item.key,
-                className:
-                  "btn fleet-status-pill" +
-                  (filter === item.key ? " btn-green" : ""),
+                className: "fleet-status-pill",
                 onClick: function () {
                   setFilter(item.key);
                 },
-                "aria-pressed": filter === item.key,
+                selected: filter === item.key,
               },
               h("span", { className: "status-dot " + item.dot }),
               item.label,
-              h("span", { className: "section-badge" }, item.count),
+              h(Badge, { tone: "neutral" }, item.count),
             );
           }),
         ),

--- a/frontend/src/pages/AgentDispatch.tsx
+++ b/frontend/src/pages/AgentDispatch.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
+import { Badge } from "../primitives/Badge";
 import { TouchButton } from "../primitives/TouchButton";
 
 /**
@@ -233,10 +234,12 @@ export function AgentDispatchPage() {
       <button key={provider.id} aria-pressed={isSelected} data-touch-primitive="TouchButton" disabled={!isAvailable} onClick={() => selectProvider(provider.id)} className={`provider-card ${isSelected ? "selected" : ""} ${isAvailable ? "" : "unavailable"}`}>
         <div className="provider-header">
           <span className="label">{provider.label}</span>
-          <span className={`status ${isAvailable ? "ready" : "missing"}`}>{isAvailable ? "Ready" : provider.status}</span>
+          <Badge tone={isAvailable ? "success" : "danger"}>
+            {isAvailable ? "Ready" : provider.status}
+          </Badge>
         </div>
         {provider.notes && <span className="notes">{provider.notes}</span>}
-        {provider.experimental && <span className="experimental">Experimental</span>}
+        {provider.experimental && <Badge tone="warning">Experimental</Badge>}
       </button>
     );
   }

--- a/frontend/src/pages/Fleet/RunnerCard.tsx
+++ b/frontend/src/pages/Fleet/RunnerCard.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { Badge, type BadgeTone } from "../../primitives/Badge";
+
 export interface RunnerCardProps {
   cpuPercent: number;
   currentJob?: string | null;
@@ -67,6 +69,8 @@ export function RunnerCard({
 }: RunnerCardProps) {
   const statusColor = status === "online" ? "#3fb950" : status === "busy" ? "#d29922" : "#f85149";
   const statusText = status === "online" ? "Online" : status === "busy" ? "Busy" : "Offline";
+  const statusTone: BadgeTone =
+    status === "online" ? "success" : status === "busy" ? "warning" : "danger";
 
   return (
     <article
@@ -83,16 +87,9 @@ export function RunnerCard({
         <h3 className="runner-name" style={{ fontSize: "14px", fontWeight: 600 }}>
           {name}
         </h3>
-        <span
-          className="runner-status-dot"
-          style={{
-            background: statusColor,
-            borderRadius: "50%",
-            display: "inline-block",
-            height: "8px",
-            width: "8px",
-          }}
-        />
+        <Badge size="sm" tone={statusTone}>
+          {statusText}
+        </Badge>
       </div>
       <div className="runner-meta" style={{ color: "var(--text-secondary)", fontSize: "12px", marginBottom: "8px" }}>
         {machine} · {fmtUptime(uptimeSeconds)}

--- a/frontend/src/pages/Fleet/StatusPill.tsx
+++ b/frontend/src/pages/Fleet/StatusPill.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Pill } from "../../primitives/Pill";
 
 export type RunnerStatus = "online" | "busy" | "offline";
 
@@ -11,34 +11,27 @@ export interface StatusPillProps {
 }
 
 const statusColors: Record<RunnerStatus, { bg: string; text: string }> = {
-  online: { bg: "rgba(63,185,80,0.15)", text: "#3fb950" },
-  busy: { bg: "rgba(210,153,34,0.15)", text: "#d29922" },
-  offline: { bg: "rgba(248,81,73,0.15)", text: "#f85149" },
+  online: { bg: "var(--badge-success-bg)", text: "var(--badge-success-fg)" },
+  busy: { bg: "var(--badge-warning-bg)", text: "var(--badge-warning-fg)" },
+  offline: { bg: "var(--badge-danger-bg)", text: "var(--badge-danger-fg)" },
 };
 
 export function StatusPill({ count, label, onClick, selected, status }: StatusPillProps) {
   const colors = statusColors[status];
   return (
-    <button
+    <Pill
       aria-pressed={selected}
-      className={`status-pill ${selected ? "status-pill-active" : ""}`}
+      className={`status-pill status-pill-${status}${selected ? " status-pill-active" : ""}`}
       onClick={onClick}
+      selected={selected}
       style={{
         background: colors.bg,
         border: `1px solid ${selected ? colors.text : "transparent"}`,
-        borderRadius: "9999px",
         color: colors.text,
-        cursor: onClick ? "pointer" : "default",
         fontSize: "12px",
-        fontWeight: 600,
         minHeight: "32px",
         padding: "6px 12px",
-        textAlign: "center",
-        touchAction: "manipulation",
-        userSelect: "none",
-        whiteSpace: "nowrap",
       }}
-      type="button"
     >
       <span aria-label={`${count} ${label}`} className="status-pill-count">
         {count}
@@ -46,6 +39,6 @@ export function StatusPill({ count, label, onClick, selected, status }: StatusPi
       <span className="status-pill-label" style={{ marginLeft: "4px", opacity: 0.85 }}>
         {label}
       </span>
-    </button>
+    </Pill>
   );
 }

--- a/frontend/src/pages/Queue/index.tsx
+++ b/frontend/src/pages/Queue/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Badge } from "../../primitives/Badge";
 
 const h = React.createElement;
 
@@ -127,7 +128,7 @@ function Collapse(p: any) {
         p.icon,
         p.title,
         p.badge
-          ? h("span", { className: "section-badge" }, p.badge)
+          ? h(Badge, { tone: "neutral" }, p.badge)
           : null,
       ),
       h(
@@ -848,8 +849,8 @@ export function QueueTab(p: QueueTabProps) {
                       "td",
                       null,
                       h(
-                        "span",
-                        { className: "conclusion-badge in_progress" },
+                        Badge,
+                        { tone: "warning" },
                         "running",
                       ),
                     ),

--- a/frontend/src/primitives/Badge.tsx
+++ b/frontend/src/primitives/Badge.tsx
@@ -1,0 +1,51 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+export type BadgeTone = "success" | "warning" | "danger" | "info" | "neutral";
+export type BadgeSize = "sm" | "md";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+  size?: BadgeSize;
+  tone?: BadgeTone;
+}
+
+const sizeStyles: Record<BadgeSize, { fontSize: string; padding: string }> = {
+  sm: { fontSize: "10px", padding: "1px 6px" },
+  md: { fontSize: "11px", padding: "2px 8px" },
+};
+
+export function Badge({
+  children,
+  className = "",
+  size = "md",
+  tone = "neutral",
+  style,
+  ...props
+}: BadgeProps) {
+  const sizing = sizeStyles[size];
+  const classes = ["badge", `badge-tone-${tone}`, `badge-size-${size}`, className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span
+      {...props}
+      className={classes}
+      data-touch-primitive="Badge"
+      style={{
+        background: `var(--badge-${tone}-bg)`,
+        borderRadius: "10px",
+        color: `var(--badge-${tone}-fg)`,
+        display: "inline-block",
+        fontSize: sizing.fontSize,
+        fontWeight: 500,
+        padding: sizing.padding,
+        textTransform: "capitalize",
+        whiteSpace: "nowrap",
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/primitives/Pill.tsx
+++ b/frontend/src/primitives/Pill.tsx
@@ -1,0 +1,52 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+export interface PillProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  selected?: boolean;
+}
+
+export function Pill({
+  children,
+  className = "",
+  onClick,
+  selected = false,
+  style,
+  type = "button",
+  ...props
+}: PillProps) {
+  const classes = ["pill", selected ? "pill-selected" : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      {...props}
+      aria-pressed={selected}
+      className={classes}
+      data-touch-primitive="Pill"
+      onClick={onClick}
+      style={{
+        alignItems: "center",
+        background: selected ? "var(--badge-info-bg)" : "var(--bg-tertiary)",
+        border: `1px solid ${selected ? "var(--accent-blue)" : "transparent"}`,
+        borderRadius: "9999px",
+        color: selected ? "var(--badge-info-fg)" : "var(--text-secondary)",
+        cursor: onClick ? "pointer" : "default",
+        display: "inline-flex",
+        fontSize: "12px",
+        fontWeight: 600,
+        gap: "6px",
+        minHeight: "30px",
+        padding: "6px 12px",
+        textAlign: "center",
+        touchAction: "manipulation",
+        userSelect: "none",
+        whiteSpace: "nowrap",
+        ...style,
+      }}
+      type={type}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/primitives/index.ts
+++ b/frontend/src/primitives/index.ts
@@ -1,3 +1,7 @@
+export { Badge } from "./Badge";
+export type { BadgeProps, BadgeSize, BadgeTone } from "./Badge";
+export { Pill } from "./Pill";
+export type { PillProps } from "./Pill";
 export { SegmentedControl } from "./SegmentedControl";
 export type { SegmentedControlOption, SegmentedControlProps } from "./SegmentedControl";
 export { TouchButton } from "./TouchButton";

--- a/tests/frontend/test_badge_pill_primitives.py
+++ b/tests/frontend/test_badge_pill_primitives.py
@@ -1,0 +1,113 @@
+"""Tests for the Badge and Pill UI primitives.
+
+These tests parse the TSX source files for the new primitives introduced
+in issue #422 and assert that:
+
+* `frontend/src/primitives/Badge.tsx` exposes the five canonical tones
+  (`success`, `warning`, `danger`, `info`, `neutral`) and the two sizes
+  (`sm`, `md`).
+* `frontend/src/primitives/Pill.tsx` exposes a `selected` prop.
+* At least five consumer files import from the new primitives.
+
+The tests intentionally parse source rather than execute the React tree —
+the dashboard frontend is exercised via Vite/Vitest in browser CI, while
+this Python suite enforces the structural contract that downstream code
+relies on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRIMITIVES_DIR = REPO_ROOT / "frontend" / "src" / "primitives"
+SRC_DIR = REPO_ROOT / "frontend" / "src"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"expected {path} to exist"
+    return path.read_text(encoding="utf-8")
+
+
+def test_badge_primitive_exports_five_tones() -> None:
+    """Badge.tsx must declare BadgeTone with all five tones."""
+    source = _read(PRIMITIVES_DIR / "Badge.tsx")
+    for tone in ("success", "warning", "danger", "info", "neutral"):
+        assert f'"{tone}"' in source, f"Badge.tsx missing tone '{tone}'"
+    assert "BadgeTone" in source, "Badge.tsx must export BadgeTone type"
+
+
+def test_badge_primitive_exports_two_sizes() -> None:
+    """Badge.tsx must declare BadgeSize with 'sm' and 'md'."""
+    source = _read(PRIMITIVES_DIR / "Badge.tsx")
+    for size in ("sm", "md"):
+        assert f'"{size}"' in source, f"Badge.tsx missing size '{size}'"
+    assert "BadgeSize" in source, "Badge.tsx must export BadgeSize type"
+
+
+def test_badge_primitive_default_tone_is_neutral() -> None:
+    """Badge default tone must be 'neutral' (lowest visual weight)."""
+    source = _read(PRIMITIVES_DIR / "Badge.tsx")
+    assert 'tone = "neutral"' in source, "Badge.tsx must default tone to 'neutral'"
+    assert 'size = "md"' in source, "Badge.tsx must default size to 'md'"
+
+
+def test_pill_primitive_exports_selected_prop() -> None:
+    """Pill.tsx must accept a `selected` boolean prop."""
+    source = _read(PRIMITIVES_DIR / "Pill.tsx")
+    assert "selected?: boolean" in source, "Pill.tsx must declare selected?: boolean"
+    assert "selected = false" in source, "Pill.tsx must default selected to false"
+
+
+def test_pill_primitive_uses_aria_pressed() -> None:
+    """Pill.tsx must wire selected -> aria-pressed for accessibility."""
+    source = _read(PRIMITIVES_DIR / "Pill.tsx")
+    assert "aria-pressed={selected}" in source
+
+
+def test_primitives_index_re_exports_badge_and_pill() -> None:
+    """The primitives barrel must re-export both new primitives."""
+    source = _read(PRIMITIVES_DIR / "index.ts")
+    assert 'from "./Badge"' in source
+    assert 'from "./Pill"' in source
+    assert "Badge" in source
+    assert "Pill" in source
+
+
+def test_at_least_five_consumer_files_import_primitives() -> None:
+    """Issue #422 requires migrating at least 5 ad-hoc badge usages."""
+    consumers: list[Path] = []
+    for tsx in SRC_DIR.rglob("*.tsx"):
+        # Skip the primitive definitions themselves and their tests.
+        if tsx.is_relative_to(PRIMITIVES_DIR):
+            continue
+        text = tsx.read_text(encoding="utf-8")
+        if (
+            'from "../../primitives/Badge"' in text
+            or 'from "../../primitives/Pill"' in text
+            or 'from "../primitives/Badge"' in text
+            or 'from "../primitives/Pill"' in text
+        ):
+            consumers.append(tsx)
+
+    rels = sorted(str(p.relative_to(REPO_ROOT)) for p in consumers)
+    assert len(consumers) >= 5, (
+        f"expected at least 5 consumer files importing Badge/Pill, "
+        f"found {len(consumers)}: {rels}"
+    )
+
+
+def test_design_tokens_declare_badge_css_variables() -> None:
+    """tokens.ts must register all 10 badge CSS variables."""
+    source = _read(SRC_DIR / "design" / "tokens.ts")
+    for tone in ("success", "warning", "danger", "info", "neutral"):
+        assert f'"--badge-{tone}-bg"' in source
+        assert f'"--badge-{tone}-fg"' in source
+
+
+def test_index_css_declares_badge_css_variables() -> None:
+    """index.css must mirror the badge CSS variables for runtime use."""
+    source = _read(SRC_DIR / "index.css")
+    for tone in ("success", "warning", "danger", "info", "neutral"):
+        assert f"--badge-{tone}-bg:" in source
+        assert f"--badge-{tone}-fg:" in source


### PR DESCRIPTION
## Summary

Consolidate the dashboard's many ad-hoc chip/badge styles (13 distinct CSS classes spread across `legacy/App.tsx` and the new TSX pages) behind two shared primitives so future tabs do not have to re-derive their own tints.

- New `<Badge tone size>` primitive at `frontend/src/primitives/Badge.tsx`:
  - tones: `success`, `warning`, `danger`, `info`, `neutral` (default)
  - sizes: `sm`, `md` (default)
  - Backed by `--badge-{tone}-{bg|fg}` CSS variables registered in `frontend/src/design/tokens.ts` (`badgeTokens`, `cssVariableMap`) and mirrored in `frontend/src/index.css`.
- New `<Pill selected onClick>` primitive at `frontend/src/primitives/Pill.tsx` for filter-chip style toggles. Defaults `selected` to `false` and wires `aria-pressed` for accessibility.
- Both re-exported from `frontend/src/primitives/index.ts`.

## Migrated consumers (5/13)

The highest-traffic ad-hoc usages are now on the new primitives:

| File | Before | After |
|---|---|---|
| `pages/Queue/index.tsx` | `.section-badge`, `.conclusion-badge.in_progress` | `<Badge tone="neutral">`, `<Badge tone="warning">` |
| `pages/Fleet/StatusPill.tsx` | bare `<button>` w/ `.status-pill` | wraps `<Pill>` |
| `pages/Fleet/RunnerCard.tsx` | `runner-status-dot` | `<Badge tone={...}>` |
| `pages/AgentDispatch.tsx` | `.status.ready/.missing`, `.experimental` | `<Badge tone="success/danger/warning">` |
| `legacy/App.tsx` | `.section-badge` (Collapse), `.subtab-badge`, `.runner-status-badge`, `.fleet-status-pill` | `<Badge>` / `<Pill>` |

## Follow-up: 8 unmigrated sites in `legacy/App.tsx`

These are intentionally left for a follow-up PR (most are dynamic `conclusion-badge` mappings that will benefit from a small mapper helper):

1. `legacy/App.tsx:~1571` — `.section-badge` (count chip)
2. `legacy/App.tsx:~1661` — `.runner-status-badge` (state-keyed)
3. `legacy/App.tsx:~1991` — `.conclusion-badge` (CI conclusion)
4. `legacy/App.tsx:~2178` — `.conclusion-badge` (run conclusion)
5. `legacy/App.tsx:~2445` — `.conclusion-badge` (workflow conclusion)
6. `legacy/App.tsx:~2476` — `.conclusion-badge` (variant)
7. `legacy/App.tsx:~2535` — `.conclusion-badge` (variant)
8. `legacy/App.tsx:~3243..4378` — many `.section-badge` count chips (Heavy/Workflows/Reports/Assessments tabs)

A small `conclusionToTone()` helper would handle items 3-7 cleanly; that is deferred to keep this PR scoped to the primitive contract.

## Tests

- `tests/frontend/test_badge_pill_primitives.py` (9 tests, all passing) — parses TSX/CSS sources to assert:
  - `Badge.tsx` declares the 5 tones and 2 sizes
  - `Pill.tsx` declares the `selected` prop and wires `aria-pressed`
  - At least 5 consumer files import from `primitives/Badge` or `primitives/Pill`
  - `tokens.ts` and `index.css` both register the 10 badge CSS variables
- All 55 existing `tests/frontend/` tests still pass.

## Spec / version

- `SPEC.md` Spec Version bumped to `2.5.14`.
- New sentence in §2.2 Frontend documenting the Badge/Pill contract.

## Test plan

- [ ] CI Standard (`ci-standard.yml`): quality-gate, security-scan, tests pass
- [ ] Spec Check (`ci-spec-check.yml`): SPEC bump satisfies the gate
- [ ] Visual smoke: open Queue, Fleet (mobile), Agent Dispatch tabs and confirm badges render with the same tints as before
- [ ] Confirm `aria-pressed` still serialises on `<StatusPill>` (covered by `tests/frontend/test_fleet_mobile.py::test_status_pill_is_clickable_and_aria_pressed`)

Closes #422.

https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT)_