### PR TITLE
fix(security): loopback bypass, HMAC envelope signing, approval_hmac binding (closes #315 #317 #318)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,4 +1,4 @@
-# SPEC.md â€” D-sorganization Runner Dashboard
+﻿# SPEC.md â€” D-sorganization Runner Dashboard
 
 **Spec Version:** 2.5.22
 **Application Version:** 4.1.0 (see `VERSION`)
@@ -1154,6 +1154,8 @@ A **principal** is either a human or a bot/agent. Both have the same shape:
 
 Principals are stored in `config/principals.yml`. The system fails closed: requests without a valid principal are rejected (HTTP 401).
 
+**Loopback bypass (issue #315):** The loopback admin shortcut (granting automatic admin access to 127.0.0.1) is disabled by default. It is only active when `DASHBOARD_LOOPBACK_AUTH=1` is explicitly set in the environment. This must never be set in production deployments — it is intended solely for local single-user development where the dashboard is not reachable beyond 127.0.0.1.
+
 **Authorization:**
 All mutating `/api/*` endpoints require a principal.
 - Humans authenticate via session cookies (from GitHub OAuth).
@@ -2297,3 +2299,26 @@ Log aggregation sidecar configuration for the runner-dashboard fleet.
 | error/critical logs | Loki | 30 days |
 | Journald on-host | systemd-journald | 1 GB max / 30 days |
 | Docker json-file | local | 7 × 100 MB |
+## Security Fixes (issues #315, #317, #318)
+
+### Auth loopback bypass (issue #315)
+The loopback bypass that granted automatic admin access to requests from
+127.0.0.1 or ::1 is now gated on the environment variable
+DASHBOARD_LOOPBACK_AUTH=1. This variable must never be set in production;
+it is intended solely for local single-user development where the dashboard
+is not reachable beyond the loopback interface.
+
+### HMAC payload signing (issue #317)
+The dispatch envelope HMAC signature now includes a SHA-256 hash of the
+payload field (payload_hash). This prevents capture-and-replay attacks
+where an attacker captures a valid signed envelope and replays it with a
+different payload. All new envelopes are signed with payload_hash in the
+canonical JSON; the signing secret is DISPATCH_SIGNING_SECRET.
+
+### approval_hmac binding (issue #318)
+DispatchConfirmation.approval_hmac must be bound to the specific
+envelope_id and action of the request it approves. The canonical
+HMAC message is approve:<envelope_id>:<action>. If approval_hmac is
+present and invalid, validate_envelope_crypto fails closed with
+valid=False. An absent approval_hmac is accepted with a deprecation
+warning for backwards-compatibility; clients should supply it.

--- a/backend/dispatch/__init__.py
+++ b/backend/dispatch/__init__.py
@@ -31,8 +31,11 @@ from dispatch.registry import (
 )
 from dispatch.signing import (
     TimestampValidationResult,
+    _compute_approval_hmac,
+    _hash_payload,
     sign_payload,
     validate_timestamp_freshness,
+    verify_approval_hmac,
     verify_payload,
 )
 from dispatch.validate import (
@@ -62,6 +65,9 @@ __all__ = [
     "sign_payload",
     "verify_payload",
     "validate_timestamp_freshness",
+    "_hash_payload",
+    "_compute_approval_hmac",
+    "verify_approval_hmac",
     # validate
     "DispatchValidationResult",
     "CryptoValidationResult",

--- a/backend/dispatch/envelope.py
+++ b/backend/dispatch/envelope.py
@@ -11,7 +11,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 from uuid import uuid4
 
-from dispatch.signing import _load_signing_secret, _sign_envelope_payload, _verify_envelope_signature
+from dispatch.signing import _hash_payload, _load_signing_secret, _sign_envelope_payload, _verify_envelope_signature
 from time_utils import utc_now_iso
 
 UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
@@ -103,6 +103,9 @@ class CommandEnvelope:
                 self.principal,
                 self.on_behalf_of,
                 self.correlation_id,
+                # Issue #317: include payload hash so captured envelopes
+                # cannot be replayed with a substituted payload.
+                _hash_payload(self.payload),
             )
             object.__setattr__(self, "signature", sig)
 
@@ -136,7 +139,7 @@ class CommandEnvelope:
         return envelope
 
     def verify_signature(self) -> bool:
-        """Verify that envelope signature is valid."""
+        """Verify that envelope signature is valid (covers payload hash, issue #317)."""
         if not self.signature:
             return False
         try:
@@ -153,6 +156,7 @@ class CommandEnvelope:
                 self.principal,
                 self.on_behalf_of,
                 self.correlation_id,
+                _hash_payload(self.payload),
             )
         except Exception:  # justified: broad guard; verify returns False on any signing failure
             return False

--- a/backend/dispatch/validate.py
+++ b/backend/dispatch/validate.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from dispatch.registry import DispatchAccess, DispatchAction, _scheduler_modify_command, get_action
-from dispatch.signing import TimestampValidationResult, validate_timestamp_freshness
+from dispatch.signing import TimestampValidationResult, validate_timestamp_freshness, verify_approval_hmac
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +69,13 @@ def validate_envelope_crypto(envelope: object) -> CryptoValidationResult:
             }
             reason = reason_map.get(approved_at_result, "unknown timestamp error")
             return CryptoValidationResult(valid=False, reason=reason)
+
+        # Issue #318: verify approval_hmac is bound to this envelope + action
+        if not verify_approval_hmac(envelope.confirmation, envelope.envelope_id, envelope.action):  # type: ignore[attr-defined]
+            return CryptoValidationResult(
+                valid=False,
+                reason="confirmation approval_hmac invalid or does not match envelope",
+            )
 
     return CryptoValidationResult(valid=True, reason="signature and timestamps valid")
 

--- a/backend/dispatch_contract.py
+++ b/backend/dispatch_contract.py
@@ -17,10 +17,13 @@ from dispatch import (
 from dispatch.envelope import _ensure_dict, _required_string, _utc_now  # noqa: F401
 from dispatch.registry import _scheduler_modify_command
 from dispatch.signing import (  # noqa: F401
+    _compute_approval_hmac,
+    _hash_payload,
     _load_signing_secret,
     _sign_envelope_payload,
     _validate_timestamp_freshness,
     _verify_envelope_signature,
+    verify_approval_hmac,
 )
 
 

--- a/backend/identity.py
+++ b/backend/identity.py
@@ -185,15 +185,20 @@ identity_manager = IdentityManager()
 auth_header = APIKeyHeader(name="Authorization", auto_error=False)
 auth_cookie = APIKeyCookie(name="dashboard_session", auto_error=False)
 
-# Synthetic admin principal granted automatically to loopback (127.0.0.1) requests.
-# This allows the local browser to use all authenticated endpoints without manual
-# principal setup on a single-machine deployment.
+# Synthetic admin principal granted to loopback requests ONLY when
+# DASHBOARD_LOOPBACK_AUTH=1 is explicitly set.  This env var must never be
+# set in production; it is intended solely for local single-user development
+# where the dashboard is not reachable beyond 127.0.0.1.
+# See security issue #315 — unconditional loopback bypass is a P0 vulnerability
+# because SSRF or local-network access grants full admin without credentials.
 _LOOPBACK_ADMIN = Principal(
     id="__loopback__",
     type="human",
     name="Local Admin (loopback)",
     roles=["admin"],
 )
+
+_LOOPBACK_AUTH_ENABLED: bool = os.environ.get("DASHBOARD_LOOPBACK_AUTH", "").strip() == "1"
 
 
 def require_principal(
@@ -217,10 +222,10 @@ def require_principal(
                 raise HTTPException(status_code=401, detail="Session revoked or expired")
             prin = identity_manager.principals[principal_id]
 
-    # 3. Loopback bypass — requests from 127.0.0.1 or ::1 are automatically
-    #    granted admin access.  This is appropriate for the local single-user
-    #    dashboard that is not exposed beyond the loopback interface.
-    if not prin:
+    # 3. Loopback bypass (issue #315) — ONLY active when DASHBOARD_LOOPBACK_AUTH=1
+    #    is explicitly set.  Never enable in production: an attacker with SSRF or
+    #    local-network access can spoof the source IP and obtain full admin access.
+    if not prin and _LOOPBACK_AUTH_ENABLED:
         client_host = getattr(request.client, "host", "") if request.client else ""
         if client_host in ("127.0.0.1", "::1"):
             prin = _LOOPBACK_ADMIN

--- a/tests/api/test_auth_perimeter.py
+++ b/tests/api/test_auth_perimeter.py
@@ -159,3 +159,57 @@ def test_conftest_make_authed_client_works(make_authed_client) -> None:
     viewer_client = make_authed_client(viewer_p)
     resp = viewer_client.get("/api/admin/principals", headers={"X-Requested-With": "XMLHttpRequest"})
     assert resp.status_code == 403, f"viewer should get 403 on /api/admin/principals, got {resp.status_code}"
+
+
+# --- Issue #315: Loopback bypass must be gated on DASHBOARD_LOOPBACK_AUTH=1 ---
+
+
+def test_loopback_denied_when_env_var_not_set() -> None:
+    """require_principal must raise 401 for 127.0.0.1 when DASHBOARD_LOOPBACK_AUTH is not set (issue #315)."""
+    import importlib
+    import os
+
+    # Ensure the env var is absent
+    os.environ.pop("DASHBOARD_LOOPBACK_AUTH", None)
+    import identity as _identity
+
+    importlib.reload(_identity)
+
+    mock_request = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.headers.get.return_value = None
+    mock_request.state = MagicMock()
+    if hasattr(mock_request, "session"):
+        del mock_request.session
+
+    with pytest.raises(HTTPException) as exc_info:
+        _identity.require_principal(request=mock_request, header_token=None, cookie_token=None)
+
+    assert exc_info.value.status_code == 401
+
+    # Re-enable to keep original module state for other tests
+    importlib.reload(_identity)
+
+
+def test_loopback_allowed_when_env_var_set() -> None:
+    """require_principal must allow 127.0.0.1 when DASHBOARD_LOOPBACK_AUTH=1 (issue #315)."""
+    import importlib
+    import os
+
+    os.environ["DASHBOARD_LOOPBACK_AUTH"] = "1"
+    try:
+        import identity as _identity
+
+        importlib.reload(_identity)
+
+        mock_request = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        mock_request.headers.get.return_value = None
+        mock_request.state = MagicMock()
+
+        prin = _identity.require_principal(request=mock_request, header_token=None, cookie_token=None)
+        assert "admin" in prin.roles
+        assert prin.id == "__loopback__"
+    finally:
+        os.environ.pop("DASHBOARD_LOOPBACK_AUTH", None)
+        importlib.reload(_identity)

--- a/tests/test_envelope_signing.py
+++ b/tests/test_envelope_signing.py
@@ -497,3 +497,183 @@ class TestEnvelopeJsonRoundTrip:
             assert restored.confirmation.envelope_id == "env123"
             assert restored.confirmation.approval_hmac == "hmac789"
             assert validate_envelope_crypto(restored).valid is True
+
+
+class TestPayloadHashInSignature:
+    """Tests verifying that payload is included in the envelope HMAC (issue #317)."""
+
+    def test_payload_hash_is_part_of_signature(self):
+        """Envelopes with different payloads must produce different signatures."""
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            env1 = CommandEnvelope(
+                action="runner.status",
+                source="hub",
+                target="node-1",
+                requested_by="alice",
+                payload={"service": "all"},
+            )
+            env2 = CommandEnvelope(
+                action="runner.status",
+                source="hub",
+                target="node-1",
+                requested_by="alice",
+                payload={"service": "malicious-override"},
+            )
+            assert env1.signature != env2.signature, (
+                "Different payloads must yield different HMAC signatures (issue #317)"
+            )
+
+    def test_signature_invalid_after_payload_swap(self):
+        """Verify_signature must return False if payload was swapped after signing."""
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            original = CommandEnvelope(
+                action="runner.status",
+                source="hub",
+                target="node-1",
+                requested_by="alice",
+                payload={"service": "all"},
+            )
+            # Simulate an attacker replacing the payload without re-signing
+            tampered = CommandEnvelope.from_dict({**original.to_dict(), "payload": {"service": "evil"}})
+            # The tampered envelope keeps the original signature but has a new payload
+            object.__setattr__(tampered, "signature", original.signature)
+            assert not tampered.verify_signature(), "Swapped payload must invalidate the HMAC signature (issue #317)"
+
+    def test_empty_payload_is_signed(self):
+        """An envelope with no payload hashes consistently (empty dict = stable hash)."""
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            env = CommandEnvelope(
+                action="runner.status",
+                source="hub",
+                target="node-1",
+                requested_by="alice",
+            )
+            assert env.verify_signature() is True
+
+    def test_hash_payload_helper_stable(self):
+        """_hash_payload returns the same digest for identical dicts."""
+        from dispatch_contract import _hash_payload
+
+        assert _hash_payload({"a": 1, "b": 2}) == _hash_payload({"b": 2, "a": 1})
+        assert _hash_payload(None) == _hash_payload({})
+        assert _hash_payload({"a": 1}) != _hash_payload({"a": 2})
+
+
+class TestApprovalHmacBinding:
+    """Tests for approval_hmac bound to envelope (issue #318)."""
+
+    def test_verify_approval_hmac_accepts_correct_hmac(self):
+        """verify_approval_hmac returns True for a correctly computed approval_hmac."""
+        from dispatch_contract import DispatchConfirmation, _compute_approval_hmac, verify_approval_hmac
+
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            envelope_id = "abc123"
+            action = "runner.restart"
+            secret = "test-secret"
+            correct_hmac = _compute_approval_hmac(envelope_id, action, secret)
+
+            confirmation = DispatchConfirmation(
+                approved_by="alice",
+                approved_at="2026-01-01T12:00:00Z",
+                envelope_id=envelope_id,
+                approval_hmac=correct_hmac,
+            )
+            assert verify_approval_hmac(confirmation, envelope_id, action) is True
+
+    def test_verify_approval_hmac_rejects_wrong_hmac(self):
+        """verify_approval_hmac returns False for an incorrect approval_hmac."""
+        from dispatch_contract import DispatchConfirmation, verify_approval_hmac
+
+        confirmation = DispatchConfirmation(
+            approved_by="alice",
+            approved_at="2026-01-01T12:00:00Z",
+            envelope_id="abc123",
+            approval_hmac="0" * 64,
+        )
+        assert verify_approval_hmac(confirmation, "abc123", "runner.restart") is False
+
+    def test_verify_approval_hmac_rejects_wrong_envelope_id(self):
+        """approval_hmac generated for one envelope_id must fail for another."""
+        from dispatch_contract import DispatchConfirmation, _compute_approval_hmac, verify_approval_hmac
+
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            secret = "test-secret"
+            original_hmac = _compute_approval_hmac("original-id", "runner.restart", secret)
+            confirmation = DispatchConfirmation(
+                approved_by="alice",
+                approved_at="2026-01-01T12:00:00Z",
+                envelope_id="different-id",
+                approval_hmac=original_hmac,
+            )
+            # The HMAC was for "original-id" but we present "different-id"
+            assert verify_approval_hmac(confirmation, "different-id", "runner.restart") is False
+
+    def test_verify_approval_hmac_rejects_wrong_action(self):
+        """approval_hmac generated for one action must fail for a different action."""
+        from dispatch_contract import DispatchConfirmation, _compute_approval_hmac, verify_approval_hmac
+
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            secret = "test-secret"
+            original_hmac = _compute_approval_hmac("abc123", "runner.restart", secret)
+            confirmation = DispatchConfirmation(
+                approved_by="alice",
+                approved_at="2026-01-01T12:00:00Z",
+                envelope_id="abc123",
+                approval_hmac=original_hmac,
+            )
+            # The HMAC was for "runner.restart" but we verify against "runner.stop"
+            assert verify_approval_hmac(confirmation, "abc123", "runner.stop") is False
+
+    def test_validate_envelope_crypto_rejects_invalid_approval_hmac(self):
+        """validate_envelope_crypto must fail if approval_hmac is wrong (issue #318)."""
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            confirmation = DispatchConfirmation(
+                approved_by="alice",
+                approved_at=now,
+                envelope_id="some-id",
+                approval_hmac="wrong" * 13,  # 65 chars but invalid
+            )
+            envelope = CommandEnvelope(
+                action="runner.restart",
+                source="hub",
+                target="node-1",
+                requested_by="alice",
+                confirmation=confirmation,
+            )
+            result = validate_envelope_crypto(envelope)
+            assert result.valid is False
+            assert "approval_hmac" in result.reason
+
+    def test_validate_envelope_crypto_accepts_correct_approval_hmac(self):
+        """validate_envelope_crypto accepts envelopes with a correct approval_hmac."""
+        from dispatch_contract import _compute_approval_hmac
+
+        with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
+            now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            # We need to know the envelope_id before creating the confirmation,
+            # so we build it first, then rebuild with the correct approval_hmac.
+            import uuid
+
+            envelope_id = uuid.uuid4().hex
+            action = "runner.restart"
+            secret = "test-secret"
+            correct_hmac = _compute_approval_hmac(envelope_id, action, secret)
+
+            confirmation = DispatchConfirmation(
+                approved_by="alice",
+                approved_at=now,
+                envelope_id=envelope_id,
+                approval_hmac=correct_hmac,
+            )
+            # Build envelope with pre-set envelope_id and confirmation
+            envelope = CommandEnvelope(
+                action=action,
+                source="hub",
+                target="node-1",
+                requested_by="alice",
+                confirmation=confirmation,
+                envelope_id=envelope_id,
+            )
+            result = validate_envelope_crypto(envelope)
+            assert result.valid is True, f"Expected valid=True, got: {result.reason}"


### PR DESCRIPTION
## Summary

Three P0 security fixes in a single PR:

- **#315 fix(auth):** The loopback bypass that granted full admin to any `127.0.0.1` caller is now gated on `DASHBOARD_LOOPBACK_AUTH=1`. When the env var is absent (the default and all production deployments), requests from `127.0.0.1` / `::1` are treated as unauthenticated and fail with HTTP 401. This eliminates the SSRF/local-network admin impersonation vector.

- **#317 fix(dispatch):** `_sign_envelope_payload` now includes a SHA-256 hash of the `payload` dict (`payload_hash`) in the canonical signed JSON. Captured envelopes replayed with a different payload will fail HMAC verification. New helper `_hash_payload()` provides a stable, sort-key-normalized digest.

- **#318 fix(dispatch):** `DispatchConfirmation.approval_hmac` is now validated by `validate_envelope_crypto` via the new `verify_approval_hmac()` helper. The canonical message is `approve:<envelope_id>:<action>`, binding the approval to exactly one dispatch action. An invalid or mismatched `approval_hmac` fails closed; a missing one emits a deprecation warning for backwards-compat with older clients.

## Files changed

| File | Change |
|------|--------|
| `backend/identity.py` | Gate loopback admin on `DASHBOARD_LOOPBACK_AUTH=1` |
| `backend/dispatch_contract.py` | Add `_hash_payload`, `payload_hash` param to signing functions, `_compute_approval_hmac`, `verify_approval_hmac`; update `validate_envelope_crypto` |
| `tests/api/test_auth_perimeter.py` | Tests: loopback denied by default, allowed when env var set |
| `tests/test_envelope_signing.py` | Tests: payload swap invalidates signature; approval_hmac binding |
| `SPEC.md` | Document all three security requirements |

## Test plan

- [ ] `pytest tests/test_envelope_signing.py -q` — all new payload hash and approval_hmac tests pass
- [ ] `pytest tests/api/test_auth_perimeter.py -q` — loopback env-var gate tests pass
- [ ] `pytest tests/ -q --tb=short` — full suite green
- [ ] Verify loopback bypass is off by default in a new dev environment
- [ ] Verify `DASHBOARD_LOOPBACK_AUTH=1` re-enables local dev access

🤖 Generated with [Claude Code](https://claude.com/claude-code)