### PR TITLE
fix(scalability): pooled httpx GhClient replaces per-call gh subprocess (#352)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2262,3 +2262,16 @@ view-models defined in `backend/models/github_payloads.py`:
 
 All models use `extra="ignore"` so new GitHub API fields never break
 existing handlers.  Handlers receive flat, typed objects (Law of Demeter).
+### 18.8 Pooled GitHub API Client (issue #352)
+
+A new `backend/gh_client.py` module replaces the hottest
+`subprocess.run(["gh", "api", ...])` call-sites with a single pooled
+`httpx.AsyncClient` that reuses TLS connections and caches the Bearer token.
+
+**Key design:**
+- Token loaded once from `GH_TOKEN` / `GITHUB_TOKEN` and cached in memory.
+- Typed exceptions: `GhAuthError`, `GhRateLimited`, `GhNotFound`, `GhServerError`.
+- `paginate(path)` async iterator follows GitHub Link headers automatically.
+- `gh` CLI subprocess retained as fallback when token is absent.
+- `gh_utils.gh_api()` delegates to `gh_client.get()` transparently; all
+  existing call-sites continue to work without changes.

--- a/backend/gh_client.py
+++ b/backend/gh_client.py
@@ -1,0 +1,303 @@
+"""GitHub API async HTTP client (issue #352).
+
+Replaces the hottest ``subprocess.run(["gh", "api", ...])`` call-sites with a
+single pooled ``httpx.AsyncClient`` that reuses TLS connections and caches the
+Bearer token from the environment (``GH_TOKEN`` / ``GITHUB_TOKEN``).
+
+Architecture
+------------
+- One module-level ``httpx.AsyncClient`` with keep-alive pooling.
+- Bearer token loaded once at first call and cached in memory.
+- Rate-limit and error handling mirrors the existing ``gh_utils`` behaviour
+  so call-sites can drop in ``gc.get(path)`` for ``gh_api(path)``.
+- ``gh`` CLI kept as fallback: if ``GH_TOKEN`` is absent the module raises
+  ``GhAuthError`` and callers can fall back to the subprocess path.
+
+Typed exceptions
+----------------
+- ``GhAuthError`` — no token available.
+- ``GhRateLimited`` — 429 / X-RateLimit-Remaining: 0.
+- ``GhNotFound`` — 404 from GitHub.
+- ``GhServerError`` — 5xx from GitHub.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+log = logging.getLogger("dashboard.gh_client")
+
+_GITHUB_API_BASE = "https://api.github.com"
+_DEFAULT_RETRY_AFTER = 60
+_MAX_RETRIES = 5
+
+# ── Token cache ──────────────────────────────────────────────────────────────
+
+_cached_token: str | None = None
+
+
+def _get_token() -> str:
+    """Return a cached GitHub Bearer token from the environment.
+
+    Raises:
+        GhAuthError: when no token is available.
+    """
+    global _cached_token
+    if _cached_token:
+        return _cached_token
+    token = os.environ.get("GH_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        raise GhAuthError("GH_TOKEN / GITHUB_TOKEN not set; cannot use httpx GitHub client")
+    _cached_token = token
+    return token
+
+
+def clear_token_cache() -> None:
+    """Invalidate the cached token (e.g. after token rotation in tests)."""
+    global _cached_token
+    _cached_token = None
+
+
+# ── Pooled client ─────────────────────────────────────────────────────────────
+
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    """Return the shared pooled GitHub API client, initialising it on first use."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            base_url=_GITHUB_API_BASE,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
+            timeout=httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0),
+            http2=False,  # httpx http2 requires the h2 extra; keep plain HTTP/1.1
+        )
+    return _client
+
+
+async def close_client() -> None:
+    """Close the pooled client (called from server shutdown hook)."""
+    global _client
+    if _client is not None and not _client.is_closed:
+        await _client.aclose()
+    _client = None
+
+
+# ── Typed exceptions ──────────────────────────────────────────────────────────
+
+
+class GhClientError(RuntimeError):
+    """Base class for all GhClient errors."""
+
+
+class GhAuthError(GhClientError):
+    """No GitHub token available."""
+
+
+class GhRateLimited(GhClientError):
+    """GitHub API rate limit hit."""
+
+    def __init__(self, *, retry_after_seconds: int = _DEFAULT_RETRY_AFTER, endpoint: str = "") -> None:
+        super().__init__(f"GitHub rate limited; retry after {retry_after_seconds}s (endpoint={endpoint})")
+        self.retry_after_seconds = retry_after_seconds
+        self.endpoint = endpoint
+
+
+class GhNotFound(GhClientError):
+    """GitHub returned 404."""
+
+    def __init__(self, endpoint: str) -> None:
+        super().__init__(f"GitHub 404: {endpoint}")
+        self.endpoint = endpoint
+
+
+class GhServerError(GhClientError):
+    """GitHub returned 5xx."""
+
+    def __init__(self, status_code: int, endpoint: str, body: str = "") -> None:
+        super().__init__(f"GitHub {status_code}: {endpoint} — {body[:200]}")
+        self.status_code = status_code
+        self.endpoint = endpoint
+
+
+# ── Core helpers ──────────────────────────────────────────────────────────────
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_get_token()}"}
+
+
+def _parse_retry_after(resp: httpx.Response) -> int:
+    ra = resp.headers.get("Retry-After", "")
+    if ra.isdigit():
+        return max(1, int(ra))
+    # Try X-RateLimit-Reset (Unix timestamp)
+    reset = resp.headers.get("X-RateLimit-Reset", "")
+    if reset.isdigit():
+        return max(1, int(reset) - int(time.time()))
+    return _DEFAULT_RETRY_AFTER
+
+
+async def _request(method: str, path: str, *, json: Any = None) -> httpx.Response:
+    """Execute one authenticated GitHub API request with retry on 429.
+
+    Raises:
+        GhAuthError: token missing.
+        GhRateLimited: after max retries exhausted.
+        GhNotFound: 404.
+        GhServerError: non-retryable 5xx.
+    """
+    client = _get_client()
+    headers = _auth_headers()
+    for attempt in range(_MAX_RETRIES):
+        resp = await client.request(method, path, headers=headers, json=json)
+        if resp.status_code == 200:
+            return resp
+        if resp.status_code == 204:
+            return resp
+        if resp.status_code == 404:
+            raise GhNotFound(path)
+        if resp.status_code == 429 or resp.headers.get("X-RateLimit-Remaining") == "0":
+            retry_after = _parse_retry_after(resp)
+            if attempt < _MAX_RETRIES - 1:
+                log.warning(
+                    "gh_client: rate limited on %s, waiting %ds (attempt %d/%d)",
+                    path,
+                    retry_after,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                import asyncio
+
+                jitter = min(retry_after, 10) * (0.5 + 0.5 * (attempt / _MAX_RETRIES))
+                await asyncio.sleep(jitter)
+                continue
+            raise GhRateLimited(retry_after_seconds=retry_after, endpoint=path)
+        if resp.status_code >= 500:
+            raise GhServerError(resp.status_code, path, resp.text)
+        # Other client error (403, 422, etc.) — surface as GhServerError with real status
+        raise GhServerError(resp.status_code, path, resp.text)
+    raise GhRateLimited(endpoint=path)
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+async def get(path: str) -> Any:
+    """GET a GitHub API path and return the parsed JSON body.
+
+    Args:
+        path: Relative API path, e.g. ``/orgs/myorg/actions/runners``.
+
+    Returns:
+        Parsed JSON (dict, list, etc.).
+
+    Raises:
+        GhAuthError, GhRateLimited, GhNotFound, GhServerError.
+    """
+    resp = await _request("GET", path)
+    if resp.status_code == 204:
+        return {}
+    return resp.json()
+
+
+async def post(path: str, *, json: Any = None) -> Any:
+    """POST to a GitHub API path.
+
+    Args:
+        path: Relative API path.
+        json: Optional JSON body.
+
+    Returns:
+        Parsed JSON body, or empty dict for 204.
+    """
+    resp = await _request("POST", path, json=json)
+    if resp.status_code in (201, 204):
+        return {}
+    return resp.json()
+
+
+async def paginate(path: str, *, per_page: int = 100) -> AsyncIterator[dict]:
+    """Yield all items from a paginated GitHub list endpoint.
+
+    Uses GitHub's ``Link: <…>; rel="next"`` header to follow pages.
+
+    Args:
+        path: Relative API path, e.g. ``/orgs/myorg/actions/runs``.
+        per_page: Page size (max 100).
+
+    Yields:
+        Individual item dicts.
+    """
+    sep = "&" if "?" in path else "?"
+    url: str | None = f"{path}{sep}per_page={per_page}"
+    client = _get_client()
+    headers = _auth_headers()
+
+    while url:
+        resp = await client.get(url, headers={**headers, **client.headers})
+        if resp.status_code == 404:
+            return
+        if resp.status_code == 429:
+            raise GhRateLimited(retry_after_seconds=_parse_retry_after(resp), endpoint=url)
+        if resp.status_code >= 400:
+            raise GhServerError(resp.status_code, url, resp.text)
+        body = resp.json()
+        items: list[dict] = body if isinstance(body, list) else []
+        for key in ("workflow_runs", "jobs", "runners", "items", "repositories"):
+            if isinstance(body, dict) and key in body:
+                items = body[key]
+                break
+        for item in items:
+            yield item
+        link = resp.headers.get("link", "")
+        url = _parse_next_link(link)
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    """Extract the ``rel="next"`` URL from a GitHub Link header."""
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        url_part, *params = part.strip().split(";")
+        url = url_part.strip().strip("<>")
+        for param in params:
+            if param.strip() == 'rel="next"':
+                return url
+    return None
+
+
+# ── High-level typed wrappers ────────────────────────────────────────────────
+
+
+async def cancel_run(repo_full: str, run_id: int) -> None:
+    """Cancel a workflow run.
+
+    Args:
+        repo_full: Full repo slug, e.g. ``"myorg/myrepo"``.
+        run_id: GitHub Actions run ID.
+    """
+    await post(f"/repos/{repo_full}/actions/runs/{run_id}/cancel")
+    log.info("gh_client: cancelled run %d in %s", run_id, repo_full)
+
+
+async def rerun_failed(repo_full: str, run_id: int) -> None:
+    """Rerun failed jobs in a workflow run.
+
+    Args:
+        repo_full: Full repo slug.
+        run_id: GitHub Actions run ID.
+    """
+    await post(f"/repos/{repo_full}/actions/runs/{run_id}/rerun-failed-jobs")
+    log.info("gh_client: rerun-failed-jobs %d in %s", run_id, repo_full)

--- a/backend/gh_utils.py
+++ b/backend/gh_utils.py
@@ -122,11 +122,35 @@ def _record_rate_limit(endpoint: str, retry_after_seconds: int) -> RateLimitedEr
 
 
 async def gh_api(endpoint: str) -> dict:
-    """Call the GitHub API via gh CLI.
+    """Call the GitHub API, preferring the pooled httpx client over subprocess.
 
-    Uses GH_TOKEN env var when set (required for admin:org endpoints).
+    When ``GH_TOKEN`` / ``GITHUB_TOKEN`` is set the request is made via
+    ``gh_client.get()`` which reuses pooled TLS connections (issue #352).
+    Falls back to spawning a ``gh api`` subprocess when no token is available.
+
+    Uses the existing circuit-breaker and rate-limit machinery from this module.
     """
     _raise_if_circuit_open(endpoint)
+
+    # ── Fast path: use pooled httpx client when token is available ──────────
+    try:
+        import gh_client as _gc
+
+        return await _gc.get(endpoint)
+    except ImportError:
+        pass
+    except _gc.GhAuthError:
+        pass  # No token — fall through to subprocess
+    except _gc.GhRateLimited as exc:
+        raise _record_rate_limit(endpoint, exc.retry_after_seconds) from exc
+    except _gc.GhNotFound as exc:
+        raise HTTPException(status_code=404, detail=f"GitHub resource not found: {endpoint}") from exc
+    except _gc.GhServerError as exc:
+        if exc.status_code == 429:
+            raise _record_rate_limit(endpoint, DEFAULT_RATE_LIMIT_RETRY_AFTER_SECONDS) from exc
+        raise HTTPException(status_code=502, detail=f"GitHub API error ({exc.status_code}): {exc}") from exc
+
+    # ── Fallback: subprocess gh CLI ─────────────────────────────────────────
     code, stdout, stderr = await run_cmd(["gh", "api", endpoint])
     if code != 0:
         output = "\n".join(part for part in (stderr, stdout) if part)
@@ -139,7 +163,7 @@ async def gh_api(endpoint: str) -> dict:
         raise HTTPException(status_code=502, detail=f"Invalid JSON from GitHub API: {stdout}") from exc
 
 
-# gh_api_admin is an alias kept for call-site clarity.
+# gh_api_admin is an alias kept for call-site clarity; all calls use GH_TOKEN.
 gh_api_admin = gh_api
 
 

--- a/tests/test_gh_client.py
+++ b/tests/test_gh_client.py
@@ -1,0 +1,177 @@
+"""Tests for the pooled GitHub API httpx client (issue #352).
+
+Validates:
+1. Token caching (GH_TOKEN read once).
+2. GhRateLimited, GhNotFound, GhServerError exception types.
+3. _parse_next_link for Link header parsing.
+4. close_client cleans up.
+5. gh_utils.gh_api delegates to gh_client when token is present (integration).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Token cache
+# ---------------------------------------------------------------------------
+
+
+def test_get_token_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    import gh_client
+
+    gh_client.clear_token_cache()
+    monkeypatch.setenv("GH_TOKEN", "test-token-abc")
+    token = gh_client._get_token()
+    assert token == "test-token-abc"
+    gh_client.clear_token_cache()
+
+
+def test_get_token_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    import gh_client
+
+    gh_client.clear_token_cache()
+    monkeypatch.setenv("GH_TOKEN", "tok1")
+    gh_client._get_token()  # prime cache
+    # change env — should not matter because token is cached
+    monkeypatch.setenv("GH_TOKEN", "tok2")
+    token = gh_client._get_token()
+    assert token == "tok1"
+    gh_client.clear_token_cache()
+
+
+def test_get_token_raises_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    import gh_client
+
+    gh_client.clear_token_cache()
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with pytest.raises(gh_client.GhAuthError):
+        gh_client._get_token()
+    gh_client.clear_token_cache()
+
+
+# ---------------------------------------------------------------------------
+# _parse_next_link
+# ---------------------------------------------------------------------------
+
+
+def test_parse_next_link_present() -> None:
+    from gh_client import _parse_next_link
+
+    link = '<https://api.github.com/orgs/x/repos?page=2>; rel="next", <…>; rel="last"'
+    assert _parse_next_link(link) == "https://api.github.com/orgs/x/repos?page=2"
+
+
+def test_parse_next_link_absent() -> None:
+    from gh_client import _parse_next_link
+
+    assert _parse_next_link("") is None
+    assert _parse_next_link('<x>; rel="last"') is None
+
+
+# ---------------------------------------------------------------------------
+# Typed exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_gh_rate_limited_has_retry_after() -> None:
+    from gh_client import GhRateLimited
+
+    exc = GhRateLimited(retry_after_seconds=120, endpoint="/orgs/x/runners")
+    assert exc.retry_after_seconds == 120
+    assert "/orgs/x/runners" in str(exc)
+
+
+def test_gh_not_found() -> None:
+    from gh_client import GhNotFound
+
+    exc = GhNotFound("/repos/org/missing")
+    assert "404" in str(exc)
+
+
+def test_gh_server_error() -> None:
+    from gh_client import GhServerError
+
+    exc = GhServerError(503, "/orgs/x/runners", "Service Unavailable")
+    assert exc.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# gh_utils.gh_api delegates to gh_client when token is present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gh_utils_delegates_to_gh_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gh_utils.gh_api should use gh_client.get() when token is available."""
+    import gh_client
+    import gh_utils
+
+    gh_client.clear_token_cache()
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+    mock_data = {"runners": [{"id": 1, "name": "runner-1", "status": "online"}]}
+    with patch.object(gh_client, "get", new=AsyncMock(return_value=mock_data)):
+        result = await gh_utils.gh_api("/orgs/test-org/actions/runners")
+
+    assert result == mock_data
+    gh_client.clear_token_cache()
+
+
+@pytest.mark.asyncio
+async def test_gh_utils_falls_back_to_subprocess_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gh_utils.gh_api falls back to subprocess when GH_TOKEN is absent."""
+    import gh_client
+    import gh_utils
+
+    gh_client.clear_token_cache()
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    import json
+
+    expected = {"runners": []}
+    with patch("gh_utils.run_cmd", new=AsyncMock(return_value=(0, json.dumps(expected), ""))) as mock_cmd:
+        result = await gh_utils.gh_api("/orgs/x/actions/runners")
+
+    assert result == expected
+    mock_cmd.assert_called_once()
+    gh_client.clear_token_cache()
+
+
+# ---------------------------------------------------------------------------
+# gh_client.py source structure checks
+# ---------------------------------------------------------------------------
+
+
+def test_gh_client_exports_get() -> None:
+    import gh_client
+
+    assert callable(gh_client.get)
+
+
+def test_gh_client_exports_paginate() -> None:
+    import gh_client
+
+    assert callable(gh_client.paginate)
+
+
+def test_gh_client_exports_cancel_run() -> None:
+    import gh_client
+
+    assert callable(gh_client.cancel_run)
+
+
+def test_gh_client_exports_rerun_failed() -> None:
+    import gh_client
+
+    assert callable(gh_client.rerun_failed)


### PR DESCRIPTION
## Summary

- Adds `backend/gh_client.py` with a pooled `httpx.AsyncClient` (reuses TLS connections across calls), Bearer token cached from `GH_TOKEN`/`GITHUB_TOKEN`, async `paginate()` iterator, and typed exceptions (`GhAuthError`, `GhRateLimited`, `GhNotFound`, `GhServerError`)
- Updates `gh_utils.gh_api()` to transparently delegate to `gh_client.get()` when token is present; all existing call-sites work unchanged
- Falls back to subprocess `gh api` when no token is set (so dev environments without `GH_TOKEN` still work)
- 14 unit tests covering: token caching, Link-header parsing, exception types, delegation path, fallback path

## Test plan

- [x] `python3 -m pytest tests/test_gh_client.py -q` — all 14 tests pass
- [x] `python3 -m ruff check` — clean on all changed files
- [x] `python3 -m ruff format --check` — all formatted

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)