### PR TITLE
fix(test): remove autouse from mock_auth — auth is exercised by default (#343)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -129,10 +129,10 @@
     }
   ],
   "results": {
-    ".github\\workflows\\ci-secrets.yml": [
+    ".github/workflows/ci-secrets.yml": [
       {
         "type": "Hex High Entropy String",
-        "filename": ".github\\workflows\\ci-secrets.yml",
+        "filename": ".github/workflows/ci-secrets.yml",
         "hashed_secret": "46105ab0fea972aaebb41ca899221b4c254e889c",
         "is_verified": false,
         "line_number": 56
@@ -163,127 +163,127 @@
         "line_number": 73
       }
     ],
-    "assessments\\2026-04-26-Bitnet_Launcher-assessment.json": [
+    "assessments/2026-04-26-Bitnet_Launcher-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-Bitnet_Launcher-assessment.json",
+        "filename": "assessments/2026-04-26-Bitnet_Launcher-assessment.json",
         "hashed_secret": "3add5e670c864f864dcff655e3c3194a64188a9d",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-Drake_Models-assessment.json": [
+    "assessments/2026-04-26-Drake_Models-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-Drake_Models-assessment.json",
+        "filename": "assessments/2026-04-26-Drake_Models-assessment.json",
         "hashed_secret": "bc62b1334557aaa7e4680657273360de7f3c26df",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-Games-assessment.json": [
+    "assessments/2026-04-26-Games-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-Games-assessment.json",
+        "filename": "assessments/2026-04-26-Games-assessment.json",
         "hashed_secret": "61d1149de9714b0b4015163642e45f073cd0e7c8",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-MEB_Conversion-assessment.json": [
+    "assessments/2026-04-26-MEB_Conversion-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-MEB_Conversion-assessment.json",
+        "filename": "assessments/2026-04-26-MEB_Conversion-assessment.json",
         "hashed_secret": "64c55fb40258eb3552e753a9270ff1941f91b59e",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-MLProjects-assessment.json": [
+    "assessments/2026-04-26-MLProjects-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-MLProjects-assessment.json",
+        "filename": "assessments/2026-04-26-MLProjects-assessment.json",
         "hashed_secret": "6b21671ba256e2a3ca8977af0ce238d50de26a27",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-Maxwell-Daemon-assessment.json": [
+    "assessments/2026-04-26-Maxwell-Daemon-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-Maxwell-Daemon-assessment.json",
+        "filename": "assessments/2026-04-26-Maxwell-Daemon-assessment.json",
         "hashed_secret": "32d13831b45f6894adcf0350d8c0ef89d176423e",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-Playground-assessment.json": [
+    "assessments/2026-04-26-Playground-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-Playground-assessment.json",
+        "filename": "assessments/2026-04-26-Playground-assessment.json",
         "hashed_secret": "eca5e735e8c47f0efa7f52051f0685626d8ae1b3",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-QuatEngine-assessment.json": [
+    "assessments/2026-04-26-QuatEngine-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-QuatEngine-assessment.json",
+        "filename": "assessments/2026-04-26-QuatEngine-assessment.json",
         "hashed_secret": "e9b3f91b7cfd3ab2cc70b437f4d3d3113215cc9a",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-Tools_Private-assessment.json": [
+    "assessments/2026-04-26-Tools_Private-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-Tools_Private-assessment.json",
+        "filename": "assessments/2026-04-26-Tools_Private-assessment.json",
         "hashed_secret": "1b74e58aca6a6b134e57053d77d3f64aeb5ccd3e",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-UpstreamDrift-assessment.json": [
+    "assessments/2026-04-26-UpstreamDrift-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-UpstreamDrift-assessment.json",
+        "filename": "assessments/2026-04-26-UpstreamDrift-assessment.json",
         "hashed_secret": "3b49fad7e7ca98883980a74a282754be1c65bb0c",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-Worksheet-Workshop-assessment.json": [
+    "assessments/2026-04-26-Worksheet-Workshop-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-Worksheet-Workshop-assessment.json",
+        "filename": "assessments/2026-04-26-Worksheet-Workshop-assessment.json",
         "hashed_secret": "c921485ac2c371ac187d6d203737f18606c9445a",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-controls-assessment.json": [
+    "assessments/2026-04-26-controls-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-controls-assessment.json",
+        "filename": "assessments/2026-04-26-controls-assessment.json",
         "hashed_secret": "9f6a6b5319bbac5becf4e88d27719a5be7f214d0",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "assessments\\2026-04-26-runner-dashboard-assessment.json": [
+    "assessments/2026-04-26-runner-dashboard-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "assessments\\2026-04-26-runner-dashboard-assessment.json",
+        "filename": "assessments/2026-04-26-runner-dashboard-assessment.json",
         "hashed_secret": "72f7bf6490482b633499a6a78087cdbf2b001980",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "config\\linear.json.example": [
+    "config/linear.json.example": [
       {
         "type": "Secret Keyword",
-        "filename": "config\\linear.json.example",
+        "filename": "config/linear.json.example",
         "hashed_secret": "f6812f111662373cfe2a784ab8c9767878903a79",
         "is_verified": false,
         "line_number": 10
@@ -298,211 +298,211 @@
         "type": "Secret Keyword"
       }
     ],
-    "docs\\assessments\\2026-04-26-runner-dashboard-assessment.json": [
+    "docs/assessments/2026-04-26-runner-dashboard-assessment.json": [
       {
         "type": "Hex High Entropy String",
-        "filename": "docs\\assessments\\2026-04-26-runner-dashboard-assessment.json",
+        "filename": "docs/assessments/2026-04-26-runner-dashboard-assessment.json",
         "hashed_secret": "72f7bf6490482b633499a6a78087cdbf2b001980",
         "is_verified": false,
         "line_number": 6
       }
     ],
-    "docs\\issue-taxonomy-backfill.yml": [
+    "docs/issue-taxonomy-backfill.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "docs\\issue-taxonomy-backfill.yml",
+        "filename": "docs/issue-taxonomy-backfill.yml",
         "hashed_secret": "dfdc8655e4d53a068469cc58d2da596d80e4c1dc",
         "is_verified": false,
         "line_number": 81
       }
     ],
-    "tests\\api\\test_dev_login_persistence.py": [
+    "tests/api/test_dev_login_persistence.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\api\\test_dev_login_persistence.py",
+        "filename": "tests/api/test_dev_login_persistence.py",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
         "line_number": 52
       }
     ],
-    "tests\\api\\test_linear_taxonomy_map.py": [
+    "tests/api/test_linear_taxonomy_map.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\api\\test_linear_taxonomy_map.py",
+        "filename": "tests/api/test_linear_taxonomy_map.py",
         "hashed_secret": "f6812f111662373cfe2a784ab8c9767878903a79",
         "is_verified": false,
         "line_number": 200
       }
     ],
-    "tests\\api\\test_linear_webhook.py": [
+    "tests/api/test_linear_webhook.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\api\\test_linear_webhook.py",
+        "filename": "tests/api/test_linear_webhook.py",
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_verified": false,
         "line_number": 115
       }
     ],
-    "tests\\test_assistant_tools.py": [
+    "tests/test_assistant_tools.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_assistant_tools.py",
+        "filename": "tests/test_assistant_tools.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
         "line_number": 184
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_assistant_tools.py",
+        "filename": "tests/test_assistant_tools.py",
         "hashed_secret": "48854c46907b8f99e4c4c711f3fb7336a93bc290",
         "is_verified": false,
         "line_number": 276
       }
     ],
-    "tests\\test_auth_webauthn.py": [
+    "tests/test_auth_webauthn.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_auth_webauthn.py",
+        "filename": "tests/test_auth_webauthn.py",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
         "line_number": 23
       }
     ],
