### PR TITLE
fix(ci): use v3 for setup-buildx-action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5730b2e35f6f84f30ff4463ad1fc62bb0b6f71d # v3.10.0
+        uses: docker/setup-buildx-action@v3 # v3.10.0
 
       - name: Build Docker image
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0


### PR DESCRIPTION
Fix broken SHA pin for docker-buildx-action.