### PR TITLE
fix(api-design): consistent error envelope, ErrorResponse model, semantic status codes (#406)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2141,3 +2141,36 @@ To ensure identity and quotas are respected across the entire fleet:
 < ! - -   U p d a t e d :   2 0 2 6 - 0 4 - 2 9 T 1 8 : 3 8 : 1 6   - - > 
  
  
+
+
+### 18.6 Consistent Error Envelope (issue #406)
+
+All 4xx and 5xx responses from `/api/*` routes return a JSON object conforming
+to `ErrorResponse` (`backend/error_models.py`):
+
+```json
+{
+  "error": "<machine-readable code>",
+  "detail": "<human-readable description>",
+  "request_id": "<optional trace id>"
+}
+```
+
+Standard error codes:
+
+| Code | HTTP status | Meaning |
+|------|-------------|---------|
+| `not_found` | 404 | Resource does not exist |
+| `forbidden` | 403 | Permission denied |
+| `validation_error` | 422 | Invalid request input |
+| `rate_limited` | 429 | GitHub rate limit hit |
+| `conflict` | 409 | State conflict (e.g. already stopped) |
+| `bad_gateway` | 502 | Upstream GitHub API error |
+| `server_error` | 500 | Internal server error |
+| `service_error` | 500/404/403 | systemd service lifecycle failure |
+
+Service lifecycle failures (`start`, `stop`, `restart`) additionally map
+stderr text to semantic status codes via `service_stderr_to_status()`:
+- "not loaded" / "Unit not found" → 404
+- "permission denied" / "access denied" → 403
+- anything else → 500

--- a/backend/error_models.py
+++ b/backend/error_models.py
@@ -1,0 +1,103 @@
+"""Shared error response models for consistent API error envelopes.
+
+All 4xx/5xx responses should use these models to guarantee a uniform shape:
+
+    {
+        "error": "<machine-readable code>",
+        "detail": "<human-readable description>",
+        "request_id": "<optional trace id>"
+    }
+
+Usage in a route handler::
+
+    from fastapi import HTTPException
+    raise HTTPException(status_code=404, detail="runner not found")
+
+The ``error_handler`` registered in ``server.py`` converts ``HTTPException``
+``detail`` strings into ``ErrorResponse`` JSON automatically.  For routes that
+return ``ErrorResponse`` directly (e.g. non-exception code paths), construct
+the model and return it with the appropriate ``JSONResponse``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ErrorResponse(BaseModel):
+    """Standard error envelope returned for every 4xx / 5xx response.
+
+    Attributes:
+        error:      Machine-readable error code (e.g. ``"not_found"``,
+                    ``"validation_error"``, ``"server_error"``).
+        detail:     Human-readable description of what went wrong.
+        request_id: Optional trace / correlation identifier injected by
+                    ``RequestContextMiddleware``.
+    """
+
+    error: str = Field(..., description="Machine-readable error code.")
+    detail: str = Field(..., description="Human-readable error description.")
+    request_id: str | None = Field(
+        default=None,
+        description="Optional request trace ID for correlation.",
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+# Convenience factories ------------------------------------------------------- #
+
+
+def not_found(detail: str, *, request_id: str | None = None) -> ErrorResponse:
+    """Return a 404 Not Found error envelope."""
+    return ErrorResponse(error="not_found", detail=detail, request_id=request_id)
+
+
+def validation_error(detail: str, *, request_id: str | None = None) -> ErrorResponse:
+    """Return a 422 Unprocessable Entity error envelope."""
+    return ErrorResponse(error="validation_error", detail=detail, request_id=request_id)
+
+
+def server_error(detail: str, *, request_id: str | None = None) -> ErrorResponse:
+    """Return a 500 Internal Server Error envelope."""
+    return ErrorResponse(error="server_error", detail=detail, request_id=request_id)
+
+
+def bad_gateway(detail: str, *, request_id: str | None = None) -> ErrorResponse:
+    """Return a 502 Bad Gateway error envelope."""
+    return ErrorResponse(error="bad_gateway", detail=detail, request_id=request_id)
+
+
+def rate_limited(detail: str, *, request_id: str | None = None) -> ErrorResponse:
+    """Return a 429 Too Many Requests error envelope."""
+    return ErrorResponse(error="rate_limited", detail=detail, request_id=request_id)
+
+
+def forbidden(detail: str, *, request_id: str | None = None) -> ErrorResponse:
+    """Return a 403 Forbidden error envelope."""
+    return ErrorResponse(error="forbidden", detail=detail, request_id=request_id)
+
+
+def conflict(detail: str, *, request_id: str | None = None) -> ErrorResponse:
+    """Return a 409 Conflict error envelope."""
+    return ErrorResponse(error="conflict", detail=detail, request_id=request_id)
+
+
+def service_error(detail: str, code: str = "service_error", *, request_id: str | None = None) -> ErrorResponse:
+    """Return an error envelope for a service-level failure (start/stop/restart)."""
+    return ErrorResponse(error=code, detail=detail, request_id=request_id)
+
+
+def service_stderr_to_status(stderr: str) -> int:
+    """Map systemd/service stderr text to a semantically correct HTTP status code.
+
+    - "not loaded" / "Unit not found" / "no such file"  → 404
+    - "permission denied" / "access denied" / "operation not permitted" → 403
+    - anything else → 500
+    """
+    lower = stderr.lower()
+    if "not loaded" in lower or "unit not found" in lower or "no such file" in lower:
+        return 404
+    if "permission denied" in lower or "access denied" in lower or "operation not permitted" in lower:
+        return 403
+    return 500

--- a/backend/routers/queue.py
+++ b/backend/routers/queue.py
@@ -16,6 +16,7 @@ import logging
 
 from cache_utils import cache_delete, cache_get, cache_set
 from dashboard_config import ORG
+from error_models import bad_gateway, validation_error
 from fastapi import APIRouter, Depends, HTTPException, Request
 from identity import Principal, require_scope
 from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
@@ -163,7 +164,10 @@ async def cancel_run(
         timeout=15,
     )
     if code != 0:
-        raise HTTPException(status_code=502, detail=f"Cancel failed: {stderr}")
+        raise HTTPException(
+            status_code=502,
+            detail=bad_gateway(f"Cancel failed: {stderr}").model_dump(exclude_none=True),
+        )
     # Invalidate stale queue/runs caches so the next poll reflects the cancel.
     cache_delete("queue")
     cache_delete("diagnose")
@@ -191,7 +195,10 @@ async def rerun_failed(
         timeout=15,
     )
     if code != 0:
-        raise HTTPException(status_code=502, detail=f"Rerun failed: {stderr}")
+        raise HTTPException(
+            status_code=502,
+            detail=bad_gateway(f"Rerun failed: {stderr}").model_dump(exclude_none=True),
+        )
     cache_delete("queue")
     return {"rerun": True, "run_id": run_id, "repo": repo}
 
@@ -215,7 +222,10 @@ async def cancel_workflow_runs(
         target_repo = validate_repo_slug(target_repo)
 
     if not workflow_name:
-        raise HTTPException(status_code=400, detail="workflow_name required")
+        raise HTTPException(
+            status_code=422,
+            detail=validation_error("workflow_name is required").model_dump(exclude_none=True),
+        )
 
     # Fetch current queue
     queue_data = await _queue_impl()

--- a/backend/routers/runners.py
+++ b/backend/routers/runners.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from cache_utils import cache_get, cache_set
 from dashboard_config import ORG
+from error_models import bad_gateway, not_found, rate_limited, service_error, service_stderr_to_status
 from fastapi import APIRouter, Depends, HTTPException, Request
 from gh_utils import RateLimitedError, gh_api_admin
 from identity import Principal, require_scope
@@ -100,16 +101,17 @@ async def get_runners(request: Request) -> dict[str, Any]:
         log.warning("GitHub rate limit while fetching runners: retry_after=%d", exc.retry_after_seconds)
         raise HTTPException(
             status_code=429,
-            detail={
-                "error": "github_rate_limited",
-                "retry_after_seconds": exc.retry_after_seconds,
-                "resource_class": exc.resource_class,
-            },
+            detail=rate_limited(f"GitHub rate limited; retry after {exc.retry_after_seconds}s").model_dump(
+                exclude_none=True
+            ),
             headers={"Retry-After": str(exc.retry_after_seconds)},
         ) from exc
     except Exception as exc:
         log.error("failed to fetch runners: %s", exc)
-        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
+        raise HTTPException(
+            status_code=502,
+            detail=bad_gateway(f"GitHub API error: {exc}").model_dump(exclude_none=True),
+        ) from exc
 
 
 @router.get("/api/runners/matlab")
@@ -187,12 +189,19 @@ async def start_runner(
 
         if num is None:
             log.warning("start_runner: runner_id=%d not found locally (principal=%s)", runner_id, principal.user_id)
-            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found locally")
+            raise HTTPException(
+                status_code=404,
+                detail=not_found(f"Runner ID {runner_id} not found locally").model_dump(exclude_none=True),
+            )
 
         code, stdout, stderr = await run_runner_svc(num, "start")
         if code != 0:
             log.error("start_runner: failed for runner_num=%d: %s (principal=%s)", num, stderr, principal.user_id)
-            raise HTTPException(status_code=500, detail=f"Failed to start runner {num}: {stderr}")
+            status = service_stderr_to_status(stderr)
+            raise HTTPException(
+                status_code=status,
+                detail=service_error(f"Failed to start runner {num}: {stderr}").model_dump(exclude_none=True),
+            )
 
         log.info("start_runner: started runner_num=%d (runner_id=%d, principal=%s)", num, runner_id, principal.user_id)
         return {"status": "started", "runner": num, "output": stdout.strip()}
@@ -200,7 +209,10 @@ async def start_runner(
         raise
     except Exception as exc:
         log.error("start_runner: unexpected error for runner_id=%d: %s", runner_id, exc)
-        raise HTTPException(status_code=500, detail=f"Internal error: {exc}") from exc
+        raise HTTPException(
+            status_code=500,
+            detail=service_error(f"Internal error: {exc}").model_dump(exclude_none=True),
+        ) from exc
 
 
 @router.post("/api/runners/{runner_id}/stop")
@@ -231,12 +243,19 @@ async def stop_runner(
 
         if num is None:
             log.warning("stop_runner: runner_id=%d not found locally (principal=%s)", runner_id, principal.user_id)
-            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found locally")
+            raise HTTPException(
+                status_code=404,
+                detail=not_found(f"Runner ID {runner_id} not found locally").model_dump(exclude_none=True),
+            )
 
         code, stdout, stderr = await run_runner_svc(num, "stop")
         if code != 0:
             log.error("stop_runner: failed for runner_num=%d: %s (principal=%s)", num, stderr, principal.user_id)
-            raise HTTPException(status_code=500, detail=f"Failed to stop runner {num}: {stderr}")
+            status = service_stderr_to_status(stderr)
+            raise HTTPException(
+                status_code=status,
+                detail=service_error(f"Failed to stop runner {num}: {stderr}").model_dump(exclude_none=True),
+            )
 
         log.info("stop_runner: stopped runner_num=%d (runner_id=%d, principal=%s)", num, runner_id, principal.user_id)
         return {"status": "stopped", "runner": num, "output": stdout.strip()}
@@ -244,7 +263,10 @@ async def stop_runner(
         raise
     except Exception as exc:
         log.error("stop_runner: unexpected error for runner_id=%d: %s", runner_id, exc)
-        raise HTTPException(status_code=500, detail=f"Internal error: {exc}") from exc
+        raise HTTPException(
+            status_code=500,
+            detail=service_error(f"Internal error: {exc}").model_dump(exclude_none=True),
+        ) from exc
 
 
 @router.post("/api/runners/{runner_id}/restart")
@@ -275,13 +297,19 @@ async def restart_runner(
 
         if num is None:
             log.warning("restart_runner: runner_id=%d not found locally (principal=%s)", runner_id, principal.user_id)
-            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found locally")
+            raise HTTPException(
+                status_code=404,
+                detail=not_found(f"Runner ID {runner_id} not found locally").model_dump(exclude_none=True),
+            )
 
         # Stop
         stop_code, stop_stdout, stop_stderr = await run_runner_svc(num, "stop")
         if stop_code != 0:
             log.error("restart_runner: stop failed for runner_num=%d: %s", num, stop_stderr)
-            raise HTTPException(status_code=500, detail=f"Failed to stop runner {num}: {stop_stderr}")
+            raise HTTPException(
+                status_code=service_stderr_to_status(stop_stderr),
+                detail=service_error(f"Failed to stop runner {num}: {stop_stderr}").model_dump(exclude_none=True),
+            )
 
         # Brief delay
         await asyncio.sleep(1)
@@ -290,7 +318,10 @@ async def restart_runner(
         start_code, start_stdout, start_stderr = await run_runner_svc(num, "start")
         if start_code != 0:
             log.error("restart_runner: start failed for runner_num=%d: %s", num, start_stderr)
-            raise HTTPException(status_code=500, detail=f"Failed to start runner {num}: {start_stderr}")
+            raise HTTPException(
+                status_code=service_stderr_to_status(start_stderr),
+                detail=service_error(f"Failed to start runner {num}: {start_stderr}").model_dump(exclude_none=True),
+            )
 
         log.info(
             "restart_runner: restarted runner_num=%d (runner_id=%d, principal=%s)",
@@ -308,7 +339,10 @@ async def restart_runner(
         raise
     except Exception as exc:
         log.error("restart_runner: unexpected error for runner_id=%d: %s", runner_id, exc)
-        raise HTTPException(status_code=500, detail=f"Internal error: {exc}") from exc
+        raise HTTPException(
+            status_code=500,
+            detail=service_error(f"Internal error: {exc}").model_dump(exclude_none=True),
+        ) from exc
 
 
 @router.get("/api/runners/{runner_id}/status")
@@ -333,7 +367,10 @@ async def get_runner_status(request: Request, runner_id: int) -> dict[str, Any]:
 
         if runner is None:
             log.warning("get_runner_status: runner_id=%d not found", runner_id)
-            raise HTTPException(status_code=404, detail=f"Runner ID {runner_id} not found")
+            raise HTTPException(
+                status_code=404,
+                detail=not_found(f"Runner ID {runner_id} not found").model_dump(exclude_none=True),
+            )
 
         num = runner_num_from_id(runner_id, runners)
         health = runner_health_check(runner)
@@ -357,4 +394,7 @@ async def get_runner_status(request: Request, runner_id: int) -> dict[str, Any]:
         raise
     except Exception as exc:
         log.error("get_runner_status: error for runner_id=%d: %s", runner_id, exc)
-        raise HTTPException(status_code=502, detail=f"GitHub API error: {exc}") from exc
+        raise HTTPException(
+            status_code=502,
+            detail=bad_gateway(f"GitHub API error: {exc}").model_dump(exclude_none=True),
+        ) from exc

--- a/backend/routers/runs_workflows.py
+++ b/backend/routers/runs_workflows.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import scheduled_workflows as scheduled_workflow_inventory
 from cache_utils import cache_get, cache_set
 from dashboard_config import ORG, REPO_ROOT, RUN_JOB_ENRICHMENT_LIMIT
+from error_models import bad_gateway, validation_error
 from fastapi import APIRouter, Depends, HTTPException, Request
 from gh_utils import gh_api, gh_api_raw
 from identity import Principal, require_scope
@@ -359,7 +360,10 @@ async def dispatch_workflow(
     approved_by = principal.id
 
     if not repo or not workflow_id:
-        raise HTTPException(status_code=422, detail="repository and workflow_id required")
+        raise HTTPException(
+            status_code=422,
+            detail=validation_error("repository and workflow_id are required").model_dump(exclude_none=True),
+        )
     repo = validate_repo_slug(repo)
 
     endpoint = f"/repos/{ORG}/{repo}/actions/workflows/{workflow_id}/dispatches"
@@ -383,7 +387,10 @@ async def dispatch_workflow(
             workflow_id,
             stderr.strip()[:300],
         )
-        raise HTTPException(status_code=502, detail="Workflow dispatch failed")
+        raise HTTPException(
+            status_code=502,
+            detail=bad_gateway("Workflow dispatch failed").model_dump(exclude_none=True),
+        )
 
     log.info(
         "workflow_dispatch audit: repo=%s workflow_id=%s ref=%s approved_by=%s",

--- a/tests/test_error_models.py
+++ b/tests/test_error_models.py
@@ -1,0 +1,123 @@
+"""Tests for the shared ErrorResponse model and factory helpers (issue #406)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+
+def test_error_response_shape() -> None:
+    """ErrorResponse must produce the canonical envelope."""
+    from error_models import ErrorResponse
+
+    resp = ErrorResponse(error="not_found", detail="runner 99 not found")
+    payload = resp.model_dump(exclude_none=True)
+    assert payload == {"error": "not_found", "detail": "runner 99 not found"}
+
+
+def test_error_response_with_request_id() -> None:
+    """request_id field is included when provided."""
+    from error_models import ErrorResponse
+
+    resp = ErrorResponse(error="server_error", detail="boom", request_id="abc-123")
+    payload = resp.model_dump(exclude_none=True)
+    assert payload["request_id"] == "abc-123"
+
+
+def test_error_response_excludes_none_request_id() -> None:
+    """request_id is absent when not set."""
+    from error_models import ErrorResponse
+
+    resp = ErrorResponse(error="not_found", detail="missing")
+    payload = resp.model_dump(exclude_none=True)
+    assert "request_id" not in payload
+
+
+def test_factory_not_found() -> None:
+    from error_models import not_found
+
+    r = not_found("runner 42 not found")
+    assert r.error == "not_found"
+    assert "42" in r.detail
+
+
+def test_factory_validation_error() -> None:
+    from error_models import validation_error
+
+    r = validation_error("workflow_name is required")
+    assert r.error == "validation_error"
+
+
+def test_factory_bad_gateway() -> None:
+    from error_models import bad_gateway
+
+    r = bad_gateway("upstream timeout")
+    assert r.error == "bad_gateway"
+
+
+def test_factory_rate_limited() -> None:
+    from error_models import rate_limited
+
+    r = rate_limited("GitHub rate limited; retry after 60s")
+    assert r.error == "rate_limited"
+
+
+def test_factory_service_error_default_code() -> None:
+    from error_models import service_error
+
+    r = service_error("Failed to start runner 3: stderr output")
+    assert r.error == "service_error"
+
+
+def test_extra_fields_forbidden() -> None:
+    """ErrorResponse rejects extra fields (extra='forbid')."""
+    from error_models import ErrorResponse
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ErrorResponse(error="x", detail="y", unexpected_key="z")  # type: ignore[call-arg]
+
+
+def test_runners_router_imports_error_models() -> None:
+    """runners.py must import from error_models (including service_stderr_to_status)."""
+    source = (_BACKEND_DIR / "routers" / "runners.py").read_text(encoding="utf-8")
+    assert "from error_models import" in source
+    assert "service_stderr_to_status" in source
+
+
+def test_queue_router_imports_error_models() -> None:
+    """queue.py must import from error_models."""
+    source = (_BACKEND_DIR / "routers" / "queue.py").read_text(encoding="utf-8")
+    assert "from error_models import" in source
+
+
+def test_runs_workflows_router_imports_error_models() -> None:
+    """runs_workflows.py must import from error_models."""
+    source = (_BACKEND_DIR / "routers" / "runs_workflows.py").read_text(encoding="utf-8")
+    assert "from error_models import" in source
+
+
+def test_service_error_status_not_loaded() -> None:
+    """service_stderr_to_status maps 'not loaded' stderr to 404."""
+    from error_models import service_stderr_to_status
+
+    assert service_stderr_to_status("Unit not found or not loaded") == 404
+
+
+def test_service_error_status_permission_denied() -> None:
+    """service_stderr_to_status maps 'permission denied' to 403."""
+    from error_models import service_stderr_to_status
+
+    assert service_stderr_to_status("Failed to start: permission denied") == 403
+
+
+def test_service_error_status_generic() -> None:
+    """service_stderr_to_status maps unknown stderr to 500."""
+    from error_models import service_stderr_to_status
+
+    assert service_stderr_to_status("Some random error occurred") == 500


### PR DESCRIPTION
## Summary

- Adds `backend/error_models.py` with a Pydantic `ErrorResponse` model (`{"error": "...", "detail": "...", "request_id": "..."}`) and factory helpers for all standard error codes
- Updates `routers/runners.py`: all 4xx/5xx now return structured envelopes; maps systemd stderr to semantic HTTP codes (`"not loaded"` → 404, `"permission denied"` → 403) instead of always returning 500
- Updates `routers/queue.py` and `routers/runs_workflows.py` with structured error dicts
- Documents the canonical error envelope in `SPEC.md §18.6`
- Adds 15 unit tests covering the model, factories, and stderr-to-status mapping

## Test plan

- [x] `python3 -m pytest tests/test_error_models.py -q` — all 15 tests pass
- [x] `python3 -m ruff check` — clean on all changed files
- [x] `python3 -m ruff format --check` — all formatted

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)