### PR TITLE
fix(security): session cookie hardening, CSP tightening, WebAuthn rate-limit (closes #322 #323 #324)

### DIFF
--- a/backend/auth_webauthn.py
+++ b/backend/auth_webauthn.py
@@ -15,6 +15,7 @@ import json
 import os
 import secrets
 import time
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,27 @@ _CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) /
 _CREDENTIALS_PATH = Path(os.environ.get("DASHBOARD_WEBAUTHN_CREDENTIALS", _CONFIG_DIR / "webauthn_credentials.json"))
 _CHALLENGE_SESSION_KEY = "webauthn_challenges"
 _CHALLENGE_TTL_SECONDS = 300
+
+# Rate limiting for challenge endpoints (issue #322).
+# Keyed on principal_id; limit is intentionally conservative because each
+# legitimate user only needs a handful of challenges per minute.
+_WEBAUTHN_RATE_LIMIT = 5  # max challenges per window per principal
+_WEBAUTHN_RATE_WINDOW = 60  # seconds
+_webauthn_rate: dict[str, list[float]] = defaultdict(list)
+
+
+def _check_webauthn_rate(principal_id: str) -> None:
+    """Enforce per-principal rate limit on challenge issuance (issue #322)."""
+    now = time.monotonic()
+    window = [t for t in _webauthn_rate[principal_id] if now - t < _WEBAUTHN_RATE_WINDOW]
+    if len(window) >= _WEBAUTHN_RATE_LIMIT:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many WebAuthn challenge requests. Please wait before retrying.",
+            headers={"Retry-After": str(_WEBAUTHN_RATE_WINDOW)},
+        )
+    window.append(now)
+    _webauthn_rate[principal_id] = window
 
 
 class WebAuthnCredentialRecord(BaseModel):
@@ -152,6 +174,7 @@ async def register_begin(
     principal: Principal = Depends(require_principal),  # noqa: B008
 ) -> dict[str, Any]:
     """Start device registration after the existing session is authenticated."""
+    _check_webauthn_rate(principal.id)
     challenge = _new_challenge(request, principal, "register")
     return {
         "challenge": challenge.challenge,
@@ -178,6 +201,7 @@ async def assert_begin(
     principal: Principal = Depends(require_principal),  # noqa: B008
 ) -> dict[str, Any]:
     """Start an assertion ceremony for the current authenticated user."""
+    _check_webauthn_rate(principal.id)
     credentials = _active_credentials_for(principal.id)
     if body.credential_id:
         credentials = [record for record in credentials if record.credential_id == body.credential_id]

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -226,13 +226,25 @@ async def add_security_headers(request: Request, call_next: Any) -> Any:
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "SAMEORIGIN"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    # CSP: remove third-party CDN sources; use 'strict-dynamic' with nonce-based
+    # scripts only (issue #324).  'unsafe-inline' on style-src is retained for
+    # Vite-injected critical CSS until a nonce pipeline is available.
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
-        "script-src 'self' 'strict-dynamic' "
-        "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://unpkg.com; "
+        "script-src 'self' 'strict-dynamic'; "
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data:; "
         "connect-src 'self'; "
-        "font-src 'self' data:;"
+        "font-src 'self' data:; "
+        "object-src 'none'; "
+        "base-uri 'self'; "
+        "frame-ancestors 'none';"
+    )
+    # HSTS: instruct browsers to use HTTPS for 1 year; include subdomains
+    # (issue #324).
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    # Permissions-Policy: lock down sensitive browser features (issue #324).
+    response.headers["Permissions-Policy"] = (
+        "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
     )
     return response

--- a/backend/server.py
+++ b/backend/server.py
@@ -445,8 +445,8 @@ app.add_middleware(
     secret_key=dashboard_config.SESSION_SECRET,
     session_cookie="dashboard_session",
     max_age=86400 * 7,  # 7 days
-    same_site="lax",
-    https_only=False,  # True if prod
+    same_site="strict",
+    https_only=True,
 )
 
 app.add_middleware(


### PR DESCRIPTION
## Summary

- **#322 WebAuthn rate limiting**: Added per-principal rate limit (5 challenges / 60 s, keyed on `principal.id`) to `/register/begin` and `/assert/begin` via a new `_check_webauthn_rate()` helper in `auth_webauthn.py`. Exceeding the limit returns HTTP 429 with a `Retry-After` header.
- **#323 Session cookie hardening**: Changed `same_site` from `"lax"` to `"strict"` and `https_only` from `False` to `True` in `server.py`. CSRF protection via `X-Requested-With: XMLHttpRequest` check was already implemented in `csrf_check` middleware — no additional change required there.
- **#324 CSP tightening + missing security headers**: Removed three third-party CDN allowances (`cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com`) from `script-src` in the CSP. Added `Strict-Transport-Security: max-age=31536000; includeSubDomains` and `Permissions-Policy` header locking down camera, microphone, geolocation, payment, usb, and interest-cohort.

## Files changed

- `backend/auth_webauthn.py` — rate limiting for challenge endpoints
- `backend/middleware.py` — CSP tightened, HSTS + Permissions-Policy added
- `backend/server.py` — session cookie `same_site=strict`, `https_only=True`

## Test plan

- [ ] Existing `tests/test_auth_webauthn.py` passes (auth still required; `require_principal` dependency enforced)
- [ ] New rate-limit: POST `/api/auth/webauthn/register/begin` 6 times in rapid succession → 6th returns 429 with `Retry-After`
- [ ] Session cookie in browser DevTools shows `SameSite=Strict` and `Secure` flag
- [ ] Response headers include `Strict-Transport-Security` and `Permissions-Policy`
- [ ] CSP no longer contains `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, or `unpkg.com`
- [ ] Existing `tests/test_security.py` and `tests/test_log_requests_middleware.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)