### PR TITLE
fix(observability): split /livez (no I/O) from /readyz (dep checks) (#332)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -464,7 +464,7 @@ All endpoints are served under `http://localhost:8321/api/`.
 | GET | `/api/system` | Host system metrics (CPU, RAM, disk, GPU) |
 | GET | `/api/health` | Simple health check — returns `{“status”: “ok”}` |
 | GET | `/api/watchdog` | Watchdog status and last heartbeat |
-| GET | `/readyz` | Readiness probe — returns `{“status”:”ready”,”session_secret_source”:”env\|persisted\|generated”}` |
+| GET | `/readyz` | Readiness probe — runs dependency checks (GH_TOKEN, gh CLI, SQLite stores); returns 200 or 503 with `{status, checks}` |
 | GET | `/livez` | Liveness probe — returns `{“status”:”ok”}` with no I/O; always 200 if process is up |
 
 **Request ID correlation (`X-Request-ID`):**


### PR DESCRIPTION
## Summary

- Adds backend/readiness.py: Probe protocol, GhTokenProbe, GhCliProbe, LeaseDbProbe, PushDbProbe, and aggregate() function
- GET /livez returns 200 unconditionally (no I/O) — suitable for liveness probes and systemd WatchdogSec
- GET /readyz runs all probes concurrently; returns 503 with structured {status, checks} when any probe fails
- health.py no longer imports from server at module level — eliminates circular import crash regression
- GET /api/health retained for backward compatibility (human-readable composite view)
- SPEC.md updated to reflect new /readyz dependency-check semantics

## Test plan

- [x] tests/test_readiness.py: GhTokenProbe, GhCliProbe, aggregate(), /livez always 200, /readyz 503 on probe failure
- [x] tests/test_health_module.py: existing tests continue passing with /livez and /readyz routes
- [ ] Manual: GET /livez → 200; GET /readyz → 503 with {status, checks} when GH_TOKEN absent

Closes #332

🤖 Generated with Claude Code