### PR TITLE
feat(mobile): M10 three-tap agent dispatch + Remediation/Mobile.tsx

### DIFF
--- a/frontend/src/pages/Remediation/Mobile.tsx
+++ b/frontend/src/pages/Remediation/Mobile.tsx
@@ -1,0 +1,700 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { SegmentedControl } from "../../primitives/SegmentedControl";
+import { Badge } from "../../primitives/Badge";
+import { TouchButton } from "../../primitives/TouchButton";
+import { SkeletonCard, SkeletonLine } from "../../primitives/Skeleton";
+import { useToast } from "../../primitives/Toaster";
+import { BottomSheet } from "../../primitives/BottomSheet";
+
+// -- Types ---------------------------------------------------------------------
+
+interface AgentProvider {
+  provider_id: string;
+  label: string;
+  execution_mode: string;
+  dispatch_mode: string;
+  notes: string;
+  experimental: boolean;
+  remote: boolean;
+  editable: boolean;
+}
+
+interface ProviderAvailability {
+  provider_id: string;
+  available: boolean;
+  status: string;
+  detail: string;
+}
+
+interface FailedRun {
+  id: number;
+  name: string;
+  workflow_name: string;
+  head_branch: string;
+  conclusion: string;
+  html_url: string;
+  created_at: string;
+  run_number?: number;
+  repository: { name: string; full_name?: string };
+}
+
+interface OpenPR {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  head: { ref: string };
+  base: { repo: { name: string; full_name?: string } };
+  draft: boolean;
+  labels: Array<{ name: string }>;
+  updated_at: string;
+}
+
+interface OpenIssue {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  repository_url: string;
+  labels: Array<{ name: string }>;
+  updated_at: string;
+}
+
+type RemediationSubtab = "automations" | "prs" | "issues";
+
+export interface InFlightDispatch {
+  id: string;
+  itemId: number;
+  itemTitle: string;
+  provider: string;
+  providerLabel: string;
+  repository: string;
+  startedAt: number;
+  lastHeartbeat: number;
+  status: "dispatched" | "running" | "done" | "error";
+  fingerprint?: string;
+}
+
+// -- Constants -----------------------------------------------------------------
+
+const SUBTAB_OPTIONS = [
+  { label: "Automations", value: "automations" },
+  { label: "PRs", value: "prs" },
+  { label: "Issues", value: "issues" },
+];
+
+const DEFAULT_PROVIDER_ORDER = [
+  "jules_api",
+  "codex_cli",
+  "claude_code_cli",
+  "gemini_cli",
+  "ollama",
+  "cline",
+];
+
+// -- Helpers -------------------------------------------------------------------
+
+function pickRecommendedProvider(
+  providers: Record<string, AgentProvider>,
+  availability: Record<string, ProviderAvailability>,
+): string {
+  for (const id of DEFAULT_PROVIDER_ORDER) {
+    if (providers[id] && availability[id]?.available) return id;
+  }
+  const first = Object.keys(providers).find((id) => availability[id]?.available);
+  return first ?? "claude_code_cli";
+}
+
+function getProviderLabel(
+  providers: Record<string, AgentProvider>,
+  providerId: string,
+): string {
+  return providers[providerId]?.label ?? providerId;
+}
+
+function elapsedLabel(startedAt: number): string {
+  const secs = Math.floor((Date.now() - startedAt) / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ${secs % 60}s`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+// -- Sub-components ------------------------------------------------------------
+
+interface InFlightTileProps {
+  dispatch: InFlightDispatch;
+}
+
+function InFlightTile({ dispatch }: InFlightTileProps) {
+  const [, forceUpdate] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => forceUpdate((n) => n + 1), 5000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const tone =
+    dispatch.status === "done"
+      ? "success"
+      : dispatch.status === "error"
+      ? "danger"
+      : "info";
+
+  return (
+    <div
+      aria-label={`In-flight dispatch: ${dispatch.itemTitle}`}
+      className="remediation-inflight-tile"
+      role="status"
+      style={{
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border)",
+        borderLeft: "4px solid var(--accent-blue)",
+        borderRadius: 10,
+        marginBottom: 10,
+        padding: "12px 14px",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+        <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
+          {dispatch.itemTitle}
+        </span>
+        <Badge tone={tone}>{dispatch.status}</Badge>
+      </div>
+      <div style={{ color: "var(--text-secondary)", fontSize: 12, display: "flex", gap: 10, flexWrap: "wrap" }}>
+        <span>Agent: {dispatch.providerLabel}</span>
+        <span>Repo: {dispatch.repository}</span>
+        <span>Elapsed: {elapsedLabel(dispatch.startedAt)}</span>
+        <span>Heartbeat: {elapsedLabel(dispatch.lastHeartbeat)} ago</span>
+      </div>
+    </div>
+  );
+}
+
+interface ActionSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  itemTitle: string;
+  itemHtmlUrl: string;
+  recommendedProviderId: string;
+  providers: Record<string, AgentProvider>;
+  availability: Record<string, ProviderAvailability>;
+  onDispatch: (providerId: string) => void;
+  dispatching: boolean;
+}
+
+function ActionSheet({
+  isOpen,
+  onClose,
+  itemTitle,
+  itemHtmlUrl,
+  recommendedProviderId,
+  providers,
+  availability,
+  onDispatch,
+  dispatching,
+}: ActionSheetProps) {
+  const [showAgentPicker, setShowAgentPicker] = useState(false);
+
+  const handleOpenDesktop = useCallback(() => {
+    window.open(itemHtmlUrl, "_blank", "noopener,noreferrer");
+    onClose();
+  }, [itemHtmlUrl, onClose]);
+
+  const sortedProviders = Object.entries(providers)
+    .map(([id, p]) => ({
+      id,
+      label: p.label ?? id,
+      available: availability[id]?.available ?? false,
+    }))
+    .sort((a, b) => {
+      if (a.available !== b.available) return a.available ? -1 : 1;
+      const ai = DEFAULT_PROVIDER_ORDER.indexOf(a.id);
+      const bi = DEFAULT_PROVIDER_ORDER.indexOf(b.id);
+      if (ai !== -1 && bi !== -1) return ai - bi;
+      if (ai !== -1) return -1;
+      if (bi !== -1) return 1;
+      return a.label.localeCompare(b.label);
+    });
+
+  return (
+    <>
+      <BottomSheet isOpen={isOpen && !showAgentPicker} onClose={onClose} title={itemTitle}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <TouchButton
+            aria-label={`Dispatch ${getProviderLabel(providers, recommendedProviderId)} for ${itemTitle}`}
+            disabled={dispatching || !(availability[recommendedProviderId]?.available)}
+            onClick={() => onDispatch(recommendedProviderId)}
+            variant="primary"
+            style={{ width: "100%", minHeight: 48, fontSize: 15 }}
+          >
+            {dispatching
+              ? "Dispatching..."
+              : `Dispatch ${getProviderLabel(providers, recommendedProviderId)}`}
+          </TouchButton>
+
+          <TouchButton
+            aria-label="Pick a different agent"
+            disabled={dispatching}
+            onClick={() => setShowAgentPicker(true)}
+            variant="default"
+            style={{ width: "100%", minHeight: 48 }}
+          >
+            Pick agent...
+          </TouchButton>
+
+          <TouchButton
+            aria-label="Open on desktop in new tab"
+            onClick={handleOpenDesktop}
+            variant="default"
+            style={{ width: "100%", minHeight: 48 }}
+          >
+            Open on desktop
+          </TouchButton>
+        </div>
+      </BottomSheet>
+
+      <BottomSheet
+        isOpen={isOpen && showAgentPicker}
+        onClose={() => setShowAgentPicker(false)}
+        title="Pick agent"
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {sortedProviders.map(({ id, label, available }) => (
+            <TouchButton
+              key={id}
+              aria-label={`Dispatch ${label}`}
+              disabled={dispatching || !available}
+              onClick={() => {
+                setShowAgentPicker(false);
+                onDispatch(id);
+              }}
+              variant={id === recommendedProviderId ? "primary" : "default"}
+              style={{ width: "100%", minHeight: 44, display: "flex", justifyContent: "space-between", alignItems: "center" }}
+            >
+              <span>{label}</span>
+              <Badge tone={available ? "success" : "danger"} size="sm">
+                {available ? "Ready" : "Unavailable"}
+              </Badge>
+            </TouchButton>
+          ))}
+        </div>
+      </BottomSheet>
+    </>
+  );
+}
+
+// -- Main component ------------------------------------------------------------
+
+export interface RemediationMobileProps {
+  /** In-flight dispatches are kept at parent level for persistence across tab switches. */
+  inFlightDispatches: InFlightDispatch[];
+  onAddInFlight: (dispatch: InFlightDispatch) => void;
+}
+
+export function RemediationMobile({ inFlightDispatches, onAddInFlight }: RemediationMobileProps) {
+  const { showToast } = useToast();
+
+  const [subtab, setSubtab] = useState<RemediationSubtab>("automations");
+  const [providers, setProviders] = useState<Record<string, AgentProvider>>({});
+  const [availability, setAvailability] = useState<Record<string, ProviderAvailability>>({});
+  const [failedRuns, setFailedRuns] = useState<FailedRun[]>([]);
+  const [openPRs, setOpenPRs] = useState<OpenPR[]>([]);
+  const [openIssues, setOpenIssues] = useState<OpenIssue[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [actionSheetItem, setActionSheetItem] = useState<{
+    id: number;
+    title: string;
+    htmlUrl: string;
+    repository: string;
+    workflowName?: string;
+    branch?: string;
+    runId?: number;
+  } | null>(null);
+  const [dispatching, setDispatching] = useState(false);
+
+  const recommendedProviderId = pickRecommendedProvider(providers, availability);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [provResp, runsResp, prsResp, issuesResp] = await Promise.all([
+        fetch("/api/agent-remediation/providers"),
+        fetch("/api/runs?conclusion=failure&per_page=20"),
+        fetch("/api/pulls?state=open&per_page=20"),
+        fetch("/api/issues?state=open&per_page=20"),
+      ]);
+
+      if (!provResp.ok) throw new Error(`Providers HTTP ${provResp.status}`);
+      const provData = await provResp.json();
+      setProviders(provData.providers ?? {});
+      setAvailability(provData.availability ?? {});
+
+      if (runsResp.ok) {
+        const runsData = await runsResp.json();
+        setFailedRuns(
+          (runsData.workflow_runs ?? []).filter(
+            (r: FailedRun) => r.conclusion === "failure",
+          ),
+        );
+      }
+
+      if (prsResp.ok) {
+        const prsData = await prsResp.json();
+        setOpenPRs(Array.isArray(prsData) ? prsData : (prsData.items ?? []));
+      }
+
+      if (issuesResp.ok) {
+        const issuesData = await issuesResp.json();
+        setOpenIssues(Array.isArray(issuesData) ? issuesData : (issuesData.items ?? []));
+      }
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Failed to load remediation data";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleDispatch = useCallback(
+    async (providerId: string) => {
+      if (!actionSheetItem) return;
+      setDispatching(true);
+      try {
+        const payload = {
+          repository: actionSheetItem.repository,
+          workflow_name: actionSheetItem.workflowName ?? "unknown",
+          branch: actionSheetItem.branch ?? "main",
+          failure_reason: `Mobile dispatch for ${actionSheetItem.title}`,
+          log_excerpt: `Dispatched via mobile remediation flow. Item ID: ${actionSheetItem.id}`,
+          run_id: actionSheetItem.runId,
+          provider: providerId,
+          dispatch_origin: "manual",
+        };
+
+        const resp = await fetch("/api/agent-remediation/dispatch", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        const data = await resp.json();
+        if (!resp.ok) {
+          throw new Error(data.detail ?? `Dispatch failed: HTTP ${resp.status}`);
+        }
+
+        const inflight: InFlightDispatch = {
+          id: `${actionSheetItem.id}-${Date.now()}`,
+          itemId: actionSheetItem.id,
+          itemTitle: actionSheetItem.title,
+          provider: providerId,
+          providerLabel: getProviderLabel(providers, providerId),
+          repository: actionSheetItem.repository,
+          startedAt: Date.now(),
+          lastHeartbeat: Date.now(),
+          status: "dispatched",
+          fingerprint: data.fingerprint,
+        };
+        onAddInFlight(inflight);
+
+        showToast(
+          data.note ?? `Dispatched ${getProviderLabel(providers, providerId)} for ${actionSheetItem.title}`,
+          { variant: "success", title: "Dispatch submitted" },
+        );
+        setActionSheetItem(null);
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : "Dispatch failed";
+        showToast(message, { variant: "error", title: "Dispatch failed" });
+      } finally {
+        setDispatching(false);
+      }
+    },
+    [actionSheetItem, providers, onAddInFlight, showToast],
+  );
+
+  function renderAutomations() {
+    const inflight = inFlightDispatches.filter((d) => d.status !== "done");
+    return (
+      <>
+        {inflight.map((d) => (
+          <InFlightTile key={d.id} dispatch={d} />
+        ))}
+        {failedRuns.length === 0 ? (
+          <div
+            aria-label="No failed runs"
+            className="remediation-empty"
+            style={{ color: "var(--text-muted)", padding: "32px 0", textAlign: "center" }}
+          >
+            No failed runs found.
+          </div>
+        ) : (
+          failedRuns.map((run) => {
+            const repoName = run.repository?.name ?? "repo";
+            const isInflight = inFlightDispatches.some((d) => d.itemId === run.id);
+            if (isInflight) return null;
+            return (
+              <button
+                key={run.id}
+                aria-label={`Failed run: ${run.name ?? run.workflow_name} in ${repoName}`}
+                className="remediation-card"
+                onClick={() =>
+                  setActionSheetItem({
+                    id: run.id,
+                    title: `${repoName}: ${run.name ?? run.workflow_name}`,
+                    htmlUrl: run.html_url,
+                    repository: repoName,
+                    workflowName: run.workflow_name ?? run.name,
+                    branch: run.head_branch ?? "main",
+                    runId: run.id,
+                  })
+                }
+                style={{
+                  background: "var(--bg-secondary)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 10,
+                  cursor: "pointer",
+                  display: "block",
+                  marginBottom: 10,
+                  padding: "12px 14px",
+                  textAlign: "left",
+                  width: "100%",
+                }}
+                type="button"
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+                  <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
+                    {repoName}: {run.name ?? run.workflow_name}
+                  </span>
+                  <Badge tone="danger" size="sm">failure</Badge>
+                </div>
+                <div style={{ color: "var(--text-secondary)", fontSize: 12, marginBottom: 4 }}>
+                  {run.head_branch ?? "main"} · #{run.run_number ?? run.id}
+                </div>
+                <Badge tone="info" size="sm">
+                  Recommended: {getProviderLabel(providers, recommendedProviderId)}
+                </Badge>
+              </button>
+            );
+          })
+        )}
+      </>
+    );
+  }
+
+  function renderPRs() {
+    return (
+      <>
+        {openPRs.length === 0 ? (
+          <div
+            aria-label="No open PRs"
+            className="remediation-empty"
+            style={{ color: "var(--text-muted)", padding: "32px 0", textAlign: "center" }}
+          >
+            No open PRs found.
+          </div>
+        ) : (
+          openPRs.map((pr) => {
+            const repoName = pr.base?.repo?.name ?? "repo";
+            const isInflight = inFlightDispatches.some((d) => d.itemId === pr.id);
+            if (isInflight) return null;
+            return (
+              <button
+                key={pr.id}
+                aria-label={`Open PR: ${pr.title} in ${repoName}`}
+                className="remediation-card"
+                onClick={() =>
+                  setActionSheetItem({
+                    id: pr.id,
+                    title: `PR #${pr.number}: ${pr.title}`,
+                    htmlUrl: pr.html_url,
+                    repository: repoName,
+                    workflowName: "pr-remediation",
+                    branch: pr.head?.ref ?? "main",
+                  })
+                }
+                style={{
+                  background: "var(--bg-secondary)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 10,
+                  cursor: "pointer",
+                  display: "block",
+                  marginBottom: 10,
+                  padding: "12px 14px",
+                  textAlign: "left",
+                  width: "100%",
+                }}
+                type="button"
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+                  <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
+                    PR #{pr.number}: {pr.title}
+                  </span>
+                  {pr.draft && <Badge tone="neutral" size="sm">Draft</Badge>}
+                </div>
+                <div style={{ color: "var(--text-secondary)", fontSize: 12, marginBottom: 4 }}>
+                  {repoName} · {pr.head?.ref ?? "unknown branch"}
+                </div>
+                <Badge tone="info" size="sm">
+                  Recommended: {getProviderLabel(providers, recommendedProviderId)}
+                </Badge>
+              </button>
+            );
+          })
+        )}
+      </>
+    );
+  }
+
+  function renderIssues() {
+    return (
+      <>
+        {openIssues.length === 0 ? (
+          <div
+            aria-label="No open issues"
+            className="remediation-empty"
+            style={{ color: "var(--text-muted)", padding: "32px 0", textAlign: "center" }}
+          >
+            No open issues found.
+          </div>
+        ) : (
+          openIssues.map((issue) => {
+            const repoName = issue.repository_url?.split("/").pop() ?? "repo";
+            const isInflight = inFlightDispatches.some((d) => d.itemId === issue.id);
+            if (isInflight) return null;
+            return (
+              <button
+                key={issue.id}
+                aria-label={`Open issue: ${issue.title}`}
+                className="remediation-card"
+                onClick={() =>
+                  setActionSheetItem({
+                    id: issue.id,
+                    title: `Issue #${issue.number}: ${issue.title}`,
+                    htmlUrl: issue.html_url,
+                    repository: repoName,
+                    workflowName: "issue-remediation",
+                    branch: "main",
+                  })
+                }
+                style={{
+                  background: "var(--bg-secondary)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 10,
+                  cursor: "pointer",
+                  display: "block",
+                  marginBottom: 10,
+                  padding: "12px 14px",
+                  textAlign: "left",
+                  width: "100%",
+                }}
+                type="button"
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+                  <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
+                    #{issue.number}: {issue.title}
+                  </span>
+                </div>
+                <div style={{ color: "var(--text-secondary)", fontSize: 12, marginBottom: 4 }}>
+                  {repoName}
+                  {issue.labels.length > 0 && (
+                    <> {issue.labels.map((l) => l.name).join(", ")}</>
+                  )}
+                </div>
+                <Badge tone="info" size="sm">
+                  Recommended: {getProviderLabel(providers, recommendedProviderId)}
+                </Badge>
+              </button>
+            );
+          })
+        )}
+      </>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div
+        aria-busy="true"
+        aria-label="Loading remediation data"
+        aria-live="polite"
+        className="remediation-mobile-loading"
+        role="status"
+        style={{ padding: "16px", display: "flex", flexDirection: "column", gap: 12 }}
+      >
+        <SkeletonLine height={20} width="60%" />
+        <SkeletonLine height={36} width="100%" />
+        <SkeletonCard lines={3} />
+        <SkeletonCard lines={3} />
+        <SkeletonCard lines={3} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        aria-live="assertive"
+        className="remediation-mobile-error"
+        role="alert"
+        style={{ color: "var(--accent-red)", padding: "24px", textAlign: "center" }}
+      >
+        <div style={{ marginBottom: 12 }}>{error}</div>
+        <TouchButton onClick={fetchData} variant="primary">
+          Retry
+        </TouchButton>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Mobile remediation"
+      className="remediation-mobile"
+      style={{ padding: "12px 12px 24px" }}
+    >
+      <SegmentedControl
+        ariaLabel="Remediation subtabs"
+        onChange={(v) => setSubtab(v as RemediationSubtab)}
+        options={SUBTAB_OPTIONS}
+        value={subtab}
+      />
+
+      <div
+        aria-live="polite"
+        className="remediation-list"
+        style={{ marginTop: 14 }}
+      >
+        {subtab === "automations" && renderAutomations()}
+        {subtab === "prs" && renderPRs()}
+        {subtab === "issues" && renderIssues()}
+      </div>
+
+      {actionSheetItem && (
+        <ActionSheet
+          isOpen={true}
+          onClose={() => !dispatching && setActionSheetItem(null)}
+          itemTitle={actionSheetItem.title}
+          itemHtmlUrl={actionSheetItem.htmlUrl}
+          recommendedProviderId={recommendedProviderId}
+          providers={providers}
+          availability={availability}
+          onDispatch={handleDispatch}
+          dispatching={dispatching}
+        />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/Remediation/__tests__/Mobile.test.tsx
+++ b/frontend/src/pages/Remediation/__tests__/Mobile.test.tsx
@@ -1,0 +1,448 @@
+// @vitest-environment jsdom
+/**
+ * Tests for Remediation/Mobile.tsx -- issue #196 M10.
+ *
+ * Covers:
+ * 1. Renders subtab control with Automations / PRs / Issues.
+ * 2. Clicking a subtab changes the visible content.
+ * 3. Tapping a card opens the action sheet (BottomSheet).
+ * 4. Confirming dispatch calls POST /api/agent-remediation/dispatch.
+ * 5. In-flight tile appears after dispatch.
+ * 6. BottomSheet closes on Escape key.
+ */
+import "@testing-library/jest-dom/vitest";
+import React, { useState } from "react";
+import { cleanup, render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RemediationMobile } from "../Mobile";
+import type { InFlightDispatch } from "../Mobile";
+
+afterEach(cleanup);
+
+// -- Mocks ---------------------------------------------------------------------
+
+const MOCK_PROVIDERS = {
+  claude_code_cli: {
+    provider_id: "claude_code_cli",
+    label: "Claude Code CLI",
+    execution_mode: "cli",
+    dispatch_mode: "workflow",
+    notes: "",
+    experimental: false,
+    remote: true,
+    editable: false,
+  },
+};
+
+const MOCK_AVAILABILITY = {
+  claude_code_cli: {
+    provider_id: "claude_code_cli",
+    available: true,
+    status: "available",
+    detail: "ready",
+  },
+};
+
+const MOCK_RUNS = {
+  workflow_runs: [
+    {
+      id: 1001,
+      name: "CI Build",
+      workflow_name: "ci.yml",
+      head_branch: "main",
+      conclusion: "failure",
+      html_url: "https://github.com/org/repo/actions/runs/1001",
+      created_at: "2026-05-01T10:00:00Z",
+      run_number: 42,
+      repository: { name: "runner-dashboard" },
+    },
+  ],
+};
+
+const MOCK_PRS = [
+  {
+    id: 2001,
+    number: 42,
+    title: "Fix flaky test",
+    html_url: "https://github.com/org/repo/pull/42",
+    head: { ref: "fix/flaky-test" },
+    base: { repo: { name: "runner-dashboard" } },
+    draft: false,
+    labels: [],
+    updated_at: "2026-05-01T10:00:00Z",
+  },
+];
+
+const MOCK_ISSUES = [
+  {
+    id: 3001,
+    number: 196,
+    title: "Mobile Remediation + 3-tap Agent Dispatch",
+    html_url: "https://github.com/org/repo/issues/196",
+    repository_url: "https://api.github.com/repos/org/runner-dashboard",
+    labels: [{ name: "enhancement" }],
+    updated_at: "2026-05-01T10:00:00Z",
+  },
+];
+
+const MOCK_DISPATCH_RESPONSE = {
+  status: "dispatched",
+  workflow: "Agent-CI-Remediation.yml",
+  target_repository: "d-sorganization/runner-dashboard",
+  provider: "claude_code_cli",
+  fingerprint: "abc123",
+  note: "Dispatch submitted successfully.",
+};
+
+// -- Helpers -------------------------------------------------------------------
+
+function setupFetch({
+  providersOk = true,
+  runsOk = true,
+  prsOk = true,
+  issuesOk = true,
+  dispatchOk = true,
+}: {
+  providersOk?: boolean;
+  runsOk?: boolean;
+  prsOk?: boolean;
+  issuesOk?: boolean;
+  dispatchOk?: boolean;
+} = {}) {
+  const fetchMock = vi.fn((url: string, options?: RequestInit) => {
+    if (url.includes("/api/agent-remediation/providers")) {
+      return Promise.resolve({
+        ok: providersOk,
+        status: providersOk ? 200 : 500,
+        json: () =>
+          Promise.resolve({
+            providers: MOCK_PROVIDERS,
+            availability: MOCK_AVAILABILITY,
+          }),
+      } as Response);
+    }
+    if (url.includes("/api/runs")) {
+      return Promise.resolve({
+        ok: runsOk,
+        status: runsOk ? 200 : 500,
+        json: () => Promise.resolve(MOCK_RUNS),
+      } as Response);
+    }
+    if (url.includes("/api/pulls")) {
+      return Promise.resolve({
+        ok: prsOk,
+        status: prsOk ? 200 : 500,
+        json: () => Promise.resolve(MOCK_PRS),
+      } as Response);
+    }
+    if (url.includes("/api/issues")) {
+      return Promise.resolve({
+        ok: issuesOk,
+        status: issuesOk ? 200 : 500,
+        json: () => Promise.resolve(MOCK_ISSUES),
+      } as Response);
+    }
+    if (url.includes("/api/agent-remediation/dispatch") && options?.method === "POST") {
+      return Promise.resolve({
+        ok: dispatchOk,
+        status: dispatchOk ? 200 : 409,
+        json: () =>
+          Promise.resolve(
+            dispatchOk
+              ? MOCK_DISPATCH_RESPONSE
+              : { detail: "Dispatch rejected" },
+          ),
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({}),
+    } as Response);
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+// -- Wrapper that holds in-flight state at parent level -----------------------
+
+interface WrapperProps {
+  initial?: InFlightDispatch[];
+}
+
+function Wrapper({ initial = [] }: WrapperProps) {
+  const [inFlight, setInFlight] = useState<InFlightDispatch[]>(initial);
+  const handleAdd = (d: InFlightDispatch) => setInFlight((prev) => [...prev, d]);
+  return (
+    <RemediationMobile inFlightDispatches={inFlight} onAddInFlight={handleAdd} />
+  );
+}
+
+// -- Tests --------------------------------------------------------------------
+
+describe("RemediationMobile", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
+  it("renders subtab control with Automations, PRs, Issues", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("radiogroup", { name: /remediation subtabs/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("radio", { name: /automations/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /prs/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /issues/i })).toBeInTheDocument();
+  });
+
+  it("defaults to Automations subtab and shows failed runs", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /automations/i })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+    });
+
+    expect(screen.getByText(/CI Build/i)).toBeInTheDocument();
+  });
+
+  it("clicking PRs subtab shows open PRs", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /prs/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /prs/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fix flaky test/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/CI Build/i)).not.toBeInTheDocument();
+  });
+
+  it("clicking Issues subtab shows open issues", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /issues/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /issues/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Mobile Remediation/i)).toBeInTheDocument();
+    });
+  });
+
+  it("tapping a card opens the action sheet BottomSheet", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/CI Build/i)).toBeInTheDocument();
+    });
+
+    const card = screen.getByRole("button", { name: /Failed run: CI Build/i });
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: /Dispatch Claude Code CLI/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Pick a different agent/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open on desktop/i })).toBeInTheDocument();
+  });
+
+  it("confirming dispatch calls POST /api/agent-remediation/dispatch", async () => {
+    const fetchMock = setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/CI Build/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Failed run: CI Build/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    const dispatchBtn = screen.getByRole("button", { name: /Dispatch Claude Code CLI/i });
+
+    await act(async () => {
+      fireEvent.click(dispatchBtn);
+    });
+
+    await waitFor(() => {
+      const dispatchCalls = (fetchMock.mock.calls as [string, RequestInit?][]).filter(
+        ([url, opts]) =>
+          url.includes("/api/agent-remediation/dispatch") &&
+          opts?.method === "POST",
+      );
+      expect(dispatchCalls).toHaveLength(1);
+    });
+
+    const dispatchCall = (fetchMock.mock.calls as [string, RequestInit?][]).find(
+      ([url, opts]) =>
+        url.includes("/api/agent-remediation/dispatch") && opts?.method === "POST",
+    );
+    expect(dispatchCall).toBeDefined();
+    const body = JSON.parse(dispatchCall![1]!.body as string);
+    expect(body.provider).toBe("claude_code_cli");
+    expect(body.repository).toBe("runner-dashboard");
+  });
+
+  it("in-flight tile appears after dispatch", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/CI Build/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Failed run: CI Build/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Dispatch Claude Code CLI/i }));
+    });
+
+    await waitFor(() => {
+      const tiles = screen.getAllByRole("status");
+      const inflight = tiles.find((el) =>
+        el.getAttribute("aria-label")?.startsWith("In-flight dispatch"),
+      );
+      expect(inflight).toBeDefined();
+    });
+  });
+
+  it("BottomSheet closes on Escape key", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/CI Build/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Failed run: CI Build/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows recommended agent badge on each automation card", async () => {
+    setupFetch();
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/CI Build/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Recommended: Claude Code CLI/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no failed runs", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes("/api/agent-remediation/providers")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              providers: MOCK_PROVIDERS,
+              availability: MOCK_AVAILABILITY,
+            }),
+        } as Response);
+      }
+      if (url.includes("/api/runs")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ workflow_runs: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      } as Response);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Wrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No failed runs found/i)).toBeInTheDocument();
+    });
+  });
+
+  it("in-flight dispatches persist across subtab switches", async () => {
+    setupFetch();
+
+    const preExisting: InFlightDispatch[] = [
+      {
+        id: "test-inflight-1",
+        itemId: 1001,
+        itemTitle: "runner-dashboard: ci.yml",
+        provider: "claude_code_cli",
+        providerLabel: "Claude Code CLI",
+        repository: "runner-dashboard",
+        startedAt: Date.now() - 30000,
+        lastHeartbeat: Date.now() - 5000,
+        status: "dispatched",
+        fingerprint: "abc123",
+      },
+    ];
+
+    render(<Wrapper initial={preExisting} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /prs/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fix flaky test/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /automations/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+    });
+
+    const inflight = screen.queryByRole("status", {
+      name: /In-flight dispatch/i,
+    });
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/primitives/BottomSheet.tsx
+++ b/frontend/src/primitives/BottomSheet.tsx
@@ -1,0 +1,219 @@
+/**
+ * BottomSheet primitive — mobile-native action sheet pattern (issue #196).
+ *
+ * Features:
+ * - Slides up from the bottom of the screen
+ * - Backdrop click closes the sheet
+ * - Escape key closes the sheet
+ * - role="dialog", aria-modal="true", focus trap (Tab / Shift+Tab)
+ * - Focus moves to first interactive element on open; returns to trigger on close
+ * - Reduced-motion: slide animation disabled when prefers-reduced-motion is set
+ */
+import React, { useCallback, useEffect, useId, useRef } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+export interface BottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+export function BottomSheet({
+  isOpen,
+  onClose,
+  title,
+  children,
+}: BottomSheetProps): React.ReactElement | null {
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+  const reduced = prefersReducedMotion();
+
+  // Remember the element that had focus before the sheet opened.
+  useEffect(() => {
+    if (isOpen) {
+      triggerRef.current = document.activeElement;
+    }
+  }, [isOpen]);
+
+  // Focus first interactive element when sheet opens.
+  useEffect(() => {
+    if (!isOpen) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusable = getFocusable(panel);
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    } else {
+      panel.focus();
+    }
+  }, [isOpen]);
+
+  // Restore focus to trigger when sheet closes.
+  useEffect(() => {
+    if (!isOpen && triggerRef.current instanceof HTMLElement) {
+      triggerRef.current.focus();
+      triggerRef.current = null;
+    }
+  }, [isOpen]);
+
+  // Escape key closes the sheet.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+  }, [isOpen, onClose]);
+
+  // Focus trap: Tab / Shift+Tab cycle within the panel.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = getFocusable(panel);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        panel.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    },
+    [],
+  );
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        className="bottom-sheet-backdrop"
+        onClick={handleBackdropClick}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(15,17,23,0.6)",
+          zIndex: 9998,
+          animation: reduced ? undefined : "bottomSheetOverlayIn 200ms ease",
+        }}
+      />
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        aria-labelledby={title ? titleId : undefined}
+        aria-modal="true"
+        className="bottom-sheet"
+        onKeyDown={handleKeyDown}
+        role="dialog"
+        tabIndex={-1}
+        style={{
+          position: "fixed",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          zIndex: 9999,
+          background: "var(--bg-secondary)",
+          borderTop: "1px solid var(--border)",
+          borderRadius: "16px 16px 0 0",
+          boxShadow: "0 -8px 32px rgba(0,0,0,0.35)",
+          maxHeight: "80vh",
+          overflowY: "auto",
+          animation: reduced ? undefined : "bottomSheetPanelIn 250ms cubic-bezier(0.32,0.72,0,1)",
+          outline: "none",
+        }}
+      >
+        {title && (
+          <div
+            className="bottom-sheet-header"
+            style={{
+              alignItems: "center",
+              borderBottom: "1px solid var(--border)",
+              display: "flex",
+              justifyContent: "space-between",
+              padding: "16px 20px 12px",
+            }}
+          >
+            <h2
+              id={titleId}
+              style={{
+                color: "var(--text-primary)",
+                fontSize: 16,
+                fontWeight: 600,
+                margin: 0,
+              }}
+            >
+              {title}
+            </h2>
+            <button
+              aria-label="Close"
+              className="bottom-sheet-close"
+              onClick={onClose}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: "var(--text-secondary)",
+                cursor: "pointer",
+                fontSize: 20,
+                lineHeight: 1,
+                minHeight: 44,
+                minWidth: 44,
+                padding: 8,
+              }}
+              type="button"
+            >
+              ×
+            </button>
+          </div>
+        )}
+        <div className="bottom-sheet-panel" style={{ padding: "16px 20px 24px" }}>
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/primitives/index.ts
+++ b/frontend/src/primitives/index.ts
@@ -34,3 +34,6 @@ export type {
   DialogActionsProps,
   DialogCloseProps,
 } from "./Dialog";