-    "tests\\test_dashboard_config.py": [
+    "tests/test_dashboard_config.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_dashboard_config.py",
+        "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "02c173fc064db3d5d36ffbea6e3d09a6ca93ae45",
         "is_verified": false,
         "line_number": 293
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_dashboard_config.py",
+        "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
         "line_number": 298
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_dashboard_config.py",
+        "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "67bd5810ec8162548419905bc9769ccf95fe3a1f",
         "is_verified": false,
         "line_number": 309
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_dashboard_config.py",
+        "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "9c9c2851a11f00c5ae73b5d4f45b10f104868644",
         "is_verified": false,
         "line_number": 330
       }
     ],
-    "tests\\test_envelope_signing.py": [
+    "tests/test_envelope_signing.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_envelope_signing.py",
+        "filename": "tests/test_envelope_signing.py",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
         "line_number": 44
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_envelope_signing.py",
+        "filename": "tests/test_envelope_signing.py",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
         "line_number": 60
       }
     ],
-    "tests\\test_linear_taxonomy_utils.py": [
+    "tests/test_linear_taxonomy_utils.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_linear_taxonomy_utils.py",
+        "filename": "tests/test_linear_taxonomy_utils.py",
         "hashed_secret": "f6812f111662373cfe2a784ab8c9767878903a79",
         "is_verified": false,
         "line_number": 42
       }
     ],
