### PR TITLE
fix(lod): typed GhWorkflowRun/GhJob/GhRunner replace .get() chains (#407)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2223,3 +2223,18 @@ stderr text to semantic status codes via `service_stderr_to_status()`:
 - "not loaded" / "Unit not found" → 404
 - "permission denied" / "access denied" → 403
 - anything else → 500
+### 18.7 Typed GitHub Payload Models (issue #407)
+
+GitHub API response dicts are now parsed at the boundary into typed Pydantic
+view-models defined in `backend/models/github_payloads.py`:
+
+| Model | Replaces |
+|-------|---------|
+| `GhWorkflowRun` | `run.get("id")`, `(run.get("repository") or {}).get("name", "")` chains |
+| `GhJob` | `j.get("runner_name")`, label dicts vs strings |
+| `GhRunner` | `runner["labels"][i]["name"]`, `runner.get("busy")` |
+| `GhRepository` | nested repository sub-dict |
+| `GhActor` | `triggering_actor.get("login")` |
+
+All models use `extra="ignore"` so new GitHub API fields never break
+existing handlers.  Handlers receive flat, typed objects (Law of Demeter).

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,1 @@
+# backend/models package

--- a/backend/models/github_payloads.py
+++ b/backend/models/github_payloads.py
@@ -1,0 +1,193 @@
+"""Typed Pydantic view-models for GitHub API response payloads.
+
+These models cover only the fields the dashboard actually consumes.
+Unknown fields are silently ignored (``extra="ignore"``), so adding new
+GitHub API fields never breaks existing handlers.
+
+Law-of-Demeter fix: instead of
+    ``(run.get("repository") or {}).get("name", "")``
+handlers receive a flat, typed object and can write
+    ``run.repository.name`` or ``run.repository_name``.
+
+Usage::
+
+    from models.github_payloads import GhWorkflowRun
+
+    raw_dict = await gh_api("/repos/org/repo/actions/runs")
+    runs = [GhWorkflowRun.model_validate(r) for r in raw_dict.get("workflow_runs", [])]
+    for run in runs:
+        print(run.id, run.repository.name if run.repository else "")
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# --------------------------------------------------------------------------- #
+# Shared sub-models
+# --------------------------------------------------------------------------- #
+
+
+class GhLabel(BaseModel):
+    """A single runner label returned by the GitHub API."""
+
+    id: int | None = None
+    name: str = ""
+    type: str | None = None
+
+    model_config = {"extra": "ignore"}
+
+
+class GhRepository(BaseModel):
+    """Minimal repository shape consumed by dashboard routes.
+
+    Fields kept to what the dashboard reads; everything else is silently
+    ignored per ``extra="ignore"``.
+    """
+
+    id: int | None = None
+    name: str = ""
+    full_name: str = ""
+    private: bool = False
+    html_url: str = ""
+    default_branch: str = "main"
+
+    model_config = {"extra": "ignore"}
+
+
+class GhActor(BaseModel):
+    """GitHub user / actor reference."""
+
+    id: int | None = None
+    login: str = ""
+    avatar_url: str = ""
+    html_url: str = ""
+    type: str = "User"
+
+    model_config = {"extra": "ignore"}
+
+
+# --------------------------------------------------------------------------- #
+# Workflow run
+# --------------------------------------------------------------------------- #
+
+
+class GhWorkflowRun(BaseModel):
+    """GitHub Actions workflow run as returned by the Workflow Runs API.
+
+    Replaces patterns like::
+
+        run.get("id")
+        (run.get("repository") or {}).get("name", "")
+        run.get("triggering_actor", {}).get("login")
+    """
+
+    id: int = 0
+    name: str = ""
+    status: str = ""
+    conclusion: str | None = None
+    created_at: str = ""
+    updated_at: str = ""
+    html_url: str = ""
+    head_branch: str = ""
+    head_sha: str = ""
+    run_number: int = 0
+    run_attempt: int = 1
+    event: str = ""
+    workflow_id: int | None = None
+    workflow_url: str = ""
+    display_title: str = ""
+    actor: GhActor | None = None
+    triggering_actor: GhActor | None = None
+    repository: GhRepository | None = None
+
+    model_config = {"extra": "ignore"}
+
+    @property
+    def repository_name(self) -> str:
+        """Convenience: repo name without chaining .get()."""
+        return self.repository.name if self.repository else ""
+
+    @property
+    def triggering_login(self) -> str:
+        """Convenience: triggering actor login."""
+        return self.triggering_actor.login if self.triggering_actor else ""
+
+    @property
+    def actor_login(self) -> str:
+        """Convenience: actor login."""
+        return self.actor.login if self.actor else ""
+
+
+# --------------------------------------------------------------------------- #
+# Workflow job
+# --------------------------------------------------------------------------- #
+
+
+class GhJob(BaseModel):
+    """A single job within a workflow run (from /actions/runs/{id}/jobs)."""
+
+    id: int = 0
+    run_id: int = 0
+    name: str = ""
+    status: str = ""
+    conclusion: str | None = None
+    runner_id: int | None = None
+    runner_name: str | None = None
+    runner_group_id: int | None = None
+    runner_group_name: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    html_url: str = ""
+    labels: list[str] = Field(default_factory=list)
+
+    model_config = {"extra": "ignore"}
+
+    @classmethod
+    def from_api_dict(cls, data: dict) -> GhJob:
+        """Construct from a raw GitHub API job dict.
+
+        Normalises ``labels`` which may be a list of dicts or strings.
+        """
+        labels_raw = data.get("labels", [])
+        if labels_raw and isinstance(labels_raw[0], dict):
+            labels = [lbl.get("name", "") for lbl in labels_raw if isinstance(lbl, dict)]
+        else:
+            labels = [str(lbl) for lbl in labels_raw]
+        return cls(**{**data, "labels": labels})
+
+
+# --------------------------------------------------------------------------- #
+# Runner
+# --------------------------------------------------------------------------- #
+
+
+class GhRunner(BaseModel):
+    """A self-hosted GitHub Actions runner.
+
+    Replaces patterns like::
+
+        runner["labels"][i]["name"]
+        runner.get("status")
+        runner.get("busy")
+    """
+
+    id: int = 0
+    name: str = ""
+    os: str = ""
+    status: str = ""
+    busy: bool = False
+    labels: list[GhLabel] = Field(default_factory=list)
+    accessed_at: str | None = None
+    created_at: str | None = None
+
+    model_config = {"extra": "ignore"}
+
+    @property
+    def label_names(self) -> list[str]:
+        """Return label names as a flat list (replaces list-comp with .get())."""
+        return [lbl.name for lbl in self.labels if lbl.name]
+
+    @property
+    def is_online(self) -> bool:
+        return self.status == "online"

--- a/backend/routers/heavy_tests.py
+++ b/backend/routers/heavy_tests.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from dashboard_config import ORG
 from fastapi import APIRouter, Depends, HTTPException, Request
 from identity import Principal, require_scope  # noqa: B008
+from models.github_payloads import GhWorkflowRun
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -64,18 +65,19 @@ async def get_heavy_test_repos() -> dict:
         if code == 0:
             try:
                 data = json.loads(stdout)
-                for run in data.get("workflow_runs", []):
+                for raw_run in data.get("workflow_runs", []):
+                    run = GhWorkflowRun.model_validate(raw_run)
                     recent_runs.append(
                         {
-                            "id": run["id"],
-                            "status": run["status"],
-                            "conclusion": run.get("conclusion"),
-                            "created_at": run.get("created_at"),
-                            "updated_at": run.get("updated_at"),
-                            "html_url": run.get("html_url"),
-                            "head_branch": run.get("head_branch"),
-                            "run_number": run.get("run_number"),
-                            "triggering_actor": run.get("triggering_actor", {}).get("login"),
+                            "id": run.id,
+                            "status": run.status,
+                            "conclusion": run.conclusion,
+                            "created_at": run.created_at,
+                            "updated_at": run.updated_at,
+                            "html_url": run.html_url,
+                            "head_branch": run.head_branch,
+                            "run_number": run.run_number,
+                            "triggering_actor": run.triggering_login or None,
                         }
                     )
             except (json.JSONDecodeError, ValueError):

--- a/backend/routers/queue.py
+++ b/backend/routers/queue.py
@@ -19,6 +19,7 @@ from dashboard_config import ORG
 from error_models import bad_gateway, validation_error
 from fastapi import APIRouter, Depends, HTTPException, Request
 from identity import Principal, require_scope
+from models.github_payloads import GhWorkflowRun
 from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
 from security import validate_repo_slug
 from system_utils import run_cmd
@@ -227,20 +228,18 @@ async def cancel_workflow_runs(
             detail=validation_error("workflow_name is required").model_dump(exclude_none=True),
         )
 
-    # Fetch current queue
+    # Fetch current queue — parse into typed view-models to avoid .get() chains
     queue_data = await _queue_impl()
+    typed_runs = [GhWorkflowRun.model_validate(r) for r in queue_data.get("queued", [])]
     runs_to_cancel = [
-        r
-        for r in queue_data["queued"]
-        if r.get("name") == workflow_name
-        and (target_repo is None or (r.get("repository") or {}).get("name") == target_repo)  # noqa: E501
+        r for r in typed_runs if r.name == workflow_name and (target_repo is None or r.repository_name == target_repo)
     ]
 
     cancelled: list[dict] = []
     errors: list[str] = []
     for run in runs_to_cancel:
-        repo = (run.get("repository") or {}).get("name", "")
-        run_id = run["id"]
+        repo = run.repository_name
+        run_id = run.id
         if not repo:
             continue
         code, _, stderr = await run_cmd(

--- a/backend/routers/runner_helpers.py
+++ b/backend/routers/runner_helpers.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from dashboard_config import RUNNER_BASE_DIR
+from models.github_payloads import GhRunner
 from system_utils import run_cmd
 
 # Python 3.11+ has datetime.UTC; fall back to timezone.utc for 3.10
@@ -90,28 +91,43 @@ def runner_sort_key(runner: dict) -> tuple[str, int, str]:
     return (status_rank, num, name)
 
 
-def is_matlab_runner(runner: dict) -> bool:
+def is_matlab_runner(runner: dict | GhRunner) -> bool:
     """Check if runner has MATLAB installed by examining labels.
 
+    Accepts both raw GitHub API dicts and typed ``GhRunner`` instances.
+
     Args:
-        runner: Runner dict from GitHub API.
+        runner: Runner dict or typed GhRunner from GitHub API.
 
     Returns:
         True if MATLAB label is present.
     """
-    labels = [lbl.get("name", "").lower() for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
-    return "matlab" in labels or "windows-matlab" in labels
+    if isinstance(runner, GhRunner):
+        label_names = [lbl.lower() for lbl in runner.label_names]
+    else:
+        label_names = [lbl.get("name", "").lower() for lbl in runner.get("labels", []) if isinstance(lbl, dict)]
+    return "matlab" in label_names or "windows-matlab" in label_names
 
 
-def matlab_runner_summary(runner: dict) -> dict[str, Any]:
+def matlab_runner_summary(runner: dict | GhRunner) -> dict[str, Any]:
     """Extract summary for MATLAB runners.
 
+    Accepts both raw GitHub API dicts and typed ``GhRunner`` instances.
+
     Args:
-        runner: Runner dict from GitHub API.
+        runner: Runner dict or typed GhRunner from GitHub API.
 
     Returns:
         Simplified runner dict with key fields.
     """
+    if isinstance(runner, GhRunner):
+        return {
+            "id": runner.id,
+            "name": runner.name,
+            "status": runner.status,
+            "busy": runner.busy,
+            "labels": runner.label_names,
+        }
     return {
         "id": runner.get("id"),
         "name": runner.get("name"),
@@ -121,11 +137,13 @@ def matlab_runner_summary(runner: dict) -> dict[str, Any]:
     }
 
 
-def runner_health_check(runner: dict, system_metrics: dict | None = None) -> dict[str, Any]:
+def runner_health_check(runner: dict | GhRunner, system_metrics: dict | None = None) -> dict[str, Any]:
     """Compute health status for a runner.
 
+    Accepts both raw GitHub API dicts and typed ``GhRunner`` instances.
+
     Args:
-        runner: Runner dict from GitHub API.
+        runner: Runner dict or typed GhRunner from GitHub API.
         system_metrics: Optional system metrics snapshot.
 
     Returns:
@@ -134,17 +152,27 @@ def runner_health_check(runner: dict, system_metrics: dict | None = None) -> dic
     health_status = "healthy"
     issues = []
 
-    if runner.get("status") != "online":
-        health_status = "offline"
-        issues.append(f"runner offline ({runner.get('status')})")
+    if isinstance(runner, GhRunner):
+        runner_id = runner.id
+        runner_name = runner.name
+        status = runner.status
+        labels: list = runner.labels
+    else:
+        runner_id = runner.get("id")
+        runner_name = runner.get("name")
+        status = runner.get("status")
+        labels = runner.get("labels", [])
 
-    labels = runner.get("labels", [])
+    if status != "online":
+        health_status = "offline"
+        issues.append(f"runner offline ({status})")
+
     if not labels:
         issues.append("no labels assigned")
 
     return {
-        "runner_id": runner.get("id"),
-        "runner_name": runner.get("name"),
+        "runner_id": runner_id,
+        "runner_name": runner_name,
         "status": health_status,
         "issues": issues,
         "last_check": _dt_mod.datetime.now(UTC).isoformat(),

--- a/backend/routers/runs_workflows.py
+++ b/backend/routers/runs_workflows.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from gh_utils import gh_api, gh_api_raw
 from identity import Principal, require_scope
 from input_validation import validate_workflow_inputs
+from models.github_payloads import GhJob, GhWorkflowRun
 from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
 from security import validate_repo_slug
 from system_utils import run_cmd
@@ -72,28 +73,32 @@ async def _fetch_repo_runs(repo_name: str, per_page: int = 10, status: str | Non
 
 
 async def _enrich_run_with_job_placement(run: dict) -> dict:
-    """Add job-level runner placement data to a workflow run."""
+    """Add job-level runner placement data to a workflow run.
+
+    Uses ``GhWorkflowRun`` and ``GhJob`` typed models to extract fields,
+    replacing nested ``.get()`` chains with typed attribute access.
+    """
     enriched = dict(run)
-    repo = run.get("repository", {}).get("name") or run.get("repo")
-    run_id = run.get("id")
+    typed_run = GhWorkflowRun.model_validate(run)
+    repo = typed_run.repository_name or run.get("repo")
+    run_id = typed_run.id
     if not repo or not run_id:
         return enriched
     repo = validate_repo_slug(repo)
     try:
         data = await gh_api(f"/repos/{ORG}/{repo}/actions/runs/{run_id}/jobs")
-        jobs = data.get("jobs", [])
         enriched["jobs"] = [
             {
-                "id": j.get("id"),
-                "name": j.get("name"),
-                "status": j.get("status"),
-                "conclusion": j.get("conclusion"),
-                "runner_name": j.get("runner_name"),
-                "runner_id": j.get("runner_id"),
-                "started_at": j.get("started_at"),
-                "completed_at": j.get("completed_at"),
+                "id": job.id,
+                "name": job.name,
+                "status": job.status,
+                "conclusion": job.conclusion,
+                "runner_name": job.runner_name,
+                "runner_id": job.runner_id,
+                "started_at": job.started_at,
+                "completed_at": job.completed_at,
             }
-            for j in jobs
+            for job in (GhJob.from_api_dict(j) for j in data.get("jobs", []))
         ]
     except Exception:  # noqa: BLE001
         enriched["jobs"] = []

--- a/tests/test_github_payloads.py
+++ b/tests/test_github_payloads.py
@@ -1,0 +1,170 @@
+"""Tests for typed GitHub payload view-models (issue #407).
+
+Verifies that:
+1. Models parse correctly from realistic GitHub API shapes.
+2. Unknown extra fields do not change handler behaviour (extra="ignore").
+3. Convenience properties replace nested .get() chains.
+4. GhJob.from_api_dict normalises mixed label formats.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+
+# ---------------------------------------------------------------------------
+# GhRepository
+# ---------------------------------------------------------------------------
+
+
+def test_gh_repository_basic() -> None:
+    from models.github_payloads import GhRepository
+
+    repo = GhRepository.model_validate({"id": 1, "name": "my-repo", "full_name": "org/my-repo"})
+    assert repo.name == "my-repo"
+    assert repo.full_name == "org/my-repo"
+
+
+def test_gh_repository_extra_fields_ignored() -> None:
+    from models.github_payloads import GhRepository
+
+    repo = GhRepository.model_validate({"name": "x", "new_github_field": "some_value"})
+    assert repo.name == "x"
+    assert not hasattr(repo, "new_github_field")
+
+
+def test_gh_repository_defaults() -> None:
+    from models.github_payloads import GhRepository
+
+    repo = GhRepository.model_validate({})
+    assert repo.name == ""
+    assert repo.default_branch == "main"
+
+
+# ---------------------------------------------------------------------------
+# GhWorkflowRun
+# ---------------------------------------------------------------------------
+
+
+def test_gh_workflow_run_basic() -> None:
+    from models.github_payloads import GhWorkflowRun
+
+    raw = {
+        "id": 12345,
+        "name": "CI Standard",
+        "status": "queued",
+        "conclusion": None,
+        "repository": {"name": "MyRepo", "full_name": "org/MyRepo"},
+        "triggering_actor": {"login": "bot-user"},
+    }
+    run = GhWorkflowRun.model_validate(raw)
+    assert run.id == 12345
+    assert run.status == "queued"
+    assert run.repository_name == "MyRepo"
+    assert run.triggering_login == "bot-user"
+
+
+def test_gh_workflow_run_repository_name_missing_repo() -> None:
+    """repository_name returns '' when repository is absent."""
+    from models.github_payloads import GhWorkflowRun
+
+    run = GhWorkflowRun.model_validate({"id": 1})
+    assert run.repository_name == ""
+
+
+def test_gh_workflow_run_extra_fields_do_not_break() -> None:
+    """Adding an unknown GitHub field must not change handler behaviour."""
+    from models.github_payloads import GhWorkflowRun
+
+    run = GhWorkflowRun.model_validate({"id": 99, "brand_new_github_field": "oops"})
+    assert run.id == 99
+    assert not hasattr(run, "brand_new_github_field")
+
+
+def test_gh_workflow_run_triggering_login_absent() -> None:
+    from models.github_payloads import GhWorkflowRun
+
+    run = GhWorkflowRun.model_validate({"id": 5})
+    assert run.triggering_login == ""
+
+
+# ---------------------------------------------------------------------------
+# GhRunner
+# ---------------------------------------------------------------------------
+
+
+def test_gh_runner_label_names() -> None:
+    from models.github_payloads import GhRunner
+
+    raw = {
+        "id": 7,
+        "name": "runner-1",
+        "status": "online",
+        "busy": False,
+        "labels": [{"id": 1, "name": "self-hosted"}, {"id": 2, "name": "Linux"}],
+    }
+    runner = GhRunner.model_validate(raw)
+    assert runner.label_names == ["self-hosted", "Linux"]
+    assert runner.is_online is True
+
+
+def test_gh_runner_extra_field_ignored() -> None:
+    from models.github_payloads import GhRunner
+
+    runner = GhRunner.model_validate({"id": 3, "status": "offline", "unknown": "val"})
+    assert runner.status == "offline"
+    assert not hasattr(runner, "unknown")
+
+
+# ---------------------------------------------------------------------------
+# GhJob
+# ---------------------------------------------------------------------------
+
+
+def test_gh_job_from_api_dict_dict_labels() -> None:
+    """GhJob.from_api_dict normalises labels that are dicts."""
+    from models.github_payloads import GhJob
+
+    raw = {"id": 1, "run_id": 2, "name": "build", "status": "completed", "labels": [{"name": "ubuntu-latest"}]}
+    job = GhJob.from_api_dict(raw)
+    assert job.labels == ["ubuntu-latest"]
+
+
+def test_gh_job_from_api_dict_string_labels() -> None:
+    """GhJob.from_api_dict normalises labels that are already strings."""
+    from models.github_payloads import GhJob
+
+    raw = {"id": 2, "run_id": 3, "name": "test", "status": "queued", "labels": ["self-hosted", "windows"]}
+    job = GhJob.from_api_dict(raw)
+    assert job.labels == ["self-hosted", "windows"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: queue router source uses GhWorkflowRun
+# ---------------------------------------------------------------------------
+
+
+def test_queue_router_imports_gh_workflow_run() -> None:
+    source = (_BACKEND_DIR / "routers" / "queue.py").read_text(encoding="utf-8")
+    assert "GhWorkflowRun" in source, "queue.py must import GhWorkflowRun"
+    assert "r.repository_name" in source or "run.repository_name" in source
+
+
+def test_runs_workflows_router_imports_models() -> None:
+    source = (_BACKEND_DIR / "routers" / "runs_workflows.py").read_text(encoding="utf-8")
+    assert "GhWorkflowRun" in source
+    assert "GhJob" in source
+
+
+def test_heavy_tests_router_imports_models() -> None:
+    source = (_BACKEND_DIR / "routers" / "heavy_tests.py").read_text(encoding="utf-8")
+    assert "GhWorkflowRun" in source
+
+
+def test_runner_helpers_imports_gh_runner() -> None:
+    source = (_BACKEND_DIR / "routers" / "runner_helpers.py").read_text(encoding="utf-8")
+    assert "GhRunner" in source


### PR DESCRIPTION
## Summary

- Adds `backend/models/github_payloads.py` with `GhWorkflowRun`, `GhJob`, `GhRunner`, `GhRepository`, `GhActor` Pydantic view-models (`extra="ignore"`, covering only dashboard-consumed fields)
- Eliminates nested `.get()` chains like `(run.get("repository") or {}).get("name", "")` and `run.get("triggering_actor", {}).get("login")` in queue, runs_workflows, heavy_tests routers
- `runner_helpers.py` helpers accept both raw dicts and typed `GhRunner` — no breaking change to existing callers
- 15 unit tests verify: correct parsing, unknown fields are silently ignored, convenience properties work, label normalisation for dict/string formats

## Test plan

- [x] `python3 -m pytest tests/test_github_payloads.py -q` — all 15 tests pass
- [x] `python3 -m ruff check` — clean on all changed files
- [x] `python3 -m ruff format --check` — all formatted

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)