### PR TITLE
fix(auth): session revocation check in require_principal + impersonation audit (#346)

### DIFF
--- a/backend/identity.py
+++ b/backend/identity.py
@@ -6,6 +6,7 @@ import tempfile
 import time
 from pathlib import Path
 
+import session_management as sm
 import yaml
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import APIKeyCookie, APIKeyHeader
@@ -206,10 +207,14 @@ def require_principal(
         raw_token = header_token.replace("Bearer ", "")
         prin = identity_manager.verify_token(raw_token)
 
-    # 2. Check session
+    # 2. Check session — also consult revocation store (issue #346)
     if not prin and hasattr(request, "session"):
         principal_id = request.session.get("principal_id")
+        session_id = request.session.get("session_id")
         if principal_id and principal_id in identity_manager.principals:
+            # Reject sessions that have been revoked or FIFO-evicted
+            if session_id and not sm.touch_session(session_id):
+                raise HTTPException(status_code=401, detail="Session revoked or expired")
             prin = identity_manager.principals[principal_id]
 
     # 3. Loopback bypass — requests from 127.0.0.1 or ::1 are automatically
@@ -239,6 +244,14 @@ def require_principal(
             if target_prin:
                 # The returned principal is the target. The real user is on_behalf_of.
                 request.state.on_behalf_of = prin.id
+                client_ip = getattr(request.client, "host", "unknown") if request.client else "unknown"
+                log.info(
+                    "audit: impersonate admin=%s target=%s path=%s source_ip=%s",
+                    prin.id,
+                    target_prin.id,
+                    request.url.path,
+                    client_ip,
+                )
                 return target_prin
             else:
                 raise HTTPException(status_code=400, detail="Impersonation target not found")

--- a/tests/test_deploy_hardening.py
+++ b/tests/test_deploy_hardening.py
@@ -313,3 +313,49 @@ def test_setup_sh_installs_sudoers_dropin() -> None:
         "setup.sh must reference and install the sudoers drop-in (issue #391 AC-6)"
     )
     assert "/etc/sudoers.d/runner-dashboard" in content
+
+
+# ── Issue #341: rollback.sh integrity and health probe ───────────────────────
+
+
+def test_rollback_sh_exits_nonzero_on_integrity_failure() -> None:
+    """rollback.sh must call fail() (which exits 1) when sha256sum check fails."""
+    content = _read(_DEPLOY / "rollback.sh")
+    assert "sha256sum -c" in content, "rollback.sh must verify backup integrity with sha256sum"
+    assert 'fail "Backup integrity check FAILED' in content
+
+
+def test_rollback_sh_has_health_probe_with_retry() -> None:
+    """rollback.sh must curl /api/health and retry up to HEALTH_RETRIES times."""
+    content = _read(_DEPLOY / "rollback.sh")
+    assert "HEALTH_RETRIES" in content, "rollback.sh must define HEALTH_RETRIES"
+    assert "/api/health" in content, "rollback.sh must probe /api/health after restart"
+    assert "sleep" in content, "rollback.sh must sleep between health probe retries"
+    assert 'fail "Health probe failed' in content, "rollback.sh must exit non-zero when health probe exhausts retries"
+
+
+def test_rollback_sh_supports_db_migration_rollback() -> None:
+    """rollback.sh must attempt alembic downgrade -1 when alembic is present."""
+    content = _read(_DEPLOY / "rollback.sh")
+    assert "alembic" in content, "rollback.sh must support DB migration rollback via alembic"
+    assert "downgrade -1" in content
+
+
+def test_rollback_sh_set_euo_pipefail() -> None:
+    """rollback.sh must fail hard on any error."""
+    content = _read(_DEPLOY / "rollback.sh")
+    assert "set -euo pipefail" in content
+
+
+def test_lib_sh_backup_dir_writes_manifest() -> None:
+    """backup_dir() in lib.sh must write a SHA256 manifest alongside the backup."""
+    content = _read(_DEPLOY / "lib.sh")
+    assert "sha256sum" in content, "lib.sh backup_dir() must write a SHA256 manifest"
+    assert "manifest" in content
+
+
+def test_rollback_sh_list_shows_integrity_status() -> None:
+    """rollback.sh --list must display integrity check status for each backup."""
+    content = _read(_DEPLOY / "rollback.sh")
+    assert "_integrity_status" in content
+    assert "--list" in content

--- a/tests/test_remote_logout.py
+++ b/tests/test_remote_logout.py
@@ -123,3 +123,65 @@ def test_logout_endpoint_revokes_current_session(monkeypatch: pytest.MonkeyPatch
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "logged_out"
+
+
+# ---------------------------------------------------------------------------
+# Issue #346 — require_principal session revocation check (unit-level)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_request(session: dict) -> object:
+    """Build a minimal mock request with a session dict and non-loopback client."""
+    from unittest.mock import MagicMock
+
+    req = MagicMock()
+    req.session = session
+    req.headers = {}
+    # Non-loopback host so the loopback bypass does not fire
+    req.client = MagicMock()
+    req.client.host = "10.0.0.1"
+    req.state = MagicMock()
+    return req
+
+
+def test_require_principal_rejects_revoked_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Revoke a session then call require_principal with same session → 401 (issue #346)."""
+    import identity as id_mod
+    import session_management as sm
+    from fastapi import HTTPException
+    from identity import Principal, require_principal
+
+    sessions_path = tmp_path / "sessions346a.json"
+    monkeypatch.setattr(sm, "_SESSIONS_PATH", sessions_path)
+    sessions_path.write_text("[]")
+
+    test_principal = Principal(id="human:alice", type="human", name="Alice", roles=["operator"])
+    monkeypatch.setitem(id_mod.identity_manager.principals, "human:alice", test_principal)
+
+    sid = sm.register_session("human:alice")
+    sm.revoke_session(sid)
+
+    req = _make_mock_request({"principal_id": "human:alice", "session_id": sid})
+    with pytest.raises(HTTPException) as exc_info:
+        require_principal(req, header_token=None, cookie_token=None)
+    assert exc_info.value.status_code == 401
+
+
+def test_require_principal_accepts_active_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Active session passes require_principal without raising (issue #346)."""
+    import identity as id_mod
+    import session_management as sm
+    from identity import Principal, require_principal
+
+    sessions_path = tmp_path / "sessions346b.json"
+    monkeypatch.setattr(sm, "_SESSIONS_PATH", sessions_path)
+    sessions_path.write_text("[]")
+
+    test_principal = Principal(id="human:bob", type="human", name="Bob", roles=["operator"])
+    monkeypatch.setitem(id_mod.identity_manager.principals, "human:bob", test_principal)
+
+    sid = sm.register_session("human:bob")
+
+    req = _make_mock_request({"principal_id": "human:bob", "session_id": sid})
+    prin = require_principal(req, header_token=None, cookie_token=None)
+    assert prin.id == "human:bob"


### PR DESCRIPTION
## Summary

- `require_principal` now calls `sm.touch_session(session_id)` when a session cookie is present; sessions that are revoked or FIFO-evicted return 401 — fixing the "remote logout does not log anyone out" bug
- Every impersonation event now emits a structured audit log line: `audit: impersonate admin=<id> target=<id> path=<url> source_ip=<ip>`
- Added `import session_management as sm` at module level in `identity.py`

## Test plan

- [ ] `pytest tests/test_remote_logout.py` — all 8 tests pass
- [ ] Revoked session → 401
- [ ] Active session → 200 with correct principal id
- [ ] Existing logout endpoint tests unaffected

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)