### PR TITLE
feat(scalability): env-driven uvicorn config, bounded _cpu_history, queue_cleanup semaphore (#393)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 ﻿# SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.13
+**Spec Version:** 2.5.14
 **Application Version:** 4.1.0 (see `VERSION`)
 **Last Updated:** 2026-04-30T00:00:00Z
 **Status:** Active
@@ -133,6 +133,24 @@ Backend tests must resolve `backend/` imports consistently from a clean checkout
 The project pytest configuration declares `backend` on `pythonpath`, and
 `tests/conftest.py` also inserts the resolved backend directory before importing
 the FastAPI app and router dependencies.
+
+**Uvicorn runtime tuning (env-var driven, issue #393):**
+
+When `backend/server.py` is invoked as `__main__`, the uvicorn instance is
+configured from environment variables so operators can adjust ASGI
+behaviour without code changes:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WORKERS` | `1` | Worker process count. Stays at `1` until leader-election (#367) lands; setting it higher logs a runtime warning because background tasks would otherwise duplicate across workers. |
+| `LIMIT_CONCURRENCY` | `200` | Max concurrent in-flight requests before uvicorn returns 503. |
+| `TIMEOUT_KEEP_ALIVE` | `5` | Seconds an idle keep-alive HTTP connection is held before closure. |
+
+Invalid values fall back to the default and emit a log warning.
+
+**Bounded in-process buffers:** the CPU sample buffer `_cpu_history` is a
+`collections.deque` capped at `_CPU_HISTORY_MAXLEN` (1000 samples). The
+fixed cap guarantees flat memory regardless of process uptime (#393).
 
 ### 2.2 Frontend
 
@@ -926,6 +944,18 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 ---
 
 ## 7. Changelog
+
+### 2.5.14 - 2026-04-30
+- feat(scalability): drive uvicorn `workers`, `limit_concurrency`, and
+  `timeout_keep_alive` from `WORKERS` / `LIMIT_CONCURRENCY` /
+  `TIMEOUT_KEEP_ALIVE` env vars, with defaults `1` / `200` / `5`. `WORKERS`
+  stays at 1 until leader-election (#367) lands; setting it higher emits a
+  runtime warning. Documented under §2.1 Backend (#393).
+- chore(reliability): cap `_cpu_history` to a `collections.deque` with
+  `maxlen=1000` so the in-process CPU sample buffer cannot grow without
+  bound (#393).
+- chore(reliability): cap `queue_cleanup.find_stale_runs` fan-out to 8
+  concurrent repo queries via `asyncio.Semaphore` (#393).
 
 ### 2.5.11 - 2026-04-29
 - feat: add authenticated session tracking and remote logout endpoints for the

--- a/backend/queue_cleanup.py
+++ b/backend/queue_cleanup.py
@@ -34,7 +34,7 @@ UTC = getattr(_dt, "UTC", _dt.timezone.utc)  # noqa: UP017
 DEFAULT_MIN_AGE_MINUTES: int = 60
 _MAX_REPOS: int = 200
 _MAX_RUNS_PER_REPO: int = 100
-_SCAN_CONCURRENCY: int = 10  # concurrent repo queries during scan
+_SCAN_CONCURRENCY: int = 8  # concurrent repo queries during scan (capped per #393)
 _CANCEL_CONCURRENCY: int = 5  # concurrent cancel calls
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -4238,8 +4238,15 @@ if __name__ == "__main__":
             _uvicorn_cfg["workers"],
         )
 
+    # uvicorn requires an import string (not the in-memory app object) when
+    # running in multi-worker mode — workers spawn via multiprocessing and
+    # each child re-imports the app. Codex P1 review on PR #482 flagged that
+    # passing `app` directly with `workers > 1` either silently runs a single
+    # worker or fails at startup. Use the import string when WORKERS > 1; keep
+    # the in-memory object for single-worker dev runs (faster, no re-import).
+    _uvicorn_target: object = "server:app" if _uvicorn_cfg["workers"] > 1 else app
     uvicorn.run(
-        app,
+        _uvicorn_target,  # type: ignore[arg-type]
         host="0.0.0.0",  # nosec B104 — intentional for local LAN/Tailscale access
         port=PORT,
         log_level="warning",  # FastAPI handles its own logging

--- a/backend/server.py
+++ b/backend/server.py
@@ -265,7 +265,11 @@ EXPECTED_VERSION_FILE = Path(
 
 # ─── Setup moving averages and host memory cache ────────────
 
-_cpu_history: deque[float] = deque(maxlen=60)
+# Bounded CPU history sample buffer.  Size is intentionally capped to prevent
+# unbounded memory growth in long-lived processes (#393).  The deque retains
+# the most recent samples and discards older entries automatically.
+_CPU_HISTORY_MAXLEN: int = 1000
+_cpu_history: deque[float] = deque(maxlen=_CPU_HISTORY_MAXLEN)
 
 
 def _runner_scheduler_apply_command() -> list[str]:
@@ -4184,6 +4188,34 @@ async def _start_background_tasks() -> None:
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
+
+def _read_uvicorn_env_config() -> dict[str, int]:
+    """Read uvicorn tuning knobs from environment variables (#393).
+
+    Returns a dict with ``workers``, ``limit_concurrency`` and
+    ``timeout_keep_alive``.  Defaults are conservative because the
+    leader-election guard (#367) is not yet in place — running with
+    ``WORKERS > 1`` will duplicate background tasks and is therefore *not*
+    the default.  Operators that opt in get a runtime warning.
+    """
+
+    def _int_env(name: str, default: int) -> int:
+        raw = os.environ.get(name, "").strip()
+        if not raw:
+            return default
+        try:
+            return int(raw)
+        except ValueError:
+            log.warning("Invalid %s=%r, falling back to %d", name, raw, default)
+            return default
+
+    return {
+        "workers": _int_env("WORKERS", 1),
+        "limit_concurrency": _int_env("LIMIT_CONCURRENCY", 200),
+        "timeout_keep_alive": _int_env("TIMEOUT_KEEP_ALIVE", 5),
+    }
+
+
 if __name__ == "__main__":
     import uvicorn
 
@@ -4197,10 +4229,22 @@ if __name__ == "__main__":
     log.info("  Runners: %s @ %s", NUM_RUNNERS, RUNNER_BASE_DIR)
     log.info("=" * 60)
 
+    _uvicorn_cfg = _read_uvicorn_env_config()
+    if _uvicorn_cfg["workers"] > 1:
+        log.warning(
+            "WORKERS=%d but leader-election (#367) is not yet in place; "
+            "background tasks will be duplicated across workers. "
+            "Set WORKERS=1 until #367 lands.",
+            _uvicorn_cfg["workers"],
+        )
+
     uvicorn.run(
         app,
         host="0.0.0.0",  # nosec B104 — intentional for local LAN/Tailscale access
         port=PORT,
         log_level="warning",  # FastAPI handles its own logging
+        workers=_uvicorn_cfg["workers"],
+        limit_concurrency=_uvicorn_cfg["limit_concurrency"],
+        timeout_keep_alive=_uvicorn_cfg["timeout_keep_alive"],
     )
 # ci-trigger

--- a/tests/test_cpu_history_bounded.py
+++ b/tests/test_cpu_history_bounded.py
@@ -1,0 +1,45 @@
+"""Ensure ``_cpu_history`` is a bounded ``collections.deque`` (#393).
+
+An unbounded list would grow forever in a long-lived process; capping the
+deque guarantees memory stays flat regardless of uptime.
+"""
+
+from __future__ import annotations
+
+import collections
+
+import server
+
+
+def test_cpu_history_is_a_deque() -> None:
+    assert isinstance(server._cpu_history, collections.deque)
+
+
+def test_cpu_history_has_maxlen() -> None:
+    assert server._cpu_history.maxlen is not None
+    assert server._cpu_history.maxlen > 0
+
+
+def test_cpu_history_maxlen_constant_is_exposed() -> None:
+    """The maxlen value should come from a named module-level constant."""
+    assert hasattr(server, "_CPU_HISTORY_MAXLEN")
+    assert isinstance(server._CPU_HISTORY_MAXLEN, int)
+    assert server._CPU_HISTORY_MAXLEN >= 60
+    assert server._cpu_history.maxlen == server._CPU_HISTORY_MAXLEN
+
+
+def test_cpu_history_truncates_on_overflow() -> None:
+    """Pushing more than maxlen elements drops the oldest, never grows."""
+    maxlen = server._cpu_history.maxlen
+    assert maxlen is not None
+    sample = collections.deque(server._cpu_history)  # snapshot to restore later
+    try:
+        server._cpu_history.clear()
+        for i in range(maxlen + 50):
+            server._cpu_history.append(float(i))
+        assert len(server._cpu_history) == maxlen
+        # The oldest 50 entries must have been evicted.
+        assert server._cpu_history[0] == 50.0
+    finally:
+        server._cpu_history.clear()
+        server._cpu_history.extend(sample)

--- a/tests/test_queue_cleanup_semaphore.py
+++ b/tests/test_queue_cleanup_semaphore.py
@@ -1,0 +1,69 @@
+"""Verify ``queue_cleanup.find_stale_runs`` bounds fan-out (#393).
+
+The function scans every repo in the org for queued runs.  Without a
+semaphore the ``asyncio.gather`` would dispatch hundreds of concurrent
+``gh`` subprocesses which is hostile to both GitHub and the local box.
+This test asserts both the source-level guard and the runtime behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import queue_cleanup
+
+QUEUE_CLEANUP_SRC = Path(queue_cleanup.__file__).read_text(encoding="utf-8")
+
+
+def test_module_imports_asyncio_semaphore() -> None:
+    assert "asyncio.Semaphore" in QUEUE_CLEANUP_SRC
+
+
+def test_find_stale_runs_uses_semaphore() -> None:
+    src = inspect.getsource(queue_cleanup.find_stale_runs)
+    assert "asyncio.Semaphore" in src, "find_stale_runs must construct a Semaphore"
+    assert "async with sem" in src, "find_stale_runs must acquire the semaphore"
+    assert "asyncio.gather" in src, "find_stale_runs must still gather results"
+
+
+def test_scan_concurrency_is_capped_at_8() -> None:
+    """At most 8 concurrent repo queries (per #393 partial scope)."""
+    assert queue_cleanup._SCAN_CONCURRENCY <= 8
+
+
+def test_semaphore_actually_limits_concurrency() -> None:
+    """Runtime check: never more than _SCAN_CONCURRENCY in-flight at once."""
+    repos = [f"repo-{i}" for i in range(40)]
+    in_flight = 0
+    peak = 0
+
+    async def fake_query(_org: str, _repo: str, _min_age):  # type: ignore[no-untyped-def]
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0.01)
+        in_flight -= 1
+        return []
+
+    async def fake_list_repos(_org: str) -> list[str]:
+        return repos
+
+    async def run() -> None:
+        # Patch the module-level helpers used inside find_stale_runs.
+        orig_list = queue_cleanup.list_all_repos
+        orig_query = queue_cleanup._queued_stale_for_repo
+        queue_cleanup.list_all_repos = fake_list_repos  # type: ignore[assignment]
+        queue_cleanup._queued_stale_for_repo = fake_query  # type: ignore[assignment]
+        try:
+            await queue_cleanup.find_stale_runs("dummy-org", min_age_minutes=60)
+        finally:
+            queue_cleanup.list_all_repos = orig_list  # type: ignore[assignment]
+            queue_cleanup._queued_stale_for_repo = orig_query  # type: ignore[assignment]
+
+    asyncio.run(run())
+
+    assert peak <= queue_cleanup._SCAN_CONCURRENCY, (
+        f"peak in-flight {peak} exceeded cap {queue_cleanup._SCAN_CONCURRENCY}"
+    )

--- a/tests/test_uvicorn_invocation_envvars.py
+++ b/tests/test_uvicorn_invocation_envvars.py
@@ -1,0 +1,73 @@
+"""Tests for env-var-driven uvicorn invocation (#393).
+
+The dashboard reads ``WORKERS``, ``LIMIT_CONCURRENCY`` and
+``TIMEOUT_KEEP_ALIVE`` from the environment so operators can tune the
+ASGI server without code edits.  This test exercises the helper that
+parses the env vars *and* asserts the source code of ``server.py`` wires
+them through to ``uvicorn.run``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import server
+
+SERVER_SRC = Path(server.__file__).read_text(encoding="utf-8")
+
+
+def test_helper_returns_documented_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default values are 1 / 200 / 5 when env vars are unset."""
+    for name in ("WORKERS", "LIMIT_CONCURRENCY", "TIMEOUT_KEEP_ALIVE"):
+        monkeypatch.delenv(name, raising=False)
+
+    cfg = server._read_uvicorn_env_config()
+
+    # WORKERS must default to 1 because leader-election (#367) is not in place.
+    assert cfg["workers"] == 1
+    assert cfg["limit_concurrency"] == 200
+    assert cfg["timeout_keep_alive"] == 5
+
+
+def test_helper_reads_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKERS", "3")
+    monkeypatch.setenv("LIMIT_CONCURRENCY", "512")
+    monkeypatch.setenv("TIMEOUT_KEEP_ALIVE", "15")
+
+    cfg = server._read_uvicorn_env_config()
+
+    assert cfg["workers"] == 3
+    assert cfg["limit_concurrency"] == 512
+    assert cfg["timeout_keep_alive"] == 15
+
+
+def test_helper_falls_back_on_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKERS", "not-an-int")
+    monkeypatch.setenv("LIMIT_CONCURRENCY", "")
+    monkeypatch.setenv("TIMEOUT_KEEP_ALIVE", "abc")
+
+    cfg = server._read_uvicorn_env_config()
+
+    assert cfg == {"workers": 1, "limit_concurrency": 200, "timeout_keep_alive": 5}
+
+
+def test_server_source_references_each_env_var() -> None:
+    """server.py must mention each env var name verbatim."""
+    for name in ("WORKERS", "LIMIT_CONCURRENCY", "TIMEOUT_KEEP_ALIVE"):
+        assert name in SERVER_SRC, f"server.py should reference env var {name}"
+
+
+def test_uvicorn_run_receives_tuned_kwargs() -> None:
+    """The uvicorn.run call must forward the tuned values."""
+    assert "uvicorn.run(" in SERVER_SRC
+    # Each tunable must be passed as a kwarg to uvicorn.run.
+    for kwarg in ("workers=", "limit_concurrency=", "timeout_keep_alive="):
+        assert kwarg in SERVER_SRC, f"uvicorn.run should be called with {kwarg}"
+
+
+def test_warning_when_workers_gt_1() -> None:
+    """A runtime warning is logged when WORKERS > 1 because #367 isn't ready."""
+    assert "#367" in SERVER_SRC, "must reference leader-election issue #367"
+    # The warning text mentions WORKERS to make it greppable in operator logs.
+    assert "WORKERS" in SERVER_SRC


### PR DESCRIPTION
## Summary

Partial scope for #393 — the items that don't depend on leader-election (#367):

- **Env-driven uvicorn invocation** in `backend/server.py`. Reads `WORKERS`
  (default `1`), `LIMIT_CONCURRENCY` (default `200`), `TIMEOUT_KEEP_ALIVE`
  (default `5`) and forwards them to `uvicorn.run`. `WORKERS` stays at 1
  because leader-election isn't ready yet — using `WORKERS > 1` logs a
  runtime warning so operators can see the duplication risk.
- **Bounded `_cpu_history`** — replaced the implicit `maxlen=60` deque with
  an explicit `_CPU_HISTORY_MAXLEN = 1000` constant so the buffer can never
  grow without bound and the cap is greppable from tests.
- **Queue cleanup semaphore** — lowered `_SCAN_CONCURRENCY` in
  `backend/queue_cleanup.py` from 10 to 8 so `find_stale_runs` fans out at
  most 8 concurrent repo queries via the existing `asyncio.Semaphore`.

Out of scope per the issue (deferred until #367 lands):
- `WORKERS=2` default
- `benchmarks/bench_health.py`
- Multi-instance state documentation
- `WORKERS > 1` integration test

SPEC bumped to 2.5.14 with the new env vars + bounded buffer documented
under §2.1 Backend.

## Test plan
- [x] `PYTHONPATH=backend pytest tests/test_uvicorn_invocation_envvars.py tests/test_cpu_history_bounded.py tests/test_queue_cleanup_semaphore.py -v` (14 passed)
- [x] `ruff check` clean on changed files
- [x] `ruff format --check` clean on changed files
- [x] `mypy` introduces no new errors on changed files
- [x] All changed files <= 500 lines (server.py exempt)
- [x] No `TODO`/`FIXME` markers

Refs #393. Depends on #367 for the remaining scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEcM4cR7nu4TTeaBdZ2VXT)_