### PR TITLE
[P1] feat(decoupling): Maxwell schema contract — strip sensitive fields, Pydantic models, 18 tests (#366)

### DIFF
--- a/backend/maxwell_contract.py
+++ b/backend/maxwell_contract.py
@@ -1,0 +1,241 @@
+"""Maxwell-Daemon contract models — dashboard consumer view.
+
+This module defines the *dashboard's* view of the Maxwell-Daemon API.
+Responses from Maxwell are deserialized into these models so that:
+
+1. Only allow-listed fields are forwarded to the frontend.
+2. Sensitive fields (e.g., ``secret_token``, ``api_key``) are never leaked.
+3. Schema drift (Maxwell adds/renames a field) is caught at the boundary.
+
+Contract version: v1 (2026-04-30, issue #366).
+Docs: docs/contracts/maxwell.md
+
+Usage::
+
+    from maxwell_contract import MaxwellVersionResponse
+    raw: dict = await _mx_get("/api/version")
+    return MaxwellVersionResponse.model_validate(raw).model_dump()
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Shared sentinel — use this for any field that must not be forwarded.
+# ---------------------------------------------------------------------------
+
+_SENSITIVE_FIELDS = frozenset(
+    {
+        "secret_token",
+        "api_key",
+        "api_secret",
+        "token",
+        "password",
+        "private_key",
+        "connection_string",
+        "db_url",
+        "webhook_secret",
+        "signing_secret",
+        "client_secret",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# /api/version
+# ---------------------------------------------------------------------------
+
+
+class MaxwellVersionResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/version endpoint."""
+
+    version: str = Field(default="unknown", description="Semantic version string")
+    build: str | None = Field(default=None, description="Build hash or CI label")
+    environment: str | None = Field(default=None)
+    started_at: str | None = Field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# /api/status  (pipeline state / daemon status)
+# ---------------------------------------------------------------------------
+
+
+class MaxwellStatusResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/status endpoint."""
+
+    state: str = Field(default="unknown")
+    active_tasks: int = Field(default=0, ge=0)
+    queued_tasks: int = Field(default=0, ge=0)
+    completed_tasks: int | None = Field(default=None, ge=0)
+    failed_tasks: int | None = Field(default=None, ge=0)
+    uptime_seconds: float | None = Field(default=None)
+    last_activity: str | None = Field(default=None)
+    paused: bool = Field(default=False)
+
+
+# ---------------------------------------------------------------------------
+# /api/tasks  (list)
+# ---------------------------------------------------------------------------
+
+
+class MaxwellTaskItem(BaseModel):
+    """A single task entry in the tasks list."""
+
+    id: str = Field(description="Task UUID")
+    status: str = Field(default="unknown")
+    created_at: str | None = Field(default=None)
+    updated_at: str | None = Field(default=None)
+    type: str | None = Field(default=None)
+    priority: int | None = Field(default=None)
+    tags: list[str] = Field(default_factory=list)
+    error: str | None = Field(default=None)
+    # No credential fields are allow-listed here.
+
+
+class MaxwellTaskListResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/tasks list endpoint."""
+
+    tasks: list[MaxwellTaskItem] = Field(default_factory=list)
+    cursor: str | None = Field(default=None, description="Opaque pagination cursor")
+    total: int | None = Field(default=None, ge=0)
+
+
+# ---------------------------------------------------------------------------
+# /api/tasks/{task_id}  (detail)
+# ---------------------------------------------------------------------------
+
+
+class MaxwellTaskDetailResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/tasks/{task_id} endpoint."""
+
+    id: str
+    status: str = Field(default="unknown")
+    created_at: str | None = Field(default=None)
+    updated_at: str | None = Field(default=None)
+    started_at: str | None = Field(default=None)
+    completed_at: str | None = Field(default=None)
+    type: str | None = Field(default=None)
+    priority: int | None = Field(default=None)
+    tags: list[str] = Field(default_factory=list)
+    error: str | None = Field(default=None)
+    result_summary: str | None = Field(default=None)
+    # Note: full result payload is intentionally omitted — use a dedicated
+    # result endpoint if needed, and filter there too.
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/backends
+# ---------------------------------------------------------------------------
+
+
+class MaxwellBackendItem(BaseModel):
+    """A single backend provider entry. Sensitive config is strip-listed."""
+
+    name: str = Field(description="Backend display name, e.g. 'Anthropic'")
+    type: str = Field(default="unknown")
+    enabled: bool = Field(default=False)
+    model: str | None = Field(default=None)
+    status: str | None = Field(default=None)
+    # connection_string, api_key, etc. are deliberately NOT listed here.
+
+
+class MaxwellBackendsResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/v1/backends endpoint."""
+
+    backends: list[MaxwellBackendItem] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/workers
+# ---------------------------------------------------------------------------
+
+
+class MaxwellWorkerItem(BaseModel):
+    """A single worker entry."""
+
+    id: str
+    status: str = Field(default="idle")
+    current_task_id: str | None = Field(default=None)
+    tasks_completed: int | None = Field(default=None, ge=0)
+    tasks_failed: int | None = Field(default=None, ge=0)
+    started_at: str | None = Field(default=None)
+    last_activity: str | None = Field(default=None)
+
+
+class MaxwellWorkersResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/v1/workers endpoint."""
+
+    workers: list[MaxwellWorkerItem] = Field(default_factory=list)
+    total: int | None = Field(default=None, ge=0)
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/cost
+# ---------------------------------------------------------------------------
+
+
+class MaxwellCostResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/v1/cost endpoint."""
+
+    total_usd: float | None = Field(default=None, ge=0)
+    window: str | None = Field(default=None, description="e.g. 'rolling_30d'")
+    by_model: dict[str, float] | None = Field(default=None)
+    by_backend: dict[str, float] | None = Field(default=None)
+    currency: str = Field(default="USD")
+
+
+# ---------------------------------------------------------------------------
+# /api/control/{action}  (pipeline control response)
+# ---------------------------------------------------------------------------
+
+
+class MaxwellControlResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's /api/v1/control/{action} response."""
+
+    action: str
+    status: str = Field(default="ok")
+    message: str | None = Field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/tasks  (dispatch response)
+# ---------------------------------------------------------------------------
+
+
+class MaxwellDispatchResponse(BaseModel):
+    """Consumer view of Maxwell-Daemon's task dispatch (POST /api/v1/tasks)."""
+
+    task_id: str = Field(alias="id", default="unknown")
+    status: str = Field(default="queued")
+    idempotency_key: str | None = Field(default=None)
+    created_at: str | None = Field(default=None)
+    message: str | None = Field(default=None)
+
+    model_config = {"populate_by_name": True}
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def strip_sensitive(data: dict[str, Any]) -> dict[str, Any]:
+    """Recursively remove known-sensitive keys from a dict before forwarding.
+
+    This is a defence-in-depth utility called before model validation when
+    the raw upstream response is passed directly (e.g., from _mx_get).
+    """
+    cleaned: dict[str, Any] = {}
+    for k, v in data.items():
+        if k in _SENSITIVE_FIELDS:
+            continue
+        if isinstance(v, dict):
+            cleaned[k] = strip_sensitive(v)
+        elif isinstance(v, list):
+            cleaned[k] = [strip_sensitive(item) if isinstance(item, dict) else item for item in v]
+        else:
+            cleaned[k] = v
+    return cleaned

--- a/backend/routers/maxwell.py
+++ b/backend/routers/maxwell.py
@@ -10,6 +10,7 @@ import uuid
 from pathlib import Path
 
 import httpx
+import maxwell_contract as _mc
 from fastapi import APIRouter, Depends, HTTPException, Request
 from identity import Principal, require_scope
 from pydantic import BaseModel, Field
@@ -177,29 +178,33 @@ async def maxwell_control(
 
 @router.get("/version")
 async def get_maxwell_version() -> dict:
-    """Proxy GET /api/version from Maxwell-Daemon."""
-    return await _mx_get("/api/version")
+    """Proxy GET /api/version from Maxwell-Daemon (contract-filtered)."""
+    raw = await _mx_get("/api/version")
+    return _mc.MaxwellVersionResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.get("/daemon-status")
 async def get_maxwell_daemon_status_detail() -> dict:
-    """Proxy GET /api/status from Maxwell-Daemon (pipeline state)."""
-    return await _mx_get("/api/status")
+    """Proxy GET /api/status from Maxwell-Daemon (pipeline state, contract-filtered)."""
+    raw = await _mx_get("/api/status")
+    return _mc.MaxwellStatusResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.get("/tasks")
 async def get_maxwell_tasks(limit: int = 20, cursor: str | None = None) -> dict:
-    """Proxy GET /api/tasks from Maxwell-Daemon."""
+    """Proxy GET /api/tasks from Maxwell-Daemon (contract-filtered)."""
     params: dict = {"limit": limit}
     if cursor is not None:
         params["cursor"] = cursor
-    return await _mx_get("/api/tasks", params=params)
+    raw = await _mx_get("/api/tasks", params=params)
+    return _mc.MaxwellTaskListResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.get("/tasks/{task_id}")
 async def get_maxwell_task_detail(task_id: str) -> dict:
-    """Proxy GET /api/tasks/{task_id} from Maxwell-Daemon."""
-    return await _mx_get(f"/api/tasks/{task_id}")
+    """Proxy GET /api/tasks/{task_id} from Maxwell-Daemon (contract-filtered)."""
+    raw = await _mx_get(f"/api/tasks/{task_id}")
+    return _mc.MaxwellTaskDetailResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.post("/dispatch")
@@ -229,7 +234,8 @@ async def maxwell_dispatch_task(
             log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
             from proxy_utils import _translate_upstream_response
 
-            return _translate_upstream_response(resp, "maxwell")
+            raw = _translate_upstream_response(resp, "maxwell")
+            return _mc.MaxwellDispatchResponse.model_validate(_mc.strip_sensitive(raw)).model_dump(by_alias=False)
     except httpx.TimeoutException as e:
         raise HTTPException(status_code=504, detail="maxwell timeout") from e
     except httpx.ConnectError as e:
@@ -268,7 +274,8 @@ async def maxwell_pipeline_control(
             log.info("maxwell_proxy: path=%s status=%s", path, resp.status_code)
             from proxy_utils import _translate_upstream_response
 
-            return _translate_upstream_response(resp, "maxwell")
+            raw = _translate_upstream_response(resp, "maxwell")
+            return _mc.MaxwellControlResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
     except httpx.TimeoutException as e:
         raise HTTPException(status_code=504, detail="maxwell timeout") from e
     except httpx.ConnectError as e:
@@ -282,23 +289,27 @@ async def maxwell_pipeline_control(
 
 @router.get("/backends")
 async def get_maxwell_backends() -> dict:
-    """Proxy GET /api/v1/backends from Maxwell-Daemon."""
-    return await _mx_get("/api/v1/backends")
+    """Proxy GET /api/v1/backends from Maxwell-Daemon (contract-filtered; secrets stripped)."""
+    raw = await _mx_get("/api/v1/backends")
+    return _mc.MaxwellBackendsResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.get("/workers")
 async def get_maxwell_workers() -> dict:
-    """Proxy GET /api/v1/workers from Maxwell-Daemon."""
-    return await _mx_get("/api/v1/workers")
+    """Proxy GET /api/v1/workers from Maxwell-Daemon (contract-filtered)."""
+    raw = await _mx_get("/api/v1/workers")
+    return _mc.MaxwellWorkersResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.get("/cost")
 async def get_maxwell_cost() -> dict:
-    """Proxy GET /api/v1/cost from Maxwell-Daemon."""
-    return await _mx_get("/api/v1/cost")
+    """Proxy GET /api/v1/cost from Maxwell-Daemon (contract-filtered)."""
+    raw = await _mx_get("/api/v1/cost")
+    return _mc.MaxwellCostResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.get("/pipeline-state")
 async def get_maxwell_pipeline_state() -> dict:
-    """Proxy GET /api/status (pipeline state) from Maxwell-Daemon."""
-    return await _mx_get("/api/status")
+    """Proxy GET /api/status (pipeline state) from Maxwell-Daemon (contract-filtered)."""
+    raw = await _mx_get("/api/status")
+    return _mc.MaxwellStatusResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()

--- a/docs/contracts/maxwell.md
+++ b/docs/contracts/maxwell.md
@@ -1,0 +1,202 @@
+# Maxwell-Daemon API Contract — Dashboard Consumer View
+
+**Contract version**: v1  
+**Date**: 2026-04-30  
+**Issue**: [#366](https://github.com/D-sorganization/Runner_Dashboard/issues/366)
+
+---
+
+## Overview
+
+The dashboard proxies requests to Maxwell-Daemon and applies a strict schema
+at the boundary. Only the fields listed in this document are forwarded to
+the frontend. Unknown fields from Maxwell are silently dropped. Sensitive
+fields (see §Sensitive Field Blocklist) are explicitly excluded from every
+model.
+
+This contract is implemented in `backend/maxwell_contract.py`.
+
+---
+
+## Endpoints and Response Shapes
+
+### `GET /api/maxwell/version`
+
+Proxy of Maxwell-Daemon `/api/version`.
+
+| Field          | Type         | Notes                          |
+|----------------|--------------|--------------------------------|
+| `version`      | `string`     | Semantic version, default `"unknown"` |
+| `build`        | `string?`    | CI build label or hash         |
+| `environment`  | `string?`    | e.g. `"production"`            |
+| `started_at`   | `string?`    | ISO 8601 daemon start time     |
+
+---
+
+### `GET /api/maxwell/daemon-status` · `GET /api/maxwell/pipeline-state`
+
+Proxy of Maxwell-Daemon `/api/status`.
+
+| Field             | Type       | Notes                           |
+|-------------------|------------|---------------------------------|
+| `state`           | `string`   | `"idle"`, `"running"`, …        |
+| `active_tasks`    | `int`      | Currently executing             |
+| `queued_tasks`    | `int`      | Waiting in queue                |
+| `completed_tasks` | `int?`     |                                 |
+| `failed_tasks`    | `int?`     |                                 |
+| `uptime_seconds`  | `float?`   |                                 |
+| `last_activity`   | `string?`  | ISO 8601                        |
+| `paused`          | `bool`     |                                 |
+
+---
+
+### `GET /api/maxwell/tasks`
+
+Proxy of Maxwell-Daemon `/api/tasks`.
+
+| Field    | Type            | Notes                       |
+|----------|-----------------|-----------------------------|
+| `tasks`  | `TaskItem[]`    | See task item schema below  |
+| `cursor` | `string?`       | Opaque pagination cursor    |
+| `total`  | `int?`          |                             |
+
+**TaskItem**:
+
+| Field          | Type       | Notes                     |
+|----------------|------------|---------------------------|
+| `id`           | `string`   | UUID                      |
+| `status`       | `string`   |                           |
+| `created_at`   | `string?`  | ISO 8601                  |
+| `updated_at`   | `string?`  | ISO 8601                  |
+| `type`         | `string?`  |                           |
+| `priority`     | `int?`     |                           |
+| `tags`         | `string[]` |                           |
+| `error`        | `string?`  |                           |
+
+---
+
+### `GET /api/maxwell/tasks/{task_id}`
+
+Proxy of Maxwell-Daemon `/api/tasks/{id}`.
+
+Same as TaskItem plus:
+
+| Field            | Type       | Notes              |
+|------------------|------------|--------------------|
+| `started_at`     | `string?`  | ISO 8601           |
+| `completed_at`   | `string?`  | ISO 8601           |
+| `result_summary` | `string?`  | Truncated summary  |
+
+---
+
+### `POST /api/maxwell/dispatch`
+
+Proxy of Maxwell-Daemon `POST /api/v1/tasks`.
+
+| Field             | Type       | Notes                        |
+|-------------------|------------|------------------------------|
+| `task_id`         | `string`   | Returned as `id` by Maxwell  |
+| `status`          | `string`   | Typically `"queued"`         |
+| `idempotency_key` | `string?`  |                              |
+| `created_at`      | `string?`  |                              |
+| `message`         | `string?`  |                              |
+
+---
+
+### `POST /api/maxwell/pipeline-control/{action}`
+
+Proxy of Maxwell-Daemon `POST /api/v1/control/{action}`.
+
+| Field     | Type      | Notes                        |
+|-----------|-----------|------------------------------|
+| `action`  | `string`  | `pause`, `resume`, `abort`   |
+| `status`  | `string`  | Default `"ok"`               |
+| `message` | `string?` |                              |
+
+---
+
+### `GET /api/maxwell/backends`
+
+Proxy of Maxwell-Daemon `/api/v1/backends`.
+
+| Field       | Type             | Notes                     |
+|-------------|------------------|---------------------------|
+| `backends`  | `BackendItem[]`  |                           |
+
+**BackendItem**:
+
+| Field     | Type      | Notes                              |
+|-----------|-----------|------------------------------------|
+| `name`    | `string`  | Display name, e.g. `"Anthropic"`  |
+| `type`    | `string`  |                                    |
+| `enabled` | `bool`    |                                    |
+| `model`   | `string?` |                                    |
+| `status`  | `string?` |                                    |
+
+> ⚠️ **`api_key`, `connection_string`, and similar fields are NEVER forwarded.**
+
+---
+
+### `GET /api/maxwell/workers`
+
+Proxy of Maxwell-Daemon `/api/v1/workers`.
+
+| Field       | Type            |
+|-------------|-----------------|
+| `workers`   | `WorkerItem[]`  |
+| `total`     | `int?`          |
+
+**WorkerItem**:
+
+| Field               | Type      |
+|---------------------|-----------|
+| `id`                | `string`  |
+| `status`            | `string`  |
+| `current_task_id`   | `string?` |
+| `tasks_completed`   | `int?`    |
+| `tasks_failed`      | `int?`    |
+| `started_at`        | `string?` |
+| `last_activity`     | `string?` |
+
+---
+
+### `GET /api/maxwell/cost`
+
+Proxy of Maxwell-Daemon `/api/v1/cost`.
+
+| Field        | Type              |
+|--------------|-------------------|
+| `total_usd`  | `float?`          |
+| `window`     | `string?`         |
+| `by_model`   | `dict[str,float]?`|
+| `by_backend` | `dict[str,float]?`|
+| `currency`   | `string`          |
+
+---
+
+## Sensitive Field Blocklist
+
+The following keys are stripped from ALL Maxwell responses before
+model validation (defence-in-depth, `strip_sensitive()`):
+
+- `secret_token`
+- `api_key`
+- `api_secret`
+- `token`
+- `password`
+- `private_key`
+- `connection_string`
+- `db_url`
+- `webhook_secret`
+- `signing_secret`
+- `client_secret`
+
+---
+
+## Versioning Policy
+
+- This contract is versioned. Breaking changes (field removal, rename)
+  require a version bump in this document and in `maxwell_contract.py`.
+- Maxwell may add new fields freely; the dashboard will silently ignore them
+  (Pydantic `extra=ignore` default).
+- The dashboard must **not** depend on any field not listed here.

--- a/tests/test_maxwell_contract.py
+++ b/tests/test_maxwell_contract.py
@@ -1,0 +1,246 @@
+"""Tests for the Maxwell contract (issue #366).
+
+Acceptance criteria verified:
+- AC-3: Extra fields from Maxwell are silently dropped (shape unchanged).
+- AC-4: Sensitive fields from Maxwell are never forwarded.
+- AC-1: Each proxy route has a declared contract model.
+- General: Models serialize/deserialize cleanly; defaults are sane.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make the backend package importable from tests/
+# ---------------------------------------------------------------------------
+_BACKEND = Path(__file__).parent.parent / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import maxwell_contract as mc  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# strip_sensitive
+# ---------------------------------------------------------------------------
+
+
+class TestStripSensitive:
+    def test_removes_known_sensitive_keys(self) -> None:
+        raw = {
+            "name": "Anthropic",
+            "api_key": "sk-secret",
+            "connection_string": "postgres://user:pass@host/db",
+            "model": "claude-3-opus",
+        }
+        result = mc.strip_sensitive(raw)
+        assert "api_key" not in result
+        assert "connection_string" not in result
+        assert result["name"] == "Anthropic"
+        assert result["model"] == "claude-3-opus"
+
+    def test_recursive_strip(self) -> None:
+        raw = {
+            "backends": [
+                {"name": "Ollama", "api_key": "hidden", "enabled": True},
+            ]
+        }
+        result = mc.strip_sensitive(raw)
+        assert "api_key" not in result["backends"][0]
+        assert result["backends"][0]["name"] == "Ollama"
+
+    def test_nested_dict_strip(self) -> None:
+        raw = {
+            "config": {
+                "token": "t-secret",
+                "host": "localhost",
+            }
+        }
+        result = mc.strip_sensitive(raw)
+        assert "token" not in result["config"]
+        assert result["config"]["host"] == "localhost"
+
+    def test_unknown_keys_passthrough_before_model(self) -> None:
+        """strip_sensitive does not strip unknown (non-sensitive) keys."""
+        raw = {"some_new_field": 42, "secret_token": "bad"}
+        result = mc.strip_sensitive(raw)
+        assert "some_new_field" in result  # not sensitive
+        assert "secret_token" not in result
+
+    def test_empty_dict(self) -> None:
+        assert mc.strip_sensitive({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Extra fields are silently dropped by Pydantic model validation
+# ---------------------------------------------------------------------------
+
+
+class TestExtraFieldsDropped:
+    """Maxwell adds new fields — dashboard response shape must be unchanged."""
+
+    def test_version_extra_fields_dropped(self) -> None:
+        raw = {
+            "version": "1.2.3",
+            "build": "abc123",
+            "new_field_maxwell_added": "surprise",
+            "internal_metric": 99,
+        }
+        result = mc.MaxwellVersionResponse.model_validate(raw).model_dump()
+        assert "new_field_maxwell_added" not in result
+        assert "internal_metric" not in result
+        assert result["version"] == "1.2.3"
+        assert result["build"] == "abc123"
+
+    def test_status_extra_fields_dropped(self) -> None:
+        raw = {
+            "state": "running",
+            "active_tasks": 3,
+            "queued_tasks": 1,
+            "maxwell_internal_secret": "should-not-appear",
+            "new_metric": "yes",
+        }
+        result = mc.MaxwellStatusResponse.model_validate(raw).model_dump()
+        assert "maxwell_internal_secret" not in result
+        assert "new_metric" not in result
+        assert result["state"] == "running"
+        assert result["active_tasks"] == 3
+
+    def test_task_list_extra_fields_dropped(self) -> None:
+        raw = {
+            "tasks": [
+                {
+                    "id": "task-1",
+                    "status": "queued",
+                    "internal_ref": "SECRET",
+                    "new_field": "ignored",
+                }
+            ],
+            "cursor": "next-cursor",
+            "total": 1,
+            "new_pagination_key": "X",
+        }
+        result = mc.MaxwellTaskListResponse.model_validate(raw).model_dump()
+        assert "new_pagination_key" not in result
+        tasks = result["tasks"]
+        assert len(tasks) == 1
+        assert "internal_ref" not in tasks[0]
+        assert tasks[0]["id"] == "task-1"
+
+    def test_backends_extra_fields_dropped(self) -> None:
+        raw = {
+            "backends": [
+                {
+                    "name": "Anthropic",
+                    "type": "cloud",
+                    "enabled": True,
+                    "model": "claude-opus-4",
+                    "extra_cloud_config": "hidden",
+                }
+            ]
+        }
+        result = mc.MaxwellBackendsResponse.model_validate(raw).model_dump()
+        backend = result["backends"][0]
+        assert "extra_cloud_config" not in backend
+        assert backend["name"] == "Anthropic"
+        assert backend["model"] == "claude-opus-4"
+
+
+# ---------------------------------------------------------------------------
+# AC-4: Sensitive fields are NOT present in dashboard responses
+# ---------------------------------------------------------------------------
+
+
+class TestSensitiveFieldsNeverForwarded:
+    """Stub returning sensitive fields must not appear in dashboard response."""
+
+    def test_api_key_stripped_from_version(self) -> None:
+        raw = {"version": "1.0.0", "api_key": "sk-dangerous", "secret_token": "another"}  # pragma: allowlist secret
+        cleaned = mc.strip_sensitive(raw)
+        result = mc.MaxwellVersionResponse.model_validate(cleaned).model_dump()
+        assert "api_key" not in result
+        assert "secret_token" not in result
+
+    def test_api_key_stripped_from_backend(self) -> None:
+        raw = {
+            "backends": [
+                {
+                    "name": "Anthropic",
+                    "api_key": "sk-ant-supersecret",  # pragma: allowlist secret
+                    "connection_string": "postgres://secret@host/db",
+                    "enabled": True,
+                    "type": "cloud",
+                }
+            ]
+        }
+        cleaned = mc.strip_sensitive(raw)
+        result = mc.MaxwellBackendsResponse.model_validate(cleaned).model_dump()
+        backend = result["backends"][0]
+        assert "api_key" not in backend
+        assert "connection_string" not in backend
+        assert backend["name"] == "Anthropic"
+
+    def test_all_known_sensitive_keys_stripped(self) -> None:
+        raw = {
+            "version": "1.0.0",
+            "secret_token": "t1",  # pragma: allowlist secret
+            "api_key": "k1",  # pragma: allowlist secret
+            "api_secret": "s1",  # pragma: allowlist secret
+            "token": "tok1",
+            "password": "p1",  # pragma: allowlist secret
+            "private_key": "pk1",  # pragma: allowlist secret
+            "connection_string": "cs1",
+            "db_url": "db1",
+            "webhook_secret": "ws1",  # pragma: allowlist secret
+            "signing_secret": "ss1",  # pragma: allowlist secret
+            "client_secret": "cs2",  # pragma: allowlist secret
+        }
+        cleaned = mc.strip_sensitive(raw)
+        result = mc.MaxwellVersionResponse.model_validate(cleaned).model_dump()
+        for sensitive_key in mc._SENSITIVE_FIELDS:
+            assert sensitive_key not in result, f"Sensitive field {sensitive_key!r} leaked into response!"
+
+
+# ---------------------------------------------------------------------------
+# Default / missing field handling
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    def test_version_defaults(self) -> None:
+        result = mc.MaxwellVersionResponse.model_validate({}).model_dump()
+        assert result["version"] == "unknown"
+        assert result["build"] is None
+
+    def test_status_defaults(self) -> None:
+        result = mc.MaxwellStatusResponse.model_validate({}).model_dump()
+        assert result["state"] == "unknown"
+        assert result["active_tasks"] == 0
+        assert result["paused"] is False
+
+    def test_task_list_defaults(self) -> None:
+        result = mc.MaxwellTaskListResponse.model_validate({}).model_dump()
+        assert result["tasks"] == []
+        assert result["cursor"] is None
+
+    def test_cost_defaults(self) -> None:
+        result = mc.MaxwellCostResponse.model_validate({}).model_dump()
+        assert result["total_usd"] is None
+        assert result["currency"] == "USD"
+
+    def test_dispatch_response_id_alias(self) -> None:
+        """Maxwell returns 'id' but dashboard exposes it as 'task_id'."""
+        raw = {"id": "task-uuid-123", "status": "queued"}
+        result = mc.MaxwellDispatchResponse.model_validate(raw).model_dump(by_alias=False)
+        assert result["task_id"] == "task-uuid-123"
+        assert "id" not in result
+
+    def test_control_response_defaults(self) -> None:
+        result = mc.MaxwellControlResponse.model_validate({"action": "pause"}).model_dump()
+        assert result["action"] == "pause"
+        assert result["status"] == "ok"
+        assert result["message"] is None


### PR DESCRIPTION
Resolves #366.

AC-1: Each Maxwell proxy route now validates through a Pydantic contract model.
AC-2: backend/maxwell_contract.py with 9 response models for all Maxwell endpoints.
AC-3: 18 unit tests verify extra fields are silently dropped.
AC-4: Sensitive-field test: api_key, secret_token, connection_string, etc. never forwarded. strip_sensitive() adds defence-in-depth before Pydantic validation.
AC-5: docs/contracts/maxwell.md documents all endpoint shapes and the sensitive field blocklist.

Key security improvement: backends endpoint (which could expose API keys) is now safely filtered.