-    "tests\\test_maxwell_contract.py": [
+    "tests/test_maxwell_contract.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_maxwell_contract.py",
+        "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "13951588fd3325e25ed1e3b116d7009fb221c85e",
         "is_verified": false,
         "line_number": 33
       },
       {
         "type": "Basic Auth Credentials",
-        "filename": "tests\\test_maxwell_contract.py",
+        "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
         "line_number": 34
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_maxwell_contract.py",
+        "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "99d72c7fc3e2e145870beab37c0b70e343ea9c3b",
         "is_verified": false,
         "line_number": 46
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_maxwell_contract.py",
+        "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "1902e3d6fc4e78a0bcc50ba12b882769afbf4a8c",
         "is_verified": false,
         "line_number": 66
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_maxwell_contract.py",
+        "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "10eb5a758459a052469c09f5cd56bab6036af011",
         "is_verified": false,
         "line_number": 101
       }
     ],
-    "tests\\test_push_module.py": [
+    "tests/test_push_module.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_push_module.py",
+        "filename": "tests/test_push_module.py",
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_verified": false,
         "line_number": 199
       }
     ],
-    "tests\\test_remote_logout.py": [
+    "tests/test_remote_logout.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_remote_logout.py",
+        "filename": "tests/test_remote_logout.py",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
         "line_number": 28
       }
     ],
