### PR TITLE
[P1] fix(scalability): migrate subprocess.run in async handlers to asyncio.to_thread (#365)

### DIFF
--- a/backend/agent_launcher_router.py
+++ b/backend/agent_launcher_router.py
@@ -31,6 +31,7 @@ import logging
 import os
 import platform
 import subprocess
+import threading
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
@@ -38,6 +39,10 @@ from pydantic import BaseModel, Field
 
 log = logging.getLogger("dashboard.agent_launcher")
 router = APIRouter(prefix="/api/agent-launcher", tags=["agent-launcher"])
+
+# Bound concurrent launcher spawns to prevent fork-bomb when multiple dashboard
+# clients race to /start or /run-once simultaneously.
+_spawn_semaphore = threading.Semaphore(2)
 
 
 # ---------------------------------------------------------------------------
@@ -378,34 +383,39 @@ def start_scheduler() -> SimpleResponse:
     if pid_info and _is_pid_alive(int(pid_info.get("pid", -1))):
         return SimpleResponse(ok=True, detail=f"already running (pid {pid_info['pid']})")
 
-    if platform.system() == "Windows":
-        bat = _bat_path()
-        if not bat.is_file():
-            raise HTTPException(status_code=500, detail=f"missing launcher.bat at {bat}")
-        try:
-            # /B = no new window. pythonw inside the .bat handles detach.
-            subprocess.Popen(
-                ["cmd.exe", "/c", "start", "/B", str(bat), "--background"],
-                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,  # type: ignore[attr-defined]
-                close_fds=True,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            raise HTTPException(status_code=500, detail=f"spawn failed: {exc}") from exc
-    else:
-        cli = _cli_path()
-        if not cli.is_file():
-            raise HTTPException(status_code=500, detail=f"missing agent_launcher.py at {cli}")
-        try:
-            subprocess.Popen(
-                [_launcher_python(), str(cli)],
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                close_fds=True,
-                start_new_session=True,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            raise HTTPException(status_code=500, detail=f"spawn failed: {exc}") from exc
+    if not _spawn_semaphore.acquire(blocking=False):
+        raise HTTPException(status_code=429, detail="Too many concurrent spawn requests — try again shortly")
+    try:
+        if platform.system() == "Windows":
+            bat = _bat_path()
+            if not bat.is_file():
+                raise HTTPException(status_code=500, detail=f"missing launcher.bat at {bat}")
+            try:
+                # /B = no new window. pythonw inside the .bat handles detach.
+                subprocess.Popen(
+                    ["cmd.exe", "/c", "start", "/B", str(bat), "--background"],
+                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,  # type: ignore[attr-defined]
+                    close_fds=True,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise HTTPException(status_code=500, detail=f"spawn failed: {exc}") from exc
+        else:
+            cli = _cli_path()
+            if not cli.is_file():
+                raise HTTPException(status_code=500, detail=f"missing agent_launcher.py at {cli}")
+            try:
+                subprocess.Popen(
+                    [_launcher_python(), str(cli)],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    close_fds=True,
+                    start_new_session=True,
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise HTTPException(status_code=500, detail=f"spawn failed: {exc}") from exc
+    finally:
+        _spawn_semaphore.release()
     return SimpleResponse(ok=True, detail="scheduler start requested")
 
 

--- a/backend/routers/credentials.py
+++ b/backend/routers/credentials.py
@@ -204,7 +204,8 @@ async def get_credentials(request: Request) -> dict:
         try:
             _excluded = {"SECRET", "PASSWORD", "ANTHROPIC_API_KEY", "DASHBOARD_API_KEY"}
             _safe_env = {k: v for k, v in os.environ.items() if not any(exc in k.upper() for exc in _excluded)}
-            result = subprocess.run(
+            result = await asyncio.to_thread(
+                subprocess.run,
                 ["gh", "auth", "status"],
                 capture_output=True,
                 text=True,
@@ -341,7 +342,8 @@ async def get_credentials(request: Request) -> dict:
     _vscode_binary = shutil.which("code")
     if _vscode_binary and not _cline_by_path:
         try:
-            _ext_result = subprocess.run(
+            _ext_result = await asyncio.to_thread(
+                subprocess.run,
                 ["code", "--list-extensions"],
                 capture_output=True,
                 text=True,
@@ -500,7 +502,8 @@ async def get_cline_status(request: Request) -> dict:
     _vscode_binary = shutil.which("code")
     if _vscode_binary and not _cline_by_path:
         try:
-            _ext_result = subprocess.run(
+            _ext_result = await asyncio.to_thread(
+                subprocess.run,
                 ["code", "--list-extensions"],
                 capture_output=True,
                 text=True,
@@ -541,7 +544,8 @@ async def get_ollama_status(request: Request) -> dict:
 
     # Check if ollama serve is responsive
     try:
-        result = subprocess.run(
+        result = await asyncio.to_thread(
+            subprocess.run,
             ["ollama", "ps"],
             capture_output=True,
             text=True,
@@ -567,7 +571,8 @@ async def get_ollama_models(request: Request) -> dict:
         raise HTTPException(status_code=503, detail="ollama not found on PATH")
 
     try:
-        result = subprocess.run(
+        result = await asyncio.to_thread(
+            subprocess.run,
             ["ollama", "list"],
             capture_output=True,
             text=True,

--- a/backend/routers/maxwell.py
+++ b/backend/routers/maxwell.py
@@ -99,8 +99,9 @@ async def get_maxwell_status() -> dict:
     service_running = False
     service_detail = "unknown"
     try:
-        # Note: using subprocess.run for simple systemctl check
-        r = subprocess.run(
+        # Note: using asyncio.to_thread to avoid blocking the event loop
+        r = await asyncio.to_thread(
+            subprocess.run,
             ["systemctl", "is-active", "maxwell-daemon"],
             capture_output=True,
             text=True,

--- a/backend/server.py
+++ b/backend/server.py
@@ -2147,7 +2147,8 @@ async def update_runner_schedule(
         env["RUNNER_SCHEDULE_CONFIG"] = str(RUNNER_SCHEDULE_CONFIG)
         env["RUNNER_SCHEDULER_STATE"] = str(RUNNER_SCHEDULER_STATE)
         apply_cmd = _runner_scheduler_apply_command()
-        result = subprocess.run(
+        result = await asyncio.to_thread(
+            subprocess.run,
             apply_cmd,
             capture_output=True,
             text=True,
@@ -3132,7 +3133,8 @@ async def get_maxwell_status() -> dict:
     try:
         import subprocess
 
-        r = subprocess.run(
+        r = await asyncio.to_thread(
+            subprocess.run,
             ["systemctl", "is-active", "maxwell-daemon"],
             capture_output=True,
             text=True,
@@ -3983,7 +3985,8 @@ async def get_git_drift() -> dict:
 
     source = "unknown"
     try:
-        out = subprocess.run(
+        out = await asyncio.to_thread(
+            subprocess.run,
             ["git", "rev-parse", "HEAD"],
             capture_output=True,
             text=True,
@@ -3996,7 +3999,8 @@ async def get_git_drift() -> dict:
         result["source_commit"] = "unknown"
 
     try:
-        out = subprocess.run(
+        out = await asyncio.to_thread(
+            subprocess.run,
             ["git", "rev-parse", "origin/main"],
             capture_output=True,
             text=True,
@@ -4026,7 +4030,8 @@ async def get_diagnostics_summary() -> dict:
 
     # WSL status
     try:
-        wsl_result = subprocess.run(
+        wsl_result = await asyncio.to_thread(
+            subprocess.run,
             ["wsl", "-l", "-v"],
             capture_output=True,
             text=True,
@@ -4038,7 +4043,8 @@ async def get_diagnostics_summary() -> dict:
         summary["wsl_available"] = wsl_result.returncode == 0
     except Exception:  # noqa: BLE001
         try:
-            wsl_result_raw = subprocess.run(
+            wsl_result_raw = await asyncio.to_thread(
+                subprocess.run,
                 ["wsl", "-l", "-v"],
                 capture_output=True,
                 timeout=10,
@@ -4057,7 +4063,8 @@ async def get_diagnostics_summary() -> dict:
 
     # Git commit
     try:
-        out = subprocess.run(
+        out = await asyncio.to_thread(
+            subprocess.run,
             ["git", "rev-parse", "--short", "HEAD"],
             capture_output=True,
             text=True,
@@ -4093,7 +4100,8 @@ async def restart_dashboard_service(
         raise HTTPException(status_code=403, detail="Local access only")
 
     try:
-        result = subprocess.run(
+        result = await asyncio.to_thread(
+            subprocess.run,
             [SYSTEMCTL_BIN, "--user", "restart", "runner-dashboard"],
             capture_output=True,
             text=True,

--- a/tests/test_async_hygiene.py
+++ b/tests/test_async_hygiene.py
@@ -1,0 +1,112 @@
+"""AST-based test: subprocess.run must not appear directly inside async def handlers.
+
+Issue #365: Every ``subprocess.run`` call inside an ``async def`` handler blocks
+the entire event loop for the subprocess's duration.  This test walks the AST of
+the router modules and ``server.py`` and fails CI if a bare ``subprocess.run``
+is found inside an ``async def`` function body.
+
+Module-import-time calls (server.py PowerShell memory probe) and sync helper
+functions are exempt by design — the rule is about *async def* bodies only.
+
+Excluded paths (noqa-equivalent):
+  - ``agent_launcher_router.py`` — all subprocess calls are in sync functions
+    or ``Popen`` (fire-and-forget), not blocking ``run`` in async context.
+  - ``routers/system.py`` — ``get_gpu_info`` is a sync function used inside
+    async routes via ``asyncio.to_thread``; pattern already correct.
+  - ``local_app_monitoring.py`` — has ``# noqa: S603`` call in sync context.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+BACKEND = REPO_ROOT / "backend"
+
+# Files to audit. Any file added to routers/ is automatically included.
+_ROUTER_DIR = BACKEND / "routers"
+_ROUTER_FILES = list(_ROUTER_DIR.glob("*.py"))
+_TOP_LEVEL = [
+    BACKEND / "server.py",
+    BACKEND / "metrics.py",
+]
+AUDIT_FILES = _TOP_LEVEL + _ROUTER_FILES
+
+# Files that are explicitly exempted (sync-only subprocess usage).
+_EXEMPT = {
+    "agent_launcher_router.py",  # all calls are in sync helpers / Popen
+    "system.py",                 # get_gpu_info is sync; called via to_thread
+    "local_app_monitoring.py",   # has noqa:S603, sync context
+}
+
+
+def _find_violations(path: Path) -> list[tuple[int, str]]:
+    """Return (lineno, func_name) for each subprocess.run inside an async def."""
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        pytest.fail(f"SyntaxError in {path}: {exc}")
+
+    violations: list[tuple[int, str]] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self._async_stack: list[str] = []
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self._async_stack.append(node.name)
+            self.generic_visit(node)
+            self._async_stack.pop()
+
+        # Also handle nested sync defs inside async (they are NOT async context)
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            # Temporarily leave async context for nested sync defs
+            saved = self._async_stack[:]
+            self._async_stack.clear()
+            self.generic_visit(node)
+            self._async_stack[:] = saved
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if self._async_stack:
+                func = node.func
+                is_subprocess_run = (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "run"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "subprocess"
+                )
+                if is_subprocess_run:
+                    violations.append((node.lineno, self._async_stack[-1]))
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return violations
+
+
+@pytest.mark.parametrize("path", AUDIT_FILES, ids=lambda p: p.name)
+def test_no_blocking_subprocess_run_in_async(path: Path) -> None:
+    """Fail if subprocess.run is called directly inside an async def handler."""
+    if path.name in _EXEMPT:
+        pytest.skip(f"{path.name} is exempt (sync-only subprocess usage)")
+
+    violations = _find_violations(path)
+    if violations:
+        details = "\n".join(
+            f"  {path.name}:{lineno} — inside async def {fn}()"
+            for lineno, fn in violations
+        )
+        pytest.fail(
+            textwrap.dedent(f"""
+                Found {len(violations)} blocking subprocess.run call(s) inside async handlers.
+                Migrate them to:
+                    result = await asyncio.to_thread(subprocess.run, ...)
+
+                Violations:
+                {details}
+            """).strip()
+        )


### PR DESCRIPTION
## Summary

Resolves #365.

Every subprocess.run call inside an sync def handler was blocking the entire event loop for the subprocess duration (up to 30 s for systemctl restart). Under concurrent load this stalls **all** requests on the single Uvicorn worker.

## Changes

| File | Sites fixed |
|---|---|
| ackend/server.py | 8 — schedule apply, maxwell systemctl, git rev-parse ×2, WSL list ×2, diagnostics git commit, service restart |
| ackend/routers/maxwell.py | 1 — systemctl is-active maxwell-daemon |
| ackend/routers/credentials.py | 5 — gh auth status, code --list-extensions ×2, ollama ps, ollama list |
| ackend/agent_launcher_router.py | 0 subprocess.run (sync helpers exempt) + 	hreading.Semaphore(2) added |

All sites migrated to wait asyncio.to_thread(subprocess.run, ...). Sync helpers (_sync_runner_scheduler_state, _unit_active_sync, get_gpu_info) remain in sync context — they are already called correctly.

## Additional hardening

- **	hreading.Semaphore(2)** on gent_launcher_router bounds concurrent Popen spawns (fork-bomb protection, AC#4).
- **esponse_model=None** on emediation.py /api/prs/dispatch and /api/issues/dispatch fixes a pre-existing FastAPI startup crash that blocked tests from loading.

## New test

	ests/test_async_hygiene.py — AST-walks ackend/server.py and ackend/routers/*.py and **fails CI** if subprocess.run appears directly inside any sync def body (AC#2).

## Acceptance criteria

- [x] All 14+ inline subprocess.run sites converted  
- [x] AST CI guard 	est_async_hygiene.py — 21 pass, 1 skip (system.py — sync-only)
- [x] Semaphore(2) on launcher spawns  
- [x] Module-import-time subprocess call (server.py:297 powershell) unchanged (not async context)