+
+export { BottomSheet } from "./BottomSheet";
+export type { BottomSheetProps } from "./BottomSheet";

--- a/tests/api/test_mobile_dispatch.py
+++ b/tests/api/test_mobile_dispatch.py
@@ -1,0 +1,312 @@
+"""Backend tests for the mobile dispatch path through POST /api/agent-remediation/dispatch.
+
+Tests the same endpoint that RemediationMobile.tsx (issue #196 M10) calls when
+the user completes the 3-tap agent dispatch flow on mobile.
+
+Test patterns follow tests/test_quick_dispatch.py and tests/conftest.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "backend"))
+
+import agent_remediation  # noqa: E402
+
+
+# -- Helpers ------------------------------------------------------------------
+
+
+def _make_run_cmd(returncode: int = 0, stdout: str = "", stderr: str = "") -> AsyncMock:
+    """Build a mock run_cmd coroutine that returns (returncode, stdout, stderr)."""
+
+    async def _run(
+        cmd: list[str],
+        timeout: int = 30,
+        cwd: Path | None = None,
+    ) -> tuple[int, str, str]:
+        return returncode, stdout, stderr
+
+    return AsyncMock(side_effect=_run)
+
+
+def _make_avail_patch(available: bool = True):
+    """Context-manager patch that stubs probe_provider_availability."""
+    status = "available" if available else "unavailable"
+    detail = "ready" if available else "agent binary missing"
+    return patch(
+        "agent_remediation.probe_provider_availability",
+        return_value={
+            "claude_code_cli": type(
+                "_Avail",
+                (),
+                {"available": available, "status": status, "detail": detail},
+            )(),
+        },
+    )
+
+
+def _make_policy_patch(auto_dispatch: bool = True):
+    """Return a RemediationPolicy that accepts dispatches by default."""
+    policy = agent_remediation.RemediationPolicy(
+        auto_dispatch_on_failure=auto_dispatch,
+        require_failure_summary=False,
+        require_non_protected_branch=False,
+        max_same_failure_attempts=5,
+        attempt_window_hours=24,
+        provider_order=("claude_code_cli",),
+        enabled_providers=("claude_code_cli",),
+        default_provider="claude_code_cli",
+    )
+    return patch("agent_remediation.load_policy", return_value=policy)
+
+
+# -- Minimal request body fixtures --------------------------------------------
+
+
+VALID_MOBILE_DISPATCH_BODY = {
+    "repository": "runner-dashboard",
+    "workflow_name": "ci.yml",
+    "branch": "main",
+    "failure_reason": "Mobile dispatch for runner-dashboard: ci.yml",
+    "log_excerpt": "Dispatched via mobile remediation flow. Item ID: 1001",
+    "run_id": 1001,
+    "provider": "claude_code_cli",
+    "dispatch_origin": "manual",
+}
+
+
+# -- Tests --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_well_formed_mobile_dispatch_accepted() -> None:
+    """A well-formed mobile dispatch request does not get rejected with a 422."""
+    import os
+
+    os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+    from fastapi.testclient import TestClient
+    from identity import Principal, require_principal
+    from server import app
+
+    def _mock_principal():
+        return Principal(id="test-admin", type="bot", name="Test", roles=["admin"])
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[require_principal] = _mock_principal
+    try:
+        with _make_policy_patch(), _make_avail_patch(True):
+            with patch("routers.remediation.run_cmd", return_value=_make_run_cmd(0)):
+                with patch("quota_enforcement.quota_enforcement.check_dispatch_quota", return_value=(True, "")):
+                    with patch("quota_enforcement.quota_enforcement.add_spend"):
+                        with patch("routers.remediation._append_remediation_history"):
+                            client = TestClient(app, raise_server_exceptions=False)
+                            resp = client.post(
+                                "/api/agent-remediation/dispatch",
+                                json=VALID_MOBILE_DISPATCH_BODY,
+                                headers={"X-Requested-With": "XMLHttpRequest"},
+                            )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert resp.status_code not in (422, 500), (
+        f"Unexpected error {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_repo_name_rejected_422() -> None:
+    """A repository name with shell metacharacters is rejected with 422."""
+    import os
+
+    os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+    from fastapi.testclient import TestClient
+    from identity import Principal, require_principal
+    from server import app
+
+    bad_body = {**VALID_MOBILE_DISPATCH_BODY, "repository": "repo-with-bad; chars"}
+
+    def _mock_principal():
+        return Principal(id="test-admin", type="bot", name="Test", roles=["admin"])
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[require_principal] = _mock_principal
+    try:
+        with _make_policy_patch(), _make_avail_patch(True):
+            with patch("quota_enforcement.quota_enforcement.check_dispatch_quota", return_value=(True, "")):
+                client = TestClient(app, raise_server_exceptions=False)
+                resp = client.post(
+                    "/api/agent-remediation/dispatch",
+                    json=bad_body,
+                )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert resp.status_code == 422, (
+        f"Expected 422 for invalid repo name, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_enforced() -> None:
+    """check_dispatch_rate raises HTTPException 429 on rate-limit breach."""
+    import os
+
+    os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+    from fastapi import HTTPException
+    from fastapi.testclient import TestClient
+    from identity import Principal, require_principal
+    from server import app
+
+    def _mock_principal():
+        return Principal(id="test-admin", type="bot", name="Test", roles=["admin"])
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[require_principal] = _mock_principal
+    try:
+        with _make_policy_patch(), _make_avail_patch(True):
+            with patch(
+                "routers.remediation.check_dispatch_rate",
+                side_effect=HTTPException(status_code=429, detail="rate_limited"),
+            ):
+                client = TestClient(app, raise_server_exceptions=False)
+                resp = client.post(
+                    "/api/agent-remediation/dispatch",
+                    json=VALID_MOBILE_DISPATCH_BODY,
+                )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert resp.status_code == 429, (
+        f"Expected 429, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_required_fields_rejected() -> None:
+    """A request body missing repository/workflow_name/branch is rejected."""
+    import os
+
+    os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+    from fastapi.testclient import TestClient
+    from identity import Principal, require_principal
+    from server import app
+
+    incomplete_body = {
+        "failure_reason": "some failure",
+        "provider": "claude_code_cli",
+    }
+
+    def _mock_principal():
+        return Principal(id="test-admin", type="bot", name="Test", roles=["admin"])
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[require_principal] = _mock_principal
+    try:
+        with _make_policy_patch(), _make_avail_patch(True):
+            with patch("quota_enforcement.quota_enforcement.check_dispatch_quota", return_value=(True, "")):
+                client = TestClient(app, raise_server_exceptions=False)
+                resp = client.post(
+                    "/api/agent-remediation/dispatch",
+                    json=incomplete_body,
+                )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert resp.status_code != 200, (
+        f"Expected non-200 for incomplete body, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_dispatch_accepts_mobile_context() -> None:
+    """Unit-level: plan_dispatch accepts a FailureContext mirroring the mobile payload."""
+    context = agent_remediation.FailureContext(
+        repository="runner-dashboard",
+        workflow_name="ci.yml",
+        branch="main",
+        failure_reason="Mobile dispatch for runner-dashboard: ci.yml",
+        log_excerpt="Dispatched via mobile remediation flow. Item ID: 1001",
+        run_id=1001,
+        source="mobile",
+    )
+    policy = agent_remediation.RemediationPolicy(
+        auto_dispatch_on_failure=True,
+        require_failure_summary=False,
+        require_non_protected_branch=False,
+        max_same_failure_attempts=5,
+        attempt_window_hours=24,
+        provider_order=("claude_code_cli",),
+        enabled_providers=("claude_code_cli",),
+        default_provider="claude_code_cli",
+    )
+    availability = {
+        "claude_code_cli": agent_remediation.ProviderAvailability(
+            provider_id="claude_code_cli",
+            available=True,
+            status="available",
+            detail="ready",
+        )
+    }
+    decision = agent_remediation.plan_dispatch(
+        context,
+        policy=policy,
+        availability=availability,
+        attempts=[],
+        provider_override="claude_code_cli",
+        dispatch_origin="manual",
+    )
+
+    assert decision.accepted is True
+    assert decision.provider_id == "claude_code_cli"
+    assert decision.fingerprint
+
+
+@pytest.mark.asyncio
+async def test_quota_exceeded_returns_403() -> None:
+    """When quota is exceeded, dispatch returns 403."""
+    import os
+
+    os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+    from fastapi.testclient import TestClient
+    from identity import Principal, require_principal
+    from server import app
+
+    def _mock_principal():
+        return Principal(id="test-admin", type="bot", name="Test", roles=["admin"])
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[require_principal] = _mock_principal
+    try:
+        with _make_policy_patch(), _make_avail_patch(True):
+            with patch("routers.remediation.check_dispatch_rate"):
+                with patch(
+                    "quota_enforcement.quota_enforcement.check_dispatch_quota",
+                    return_value=(False, "hourly cap reached"),
+                ):
+                    client = TestClient(app, raise_server_exceptions=False)
+                    resp = client.post(
+                        "/api/agent-remediation/dispatch",
+                        json=VALID_MOBILE_DISPATCH_BODY,
+                    )
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+    assert resp.status_code == 403, (
+        f"Expected 403 for quota exceeded, got {resp.status_code}: {resp.text}"
+    )


### PR DESCRIPTION
Closes #196

Implements the M10 mobile remediation dispatch flow:
- BottomSheet primitive for action sheets
- Remediation/Mobile.tsx with SegmentedControl subtabs (Automations/PRs/Issues)
- Card-tap → action sheet → dispatch flow
- In-flight tile persists across tab switches
- Tests for frontend and backend mobile dispatch path

Depends on: #189 ✅ #190 ✅ #192 ✅