-    "tests\\test_security.py": [
+    "tests/test_security.py": [
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_security.py",
+        "filename": "tests/test_security.py",
         "hashed_secret": "52e0b684278a23a4df0591929d470b8a8af68bcb",
         "is_verified": false,
         "line_number": 239
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_security.py",
+        "filename": "tests/test_security.py",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
         "line_number": 240
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_security.py",
+        "filename": "tests/test_security.py",
         "hashed_secret": "0c731a5f1dc781894b434c27b9f6a9cd9d9bdfcb",
         "is_verified": false,
         "line_number": 241
       },
       {
         "type": "Secret Keyword",
-        "filename": "tests\\test_security.py",
+        "filename": "tests/test_security.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 242

--- a/SPEC.md
+++ b/SPEC.md
@@ -134,6 +134,13 @@ The project pytest configuration declares `backend` on `pythonpath`, and
 `tests/conftest.py` also inserts the resolved backend directory before importing
 the FastAPI app and router dependencies.
 
+**Auth test fixtures (issue #343):** `mock_auth` is opt-in (not `autouse`).
+Tests that need to bypass authentication must declare `mock_auth` explicitly.
+`make_principal(id, type, roles)` creates a minimal `Principal`; the helpers
+`admin_principal`, `operator_principal`, and `viewer_principal` cover the
+three main roles. `make_authed_client(principal)` returns a `TestClient` with
+the given principal pre-wired.
+
 **Uvicorn runtime tuning (env-var driven, issue #393):**
 
 When `backend/server.py` is invoked as `__main__`, the uvicorn instance is

--- a/backend/routers/web_vitals.py
+++ b/backend/routers/web_vitals.py
@@ -9,7 +9,7 @@ import json
 import os
 import random
 import statistics
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -95,7 +95,7 @@ async def post_web_vitals(payload: WebVitalsPayload, request: Request) -> dict[s
             "delta": metric.delta,
             "id": metric.id,
             "navigation_type": metric.navigation_type,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
             "user_agent": request.headers.get("user-agent", ""),
         }
         data.append(entry)

--- a/backend/time_utils.py
+++ b/backend/time_utils.py
@@ -13,12 +13,12 @@ Two helpers are exposed:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def utc_now() -> datetime:
     """Return the current UTC time as a timezone-aware datetime."""
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def utc_now_iso() -> str:

--- a/tests/api/test_auth_perimeter.py
+++ b/tests/api/test_auth_perimeter.py
@@ -1,0 +1,160 @@
+"""Auth perimeter tests (issue #343).
+
+Verifies that:
+- Unauthenticated non-loopback requests are rejected with 401 by the auth gate.
+  (TestClient sends from 127.0.0.1 which is covered by the loopback admin bypass
+  from issue #315.  We test the logic directly via require_principal with a spoofed
+  non-loopback request rather than via the HTTP stack, to avoid coupling these tests
+  to #315 fix status.)
+- Operator-scoped principal is rejected on admin-only routes with 403.
+- Admin-scoped principal is accepted on admin-only routes.
+- make_principal / make_authed_client factories work across roles.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+import server  # noqa: E402
+from conftest import make_principal  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+from identity import require_principal  # noqa: E402
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _authed_client(role: str) -> TestClient:
+    """Create a TestClient with the given role injected."""
+    principal = make_principal(role)
+    server.app.dependency_overrides[require_principal] = lambda: principal
+    return TestClient(server.app, raise_server_exceptions=False)
+
+
+# ─── 1. Unauthenticated → 401 (tested via require_principal unit test) ────────
+#
+# The HTTP-level test cannot easily test 401 because TestClient connects from
+# 127.0.0.1, which is granted automatic admin access by the loopback bypass
+# (issue #315).  We instead unit-test require_principal directly with a spoofed
+# non-loopback request that has no token or session.
+
+
+def test_require_principal_raises_401_for_remote_unauthenticated_request() -> None:
+    """require_principal must raise HTTP 401 for non-loopback requests with no creds."""
+    mock_request = MagicMock()
+    mock_request.client.host = "192.168.1.100"  # non-loopback
+    mock_request.headers.get.return_value = None  # no impersonation header
+    mock_request.state = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_principal(request=mock_request, header_token=None, cookie_token=None)
+
+    assert exc_info.value.status_code == 401
+    assert "Authentication required" in str(exc_info.value.detail)
+
+
+@pytest.fixture(autouse=True)
+def _restore_dependency_overrides():
+    """Ensure overrides set by the local ``_authed_client`` helper are cleaned up.
+
+    The ``make_authed_client`` conftest fixture handles its own teardown separately.
+    """
+    yield
+    server.app.dependency_overrides.clear()
+
+
+# ─── 2. Operator on admin route → 403 ────────────────────────────────────────
+
+ADMIN_ONLY_ROUTES = [
+    ("GET", "/api/admin/principals"),
+    ("GET", "/api/admin/tokens"),
+    ("POST", "/api/admin/principals/test-id/token"),
+]
+
+
+@pytest.mark.parametrize(("method", "path"), ADMIN_ONLY_ROUTES)
+def test_operator_on_admin_route_returns_403(method: str, path: str) -> None:
+    """Operator-scoped principal must be rejected on admin-only routes with 403."""
+    client = _authed_client("operator")
+    resp = client.request(method, path, headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 403, f"Expected 403 on {method} {path} with operator, got {resp.status_code}"
+
+
+@pytest.mark.parametrize(("method", "path"), ADMIN_ONLY_ROUTES)
+def test_viewer_on_admin_route_returns_403(method: str, path: str) -> None:
+    """Viewer-scoped principal must be rejected on admin-only routes with 403."""
+    client = _authed_client("viewer")
+    resp = client.request(method, path, headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 403, f"Expected 403 on {method} {path} with viewer, got {resp.status_code}"
+
+
+# ─── 3. Admin accepted on admin routes ───────────────────────────────────────
+
+
+def test_admin_principal_can_list_principals() -> None:
+    """Admin-scoped principal must be accepted on GET /api/admin/principals."""
+    client = _authed_client("admin")
+    resp = client.get("/api/admin/principals", headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 200
+
+
+def test_admin_principal_can_list_tokens() -> None:
+    """Admin-scoped principal must be accepted on GET /api/admin/tokens."""
+    client = _authed_client("admin")
+    resp = client.get("/api/admin/tokens", headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 200
+
+
+# ─── 4. make_principal factory ───────────────────────────────────────────────
+
+@pytest.mark.parametrize("role", ["admin", "operator", "viewer"])
+def test_make_principal_factory_produces_correct_role(role: str) -> None:
+    """make_principal factory must produce a Principal with the given role."""
+    p = make_principal(role)
+    assert role in p.roles
+    assert p.id == f"test-{role}"
+    assert p.type == "bot"
+
+
+# ─── 5. make_authed_client fixture ───────────────────────────────────────────
+
+
+def test_make_authed_client_admin_can_access_protected_route() -> None:
+    """make_authed_client (inline) with admin principal must get 200 on /api/admin/principals."""
+    client = _authed_client("admin")
+    resp = client.get("/api/admin/principals", headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 200
+
+
+def test_make_authed_client_viewer_blocked_from_admin_route() -> None:
+    """make_authed_client (inline) with viewer principal must get 403 on admin routes."""
+    client = _authed_client("viewer")
+    resp = client.get("/api/admin/principals", headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 403
+
+
+def test_conftest_make_authed_client_works(make_authed_client) -> None:
+    """Verify the conftest make_authed_client factory works with different roles."""
+    admin_p = make_principal("admin")
+    viewer_p = make_principal("viewer")
+
+    admin_client = make_authed_client(admin_p)
+    resp = admin_client.get("/api/admin/principals", headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 200, f"admin should get 200 on /api/admin/principals, got {resp.status_code}"
+
+    # Reset for viewer test
+    server.app.dependency_overrides.clear()
+    viewer_client = make_authed_client(viewer_p)
+    resp = viewer_client.get("/api/admin/principals", headers={"X-Requested-With": "XMLHttpRequest"})
+    assert resp.status_code == 403, f"viewer should get 403 on /api/admin/principals, got {resp.status_code}"

--- a/tests/api/test_push.py
+++ b/tests/api/test_push.py
@@ -15,7 +15,7 @@ from identity import Principal  # noqa: E402
 
 
 @pytest_asyncio.fixture
-async def client():
+async def client(mock_auth):  # noqa: ARG001
     from httpx import ASGITransport, AsyncClient  # noqa: PLC0415
     from server import app  # noqa: PLC0415
 

--- a/tests/api/test_routers_linear.py
+++ b/tests/api/test_routers_linear.py
@@ -20,7 +20,7 @@ from routers import linear as linear_router  # noqa: E402
 
 
 @pytest.fixture
-def client() -> TestClient:
+def client(mock_auth) -> TestClient:  # noqa: ARG001
     return TestClient(server.app)
 
 

--- a/tests/api/test_routers_runners.py
+++ b/tests/api/test_routers_runners.py
@@ -31,7 +31,7 @@ from routers import runners as runners_router  # noqa: E402
 
 
 @pytest.fixture
-def client() -> TestClient:
+def client(mock_auth) -> TestClient:  # noqa: ARG001
     """Create a test client for the FastAPI app."""
     return TestClient(server.app)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,14 +10,81 @@ REPO_ROOT = Path(__file__).parent.parent
 import pytest  # noqa: E402
 
 
-@pytest.fixture(autouse=True)
-def mock_auth():
-    from identity import Principal, require_principal
-    from server import app
+def _make_principal(principal_id: str, role: str):
+    """Factory: build a Principal with a single role for use in tests."""
+    from identity import Principal  # noqa: PLC0415
 
-    def mock_principal():
+    return Principal(id=principal_id, type="bot", name=f"Test {role.capitalize()}", roles=[role])
+
+
+def make_principal(role: str, principal_id: str | None = None):
+    """Public factory consumed by parametrised tests.
+
+    Usage::
+
+        @pytest.mark.parametrize("role", ["admin", "operator", "viewer"])
+        def test_xxx(role):
+            p = make_principal(role)
+            ...
+    """
+    pid = principal_id or f"test-{role}"
+    return _make_principal(pid, role)
+
+
+@pytest.fixture
+def admin_principal():
+    """Pre-built admin Principal for opt-in use in tests."""
+    return _make_principal("test-admin", "admin")
+
+
+@pytest.fixture
+def operator_principal():
+    """Pre-built operator Principal for opt-in use in tests."""
+    return _make_principal("test-operator", "operator")
+
+
+@pytest.fixture
+def viewer_principal():
+    """Pre-built viewer Principal for opt-in use in tests."""
+    return _make_principal("test-viewer", "viewer")
+
+
+@pytest.fixture
+def make_authed_client():
+    """Factory returning a FastAPI TestClient with the given Principal injected.
+
+    Usage::
+
+        def test_xxx(make_authed_client, admin_principal):
+            client = make_authed_client(admin_principal)
+            resp = client.get("/api/some-route")
+            assert resp.status_code == 200
+    """
+    from fastapi.testclient import TestClient  # noqa: PLC0415
+    from identity import require_principal  # noqa: PLC0415
+    from server import app  # noqa: PLC0415
+
+    def _make(principal):
+        app.dependency_overrides[require_principal] = lambda: principal
+        return TestClient(app, raise_server_exceptions=False)
+
+    yield _make
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mock_auth():
+    """Opt-in fixture: override require_principal with a permanent admin Principal.
+
+    Tests that want the old "bypass auth" behaviour must declare this fixture
+    explicitly.  It is **not** autouse — authorization is exercised by default.
+    """
+    from identity import Principal, require_principal  # noqa: PLC0415
+    from server import app  # noqa: PLC0415
+
+    def _mock_principal():
         return Principal(id="test-admin", type="bot", name="Test Admin", roles=["admin"])
 
-    app.dependency_overrides[require_principal] = mock_principal
+    app.dependency_overrides[require_principal] = _mock_principal
     yield
     app.dependency_overrides.clear()

--- a/tests/frontend/test_fleet_mobile.py
+++ b/tests/frontend/test_fleet_mobile.py
@@ -17,7 +17,7 @@ if str(_BACKEND) not in sys.path:
 
 
 @pytest_asyncio.fixture
-async def client():
+async def client(mock_auth):  # noqa: ARG001
     from httpx import ASGITransport, AsyncClient  # noqa: PLC0415
     from server import app  # noqa: PLC0415
 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -39,7 +39,7 @@ def app():
 
 
 @pytest_asyncio.fixture
-async def client(app):
+async def client(app, mock_auth):  # noqa: ARG001
     """Async HTTP client wired directly to the ASGI app."""
     from httpx import ASGITransport, AsyncClient  # noqa: PLC0415
 

--- a/tests/test_maxwell_proxy.py
+++ b/tests/test_maxwell_proxy.py
@@ -28,7 +28,7 @@ def app():
 
 
 @pytest_asyncio.fixture
-async def client(app):
+async def client(app, mock_auth):  # noqa: ARG001
     """Async HTTP client wired directly to the ASGI app."""
     from httpx import ASGITransport, AsyncClient  # noqa: PLC0415
 

--- a/tests/test_repo_slug_validation.py
+++ b/tests/test_repo_slug_validation.py
@@ -43,11 +43,16 @@ def test_repository_normalizers_reuse_slug_validation(normalizer) -> None:
 
 
 @pytest.mark.parametrize("repo", ["abc&def", "../etc", "", "a" * 200])
-def test_workflow_dispatch_rejects_invalid_repository_before_gh_api(repo: str, monkeypatch) -> None:
+def test_workflow_dispatch_rejects_invalid_repository_before_gh_api(
+    repo: str, monkeypatch, mock_auth  # noqa: ARG001
+) -> None:
+    """Input validation (422) fires before dispatching — mock_auth prevents 401 masking it."""
+    from routers import runs_workflows  # noqa: PLC0415
+
     async def fail_run_cmd(*_args, **_kwargs):  # pragma: no cover - must not run
         raise AssertionError("invalid repository reached gh api")
 
-    monkeypatch.setattr("routers.runs_workflows.run_cmd", fail_run_cmd)
+    monkeypatch.setattr(runs_workflows, "run_cmd", fail_run_cmd)
     client = TestClient(server.app, headers={"X-Requested-With": "XMLHttpRequest"})
 
     response = client.post(
@@ -58,11 +63,16 @@ def test_workflow_dispatch_rejects_invalid_repository_before_gh_api(repo: str, m
     assert response.status_code == 422
 
 
-def test_cancel_run_rejects_invalid_path_repository_before_gh_api(monkeypatch) -> None:
+def test_cancel_run_rejects_invalid_path_repository_before_gh_api(
+    monkeypatch, mock_auth  # noqa: ARG001
+) -> None:
+    """Input validation (422) fires before dispatching — mock_auth prevents 401 masking it."""
+    from routers import queue  # noqa: PLC0415
+
     async def fail_run_cmd(*_args, **_kwargs):  # pragma: no cover - must not run
         raise AssertionError("invalid repository reached gh api")
 
-    monkeypatch.setattr("routers.queue.run_cmd", fail_run_cmd)
+    monkeypatch.setattr(queue, "run_cmd", fail_run_cmd)
     client = TestClient(server.app, headers={"X-Requested-With": "XMLHttpRequest"})
 
     response = client.post("/api/runs/abc%26def/cancel/123")

--- a/tests/test_workflow_inputs_validation.py
+++ b/tests/test_workflow_inputs_validation.py
@@ -115,7 +115,7 @@ def test_validate_keys_at_exact_limit_ok() -> None:
 
 
 @pytest.fixture
-def client() -> TestClient:
+def client(mock_auth) -> TestClient:  # noqa: ARG001
     return TestClient(app, headers={"X-Requested-With": "XMLHttpRequest"})
 
 


### PR DESCRIPTION
## Summary

- Closes #343
- `tests/conftest.py`: `mock_auth` is no longer `autouse=True`. Tests that need auth bypass must declare it explicitly.
- Added `make_principal()`, `admin_principal`, `operator_principal`, `viewer_principal` fixtures and `make_authed_client` factory for role-parametrised tests.
- Updated 9 existing test files to explicitly declare `mock_auth` on their `client` fixtures.
- Fixed pre-existing broken `monkeypatch.setattr` string paths in `test_repo_slug_validation` (was using string path `"routers.runs_workflows.run_cmd"` which doesn't work; changed to attribute patching on the imported module object).
- `tests/api/test_auth_perimeter.py` (new): 15 tests covering 401 for unauthenticated requests, 403 for insufficient roles on admin routes, admin access to admin routes, and factory correctness.

## Test plan

- [x] 237 existing tests pass with `mock_auth` opt-in
- [x] 15 new auth perimeter tests pass
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)