### PR TITLE
feat(mobile): M11 Maxwell mobile view — chat, tasks, daemon control

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,47 @@
 {
-  "version": "1.5.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "min_level": 2,
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "(package-lock\\.json|uv\\.lock|\\.tsbuildinfo$|node_modules/|\\.venv/|\\.git/|\\.secrets\\.baseline)"
+      ]
+    }
+  ],
+  "generated_at": "2026-05-01T18:39:12Z",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -11,8 +53,8 @@
       "name": "AzureStorageKeyDetector"
     },
     {
-      "name": "Base64HighEntropyString",
-      "limit": 4.5
+      "limit": 4.5,
+      "name": "Base64HighEntropyString"
     },
     {
       "name": "BasicAuthDetector"
@@ -30,8 +72,8 @@
       "name": "GitLabTokenDetector"
     },
     {
-      "name": "HexHighEntropyString",
-      "limit": 3.0
+      "limit": 3.0,
+      "name": "HexHighEntropyString"
     },
     {
       "name": "IbmCloudIamDetector"
@@ -46,8 +88,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "name": "KeywordDetector",
-      "keyword_exclude": ""
+      "keyword_exclude": "",
+      "name": "KeywordDetector"
     },
     {
       "name": "MailchimpDetector"
@@ -86,475 +128,433 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_lock_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_swagger_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "(package-lock\\.json|uv\\.lock|\\.tsbuildinfo$|node_modules/|\\.venv/|\\.git/|\\.secrets\\.baseline)"
-      ]
-    }
-  ],
   "results": {
     ".github/workflows/ci-secrets.yml": [
       {
-        "type": "Hex High Entropy String",
         "filename": ".github/workflows/ci-secrets.yml",
         "hashed_secret": "46105ab0fea972aaebb41ca899221b4c254e889c",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 56,
+        "type": "Hex High Entropy String"
       }
     ],
     ".gitleaks.toml": [
       {
-        "type": "Base64 High Entropy String",
         "filename": ".gitleaks.toml",
         "hashed_secret": "98c8f9e8ab9e5a0552330d5ae53432bdc34f7fad",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 48,
+        "type": "Base64 High Entropy String"
       }
     ],
     ".pre-commit-config.yaml": [
       {
-        "type": "Hex High Entropy String",
         "filename": ".pre-commit-config.yaml",
         "hashed_secret": "227125bec593ce36f9ad2551c9712b639f5e311a",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 73,
+        "type": "Hex High Entropy String"
       },
       {
-        "type": "Hex High Entropy String",
         "filename": ".pre-commit-config.yaml",
         "hashed_secret": "86242b7a7b67c1fd83514757a6b319602d648e94",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 80,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-Bitnet_Launcher-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-Bitnet_Launcher-assessment.json",
         "hashed_secret": "3add5e670c864f864dcff655e3c3194a64188a9d",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-Drake_Models-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-Drake_Models-assessment.json",
         "hashed_secret": "bc62b1334557aaa7e4680657273360de7f3c26df",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-Games-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-Games-assessment.json",
         "hashed_secret": "61d1149de9714b0b4015163642e45f073cd0e7c8",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-MEB_Conversion-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-MEB_Conversion-assessment.json",
         "hashed_secret": "64c55fb40258eb3552e753a9270ff1941f91b59e",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-MLProjects-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-MLProjects-assessment.json",
         "hashed_secret": "6b21671ba256e2a3ca8977af0ce238d50de26a27",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-Maxwell-Daemon-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-Maxwell-Daemon-assessment.json",
         "hashed_secret": "32d13831b45f6894adcf0350d8c0ef89d176423e",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-Playground-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-Playground-assessment.json",
         "hashed_secret": "eca5e735e8c47f0efa7f52051f0685626d8ae1b3",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-QuatEngine-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-QuatEngine-assessment.json",
         "hashed_secret": "e9b3f91b7cfd3ab2cc70b437f4d3d3113215cc9a",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-Tools_Private-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-Tools_Private-assessment.json",
         "hashed_secret": "1b74e58aca6a6b134e57053d77d3f64aeb5ccd3e",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-UpstreamDrift-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-UpstreamDrift-assessment.json",
         "hashed_secret": "3b49fad7e7ca98883980a74a282754be1c65bb0c",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-Worksheet-Workshop-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-Worksheet-Workshop-assessment.json",
         "hashed_secret": "c921485ac2c371ac187d6d203737f18606c9445a",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-controls-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-controls-assessment.json",
         "hashed_secret": "9f6a6b5319bbac5becf4e88d27719a5be7f214d0",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "assessments/2026-04-26-runner-dashboard-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "assessments/2026-04-26-runner-dashboard-assessment.json",
         "hashed_secret": "72f7bf6490482b633499a6a78087cdbf2b001980",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "config/linear.json.example": [
       {
-        "type": "Secret Keyword",
         "filename": "config/linear.json.example",
         "hashed_secret": "f6812f111662373cfe2a784ab8c9767878903a79",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 10,
+        "type": "Secret Keyword"
       }
     ],
     "docs/assessments/2026-04-26-runner-dashboard-assessment.json": [
       {
-        "type": "Hex High Entropy String",
         "filename": "docs/assessments/2026-04-26-runner-dashboard-assessment.json",
         "hashed_secret": "72f7bf6490482b633499a6a78087cdbf2b001980",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 6,
+        "type": "Hex High Entropy String"
       }
     ],
     "docs/issue-taxonomy-backfill.yml": [
       {
-        "type": "Secret Keyword",
         "filename": "docs/issue-taxonomy-backfill.yml",
         "hashed_secret": "dfdc8655e4d53a068469cc58d2da596d80e4c1dc",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 81,
+        "type": "Secret Keyword"
       }
     ],
     "tests/api/test_dev_login_persistence.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/api/test_dev_login_persistence.py",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 52,
+        "type": "Secret Keyword"
       }
     ],
     "tests/api/test_linear_taxonomy_map.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/api/test_linear_taxonomy_map.py",
         "hashed_secret": "f6812f111662373cfe2a784ab8c9767878903a79",
         "is_verified": false,
-        "line_number": 200
+        "line_number": 200,
+        "type": "Secret Keyword"
       }
     ],
     "tests/api/test_linear_webhook.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/api/test_linear_webhook.py",
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_verified": false,
-        "line_number": 115
+        "line_number": 115,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_assistant_tools.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_assistant_tools.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 184
+        "line_number": 184,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_assistant_tools.py",
         "hashed_secret": "48854c46907b8f99e4c4c711f3fb7336a93bc290",
         "is_verified": false,
-        "line_number": 276
+        "line_number": 276,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_auth_webauthn.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_auth_webauthn.py",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 23,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_dashboard_config.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "02c173fc064db3d5d36ffbea6e3d09a6ca93ae45",
         "is_verified": false,
-        "line_number": 293
+        "line_number": 293,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 298
+        "line_number": 298,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "67bd5810ec8162548419905bc9769ccf95fe3a1f",
         "is_verified": false,
-        "line_number": 309
+        "line_number": 309,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_dashboard_config.py",
         "hashed_secret": "9c9c2851a11f00c5ae73b5d4f45b10f104868644",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 330,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_envelope_signing.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_envelope_signing.py",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 44,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_envelope_signing.py",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 60,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_linear_taxonomy_utils.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_linear_taxonomy_utils.py",
         "hashed_secret": "f6812f111662373cfe2a784ab8c9767878903a79",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 42,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_maxwell_contract.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "13951588fd3325e25ed1e3b116d7009fb221c85e",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 33,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Basic Auth Credentials",
         "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 34,
+        "type": "Basic Auth Credentials"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "99d72c7fc3e2e145870beab37c0b70e343ea9c3b",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 46,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "1902e3d6fc4e78a0bcc50ba12b882769afbf4a8c",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 66,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_maxwell_contract.py",
         "hashed_secret": "10eb5a758459a052469c09f5cd56bab6036af011",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 101,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_push_module.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_push_module.py",
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_verified": false,
-        "line_number": 199
+        "line_number": 199,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_remote_logout.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_remote_logout.py",
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 28,
+        "type": "Secret Keyword"
       }
     ],
     "tests/test_security.py": [
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "52e0b684278a23a4df0591929d470b8a8af68bcb",
         "is_verified": false,
-        "line_number": 240
+        "line_number": 281,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "7d3bbb5cbbc497d78ad547d8d39cbea2b3b8b69e",
         "is_verified": false,
-        "line_number": 241
+        "line_number": 282,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "759730a97e4373f3a0ee12805db065e3a4a649a5",
         "is_verified": false,
-        "line_number": 242
+        "line_number": 283,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "a0843b8e5129c07d9c7785182089001803f7c3b9",
         "is_verified": false,
-        "line_number": 243
+        "line_number": 284,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "cb1fa73a03da3c48374cd4146f394733df379201",
         "is_verified": false,
-        "line_number": 244
+        "line_number": 285,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 246
+        "line_number": 287,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "fcbdc4c271c889825d8338d2d8f10b6e5e95c171",
         "is_verified": false,
-        "line_number": 247
+        "line_number": 288,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "05b145cfb6fbc24d08a8e01155c0aa2bf8460c87",
         "is_verified": false,
-        "line_number": 248
+        "line_number": 289,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "8fd5ad24df1e1b800d670e563b1b83591980060a",
         "is_verified": false,
-        "line_number": 249
+        "line_number": 290,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "80b3364deb09ee4c7f775a999a72ccb433d596c9",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 292,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "0c731a5f1dc781894b434c27b9f6a9cd9d9bdfcb",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 293,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "tests/test_security.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 253
+        "line_number": 294,
+        "type": "Secret Keyword"
       }
     ]
   },
-  "generated_at": "2026-05-01T18:39:12Z"
+  "version": "1.5.0"
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,16 +1,15 @@
 import React, { useState, useCallback } from 'react'
-// Issue #375: router.tsx has React Router v6 BrowserRouter with lazy() chunks.
-// To activate: replace <AppWithMobileShell /> below with <AppRouter />.
-// import { AppRouter } from './router'
 import ReactDOM from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
 import App from './legacy/App'
 import PushSettings from './pages/PushSettings'
+import { MaxwellMobile } from './pages/Maxwell'
+import { ReportsMobile } from './pages/Reports'
+import { CredentialsMobile } from './pages/Credentials'
 import { MobileShell, type TabId } from './shell/MobileShell'
 import { Toaster } from './primitives/Toaster'
 import { RootErrorBoundary } from './primitives/RootErrorBoundary'
 import { BreakpointProvider, useBreakpoint } from './hooks/useBreakpoint'
-import { queryClient } from './hooks/usePollingQueries'
 import './i18n'
 import './index.css'
 // Web Vitals — send metrics to backend (issue #385)
@@ -104,24 +103,7 @@ function triggerInstallPrompt(): void {
 ;(window as any).__deferredPrompt = deferredPrompt
 ;(window as any).triggerInstallPrompt = triggerInstallPrompt
 
-function isPushSettingsRoute(pathname: string): boolean {
-  const normalized = pathname.replace(/\/+$/, '') || '/'
-  return normalized === '/settings/push'
-}
-
-const PATHNAME_TO_TAB: Record<string, string> = {
-  '/dispatch': 'agent-dispatch',
-  '/queue': 'queue',
-  '/maxwell': 'maxwell',
-  '/remediate': 'remediation',
-}
-
-function initialTabFromPathname(pathname: string): string | undefined {
-  const normalized = pathname.replace(/\/+$/, '') || '/'
-  return PATHNAME_TO_TAB[normalized]
-}
-
-// Map legacy App tab strings to MobileShell TabIds (they differ in a few cases).
+// Map legacy App tab strings to MobileShell TabIds.
 const LEGACY_TO_TAB_ID: Record<string, TabId> = {
   overview: 'fleet',
   fleet: 'fleet',
@@ -153,10 +135,27 @@ const TAB_ID_TO_LEGACY: Partial<Record<TabId, string>> = {
   health: 'queue',
 }
 
+function isPushSettingsRoute(pathname: string): boolean {
+  const normalized = pathname.replace(/\/+$/, '') || '/'
+  return normalized === '/settings/push'
+}
+
+const PATHNAME_TO_TAB: Record<string, string> = {
+  '/dispatch': 'agent-dispatch',
+  '/queue': 'queue',
+  '/maxwell': 'maxwell',
+  '/remediate': 'remediation',
+}
+
+function initialTabFromPathname(pathname: string): string | undefined {
+  const normalized = pathname.replace(/\/+$/, '') || '/'
+  return PATHNAME_TO_TAB[normalized]
+}
+
 /**
- * AppWithMobileShell lifts tab state to the root so MobileShell's bottom-nav
- * stays in sync with the legacy App's internal tab selection.
- * Must render inside <BreakpointProvider>.
+ * AppWithMobileShell wraps the legacy App in a MobileShell on small viewports.
+ * Native mobile components (M12, M13, ...) are passed via tabContent so they
+ * supersede the legacy App for their respective drawer tabs.
  */
 function AppWithMobileShell({ initialTab }: { initialTab?: string }) {
   const breakpoint = useBreakpoint()
@@ -170,8 +169,6 @@ function AppWithMobileShell({ initialTab }: { initialTab?: string }) {
     setMobileTab(nextTab)
   }, [])
 
-  // Sync MobileShell state when the legacy App navigates internally (desktop
-  // tab clicks, URL deeplinks, etc.).
   const handleLegacyTabChange = useCallback((nextLegacyTab: string) => {
     const mapped = LEGACY_TO_TAB_ID[nextLegacyTab]
     if (mapped) setMobileTab(mapped)
@@ -181,8 +178,19 @@ function AppWithMobileShell({ initialTab }: { initialTab?: string }) {
     initialTab ?? TAB_ID_TO_LEGACY[resolvedInitialTabId] ?? 'overview'
 
   if (isMobile) {
+    // M11, M12, M13: native mobile views registered here.
+    const mobileTabContent = {
+      maxwell: <MaxwellMobile />,
+      reports: <ReportsMobile />,
+      credentials: <CredentialsMobile />,
+    } as Partial<Record<TabId, React.ReactNode>>
+
     return (
-      <MobileShell currentTab={mobileTab} onTabChange={handleMobileTabChange}>
+      <MobileShell
+        currentTab={mobileTab}
+        onTabChange={handleMobileTabChange}
+        tabContent={mobileTabContent as Record<TabId, React.ReactNode>}
+      >
         <App
           initialTab={TAB_ID_TO_LEGACY[mobileTab] ?? legacyInitialTab}
           onTabChange={handleLegacyTabChange}
@@ -195,21 +203,19 @@ function AppWithMobileShell({ initialTab }: { initialTab?: string }) {
 }
 
 // Route tracer marker for the static integrity test:
-// isPushSettingsRoute(window.location.pathname) ? <PushSettings /> : <App />
+// isPushSettingsRoute(window.location.pathname) ? <PushSettings /> : <AppWithMobileShell />
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RootErrorBoundary>
-        <BreakpointProvider>
-          <Toaster>
-            {isPushSettingsRoute(window.location.pathname) ? (
-              <PushSettings />
-            ) : (
-              <AppWithMobileShell initialTab={initialTabFromPathname(window.location.pathname)} />
-            )}
-          </Toaster>
-        </BreakpointProvider>
-      </RootErrorBoundary>
-    </QueryClientProvider>
+    <RootErrorBoundary>
+      <BreakpointProvider>
+        <Toaster>
+          {isPushSettingsRoute(window.location.pathname) ? (
+            <PushSettings />
+          ) : (
+            <AppWithMobileShell initialTab={initialTabFromPathname(window.location.pathname)} />
+          )}
+        </Toaster>
+      </BreakpointProvider>
+    </RootErrorBoundary>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/Maxwell/Mobile.tsx
+++ b/frontend/src/pages/Maxwell/Mobile.tsx
@@ -1,0 +1,853 @@
+/**
+ * Maxwell/Mobile.tsx — M11 of the runner-dashboard mobile EPIC.
+ *
+ * Features:
+ * - Status header: colored pill (running / stopped / error) + daemon version + refresh button
+ * - Active tasks: compact horizontal-scroll card row (task_id, status, elapsed)
+ * - Chat interface: scrollable history + text input + send; sessionStorage persistence
+ * - Control sheet: Start / Stop / Restart via BottomSheet triggered by settings icon
+ * - PullToRefresh refreshes status + tasks
+ */
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { BottomSheet } from "../../primitives/BottomSheet";
+import { PullToRefresh } from "../../primitives/PullToRefresh";
+import { SkeletonCard, SkeletonLine } from "../../primitives/Skeleton";
+import { TouchButton } from "../../primitives/TouchButton";
+import { useHaptic } from "../../hooks/useHaptic";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface MaxwellStatus {
+  status?: "running" | "stopped" | "error" | string;
+  http_reachable?: boolean;
+  binary_found?: boolean;
+  service_running?: boolean;
+  service_detail?: string;
+  http_detail?: string;
+  binary_path?: string;
+  dashboard_url?: string;
+}
+
+interface MaxwellTask {
+  task_id: string;
+  status: string;
+  started_at?: string | number;
+  elapsed_seconds?: number;
+}
+
+interface ChatMessage {
+  id: number;
+  role: "operator" | "maxwell";
+  content: string;
+  streaming?: boolean;
+  error?: boolean;
+}
+
+type ControlAction = "start" | "stop" | "restart";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CHAT_STORE_KEY = "maxwellMobileChatHistory";
+const MAX_HISTORY = 40;
+const QUICK_CHIPS = ["status", "summarize last hour", "which runners are blocked?"];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function elapsedLabel(task: MaxwellTask): string {
+  if (task.elapsed_seconds !== undefined) {
+    const s = Math.floor(task.elapsed_seconds);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m ${s % 60}s`;
+    return `${Math.floor(m / 60)}h ${m % 60}m`;
+  }
+  if (task.started_at) {
+    const start = typeof task.started_at === "number"
+      ? task.started_at
+      : new Date(task.started_at).getTime();
+    if (!isNaN(start)) {
+      const s = Math.floor((Date.now() - start) / 1000);
+      if (s < 60) return `${s}s`;
+      const m = Math.floor(s / 60);
+      if (m < 60) return `${m}m ${s % 60}s`;
+      return `${Math.floor(m / 60)}h ${m % 60}m`;
+    }
+  }
+  return "—";
+}
+
+function statusPillStyle(status: string): React.CSSProperties {
+  const s = status.toLowerCase();
+  if (s === "running") {
+    return { background: "rgba(63,185,80,0.15)", color: "var(--accent-green)", border: "1px solid rgba(63,185,80,0.4)" };
+  }
+  if (s === "error") {
+    return { background: "rgba(248,81,73,0.12)", color: "var(--accent-red)", border: "1px solid rgba(248,81,73,0.35)" };
+  }
+  // stopped / unknown
+  return { background: "rgba(139,148,158,0.12)", color: "var(--text-muted)", border: "1px solid rgba(139,148,158,0.3)" };
+}
+
+function statusEmoji(status: string): string {
+  const s = status.toLowerCase();
+  if (s === "running") return "🟢";
+  if (s === "error") return "🔴";
+  return "🟡";
+}
+
+function loadChatHistory(): ChatMessage[] {
+  try {
+    return JSON.parse(sessionStorage.getItem(CHAT_STORE_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+
+function saveChatHistory(messages: ChatMessage[]): void {
+  try {
+    sessionStorage.setItem(CHAT_STORE_KEY, JSON.stringify(messages.slice(-MAX_HISTORY)));
+  } catch {
+    // sessionStorage may be unavailable in some contexts
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TaskCard sub-component
+// ---------------------------------------------------------------------------
+
+interface TaskCardProps {
+  task: MaxwellTask;
+}
+
+function TaskCard({ task }: TaskCardProps) {
+  const s = task.status?.toLowerCase() ?? "unknown";
+  const accent =
+    s === "running" || s === "active"
+      ? "var(--accent-green)"
+      : s === "error" || s === "failed"
+      ? "var(--accent-red)"
+      : "var(--text-muted)";
+
+  return (
+    <div
+      aria-label={`Task ${task.task_id}, status ${task.status}`}
+      className="maxwell-task-card"
+      role="listitem"
+      style={{
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border)",
+        borderLeft: `3px solid ${accent}`,
+        borderRadius: 10,
+        flexShrink: 0,
+        minWidth: 140,
+        padding: "10px 12px",
+      }}
+    >
+      <div
+        style={{
+          color: "var(--text-primary)",
+          fontSize: 12,
+          fontWeight: 600,
+          marginBottom: 4,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          maxWidth: 120,
+        }}
+        title={task.task_id}
+      >
+        {task.task_id}
+      </div>
+      <div style={{ color: accent, fontSize: 11, marginBottom: 2 }}>{task.status}</div>
+      <div style={{ color: "var(--text-muted)", fontSize: 11 }}>{elapsedLabel(task)}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChatBubble sub-component
+// ---------------------------------------------------------------------------
+
+interface ChatBubbleProps {
+  message: ChatMessage;
+}
+
+function ChatBubble({ message }: ChatBubbleProps) {
+  const isOperator = message.role === "operator";
+  return (
+    <div
+      className={`maxwell-chat-bubble ${message.role}${message.error ? " error" : ""}`}
+      style={{
+        alignSelf: isOperator ? "flex-end" : "flex-start",
+        background: isOperator
+          ? "var(--accent-blue)"
+          : message.error
+          ? "rgba(248,81,73,0.12)"
+          : "var(--bg-secondary)",
+        border: message.error ? "1px solid rgba(248,81,73,0.35)" : undefined,
+        borderRadius: isOperator ? "16px 16px 4px 16px" : "16px 16px 16px 4px",
+        color: isOperator ? "#fff" : message.error ? "var(--accent-red)" : "var(--text-primary)",
+        fontSize: 13,
+        maxWidth: "84%",
+        padding: "10px 14px",
+        wordBreak: "break-word",
+      }}
+    >
+      {message.content || (message.streaming ? "Receiving…" : "")}
+      {message.streaming && (
+        <span aria-hidden="true" style={{ color: isOperator ? "rgba(255,255,255,0.6)" : "var(--text-muted)" }}>
+          {" ▌"}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function MaxwellMobile() {
+  const haptic = useHaptic();
+
+  // -- Status state -----------------------------------------------------------
+  const [status, setStatus] = useState<MaxwellStatus>({});
+  const [statusLoading, setStatusLoading] = useState(true);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [daemonVersion, setDaemonVersion] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+
+  // -- Tasks state ------------------------------------------------------------
+  const [tasks, setTasks] = useState<MaxwellTask[]>([]);
+  const [tasksLoading, setTasksLoading] = useState(true);
+
+  // -- Chat state -------------------------------------------------------------
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>(loadChatHistory);
+  const [chatInput, setChatInput] = useState("");
+  const [chatSending, setChatSending] = useState(false);
+  const [showScrollBtn, setShowScrollBtn] = useState(false);
+  const chatListRef = useRef<HTMLDivElement>(null);
+
+  // -- Control sheet state ----------------------------------------------------
+  const [controlSheetOpen, setControlSheetOpen] = useState(false);
+  const [controlling, setControlling] = useState(false);
+  const [controlResult, setControlResult] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Data fetching
+  // ---------------------------------------------------------------------------
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const resp = await fetch("/api/maxwell/status");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data: MaxwellStatus = await resp.json();
+      setStatus(data);
+      setStatusError(null);
+    } catch (e: unknown) {
+      setStatusError(e instanceof Error ? e.message : "Failed to load Maxwell status");
+    } finally {
+      setStatusLoading(false);
+    }
+  }, []);
+
+  const fetchVersion = useCallback(async () => {
+    try {
+      const resp = await fetch("/api/maxwell/version");
+      if (!resp.ok) return;
+      const data = await resp.json();
+      setDaemonVersion(data.contract ?? data.daemon ?? "");
+    } catch {
+      setDaemonVersion("");
+    }
+  }, []);
+
+  const fetchTasks = useCallback(async () => {
+    setTasksLoading(true);
+    try {
+      const resp = await fetch("/api/maxwell/tasks?limit=10");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = await resp.json();
+      setTasks(data.tasks ?? []);
+    } catch {
+      setTasks([]);
+    } finally {
+      setTasksLoading(false);
+    }
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    fetchStatus();
+    fetchVersion();
+    fetchTasks();
+  }, [fetchStatus, fetchVersion, fetchTasks]);
+
+  // Persist chat history
+  useEffect(() => {
+    saveChatHistory(chatMessages);
+  }, [chatMessages]);
+
+  // Auto-scroll chat when new messages arrive (unless user scrolled up)
+  useEffect(() => {
+    if (showScrollBtn) return;
+    const el = chatListRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [chatMessages, showScrollBtn]);
+
+  // ---------------------------------------------------------------------------
+  // Pull-to-refresh
+  // ---------------------------------------------------------------------------
+
+  const handleRefresh = useCallback(async () => {
+    haptic.medium();
+    setRefreshing(true);
+    await Promise.all([fetchStatus(), fetchTasks(), fetchVersion()]);
+    setRefreshing(false);
+    haptic.success();
+  }, [fetchStatus, fetchTasks, fetchVersion, haptic]);
+
+  // ---------------------------------------------------------------------------
+  // Chat
+  // ---------------------------------------------------------------------------
+
+  function isNearBottom(): boolean {
+    const el = chatListRef.current;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 56;
+  }
+
+  function onChatScroll() {
+    setShowScrollBtn(!isNearBottom());
+  }
+
+  function updateMessage(id: number, patch: Partial<ChatMessage>) {
+    setChatMessages((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, ...patch } : m)),
+    );
+  }
+
+  const sendChat = useCallback(
+    async (text?: string) => {
+      const msg = (text ?? chatInput).trim();
+      if (!msg || chatSending) return;
+      setChatInput("");
+      setShowScrollBtn(false);
+
+      const now = Date.now();
+      const userMsg: ChatMessage = { id: now, role: "operator", content: msg };
+      const assistantId = now + 1;
+      setChatMessages((prev) => [
+        ...prev,
+        userMsg,
+        { id: assistantId, role: "maxwell", content: "", streaming: true },
+      ]);
+      setChatSending(true);
+
+      try {
+        const resp = await fetch("/api/maxwell/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
+          body: JSON.stringify({ message: msg, history: chatMessages.slice(-12) }),
+        });
+
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+
+        // Handle SSE / streaming response
+        if (resp.body && typeof window !== "undefined" && window.TextDecoder) {
+          const reader = resp.body.getReader();
+          const decoder = new TextDecoder();
+          let acc = "";
+          const pump = async (): Promise<string> => {
+            const { done, value } = await reader.read();
+            if (done) return acc;
+            acc += decoder.decode(value, { stream: true });
+            updateMessage(assistantId, { content: acc || "Receiving…", streaming: true });
+            return pump();
+          };
+          const finalText = await pump();
+          updateMessage(assistantId, {
+            content: finalText || "Maxwell returned an empty response.",
+            streaming: false,
+          });
+        } else {
+          // Fallback: plain JSON
+          const data = await resp.json();
+          updateMessage(assistantId, {
+            content: data.response ?? data.message ?? "Maxwell returned an empty response.",
+            streaming: false,
+          });
+        }
+      } catch (e: unknown) {
+        updateMessage(assistantId, {
+          content: "Maxwell-Daemon is unreachable. Check daemon status above, then retry.",
+          streaming: false,
+          error: true,
+        });
+      } finally {
+        setChatSending(false);
+      }
+    },
+    [chatInput, chatSending, chatMessages],
+  );
+
+  function onChatKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChat();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Daemon control
+  // ---------------------------------------------------------------------------
+
+  const handleControl = useCallback(
+    async (action: ControlAction) => {
+      setControlling(true);
+      setControlResult(null);
+      try {
+        const resp = await fetch("/api/maxwell/control", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
+          body: JSON.stringify({ action }),
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          throw new Error(data.detail ?? `HTTP ${resp.status}`);
+        }
+        setControlResult({ ok: true, msg: `Requested ${action}.` });
+        setTimeout(() => {
+          fetchStatus();
+          fetchTasks();
+        }, 1000);
+      } catch (e: unknown) {
+        setControlResult({ ok: false, msg: e instanceof Error ? e.message : "Control failed" });
+      } finally {
+        setControlling(false);
+      }
+    },
+    [fetchStatus, fetchTasks],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Render helpers
+  // ---------------------------------------------------------------------------
+
+  const daemonStatus = (status.status ?? "unknown").toLowerCase();
+  const isRunning = daemonStatus === "running";
+
+  function renderStatusHeader() {
+    const pillStyle: React.CSSProperties = {
+      ...statusPillStyle(daemonStatus),
+      borderRadius: 20,
+      display: "inline-flex",
+      alignItems: "center",
+      gap: 5,
+      fontSize: 12,
+      fontWeight: 600,
+      padding: "4px 10px",
+    };
+
+    return (
+      <div
+        style={{
+          alignItems: "center",
+          display: "flex",
+          gap: 8,
+          justifyContent: "space-between",
+          marginBottom: 14,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <span aria-label={`Maxwell daemon status: ${daemonStatus}`} style={pillStyle}>
+            <span aria-hidden="true">{statusEmoji(daemonStatus)}</span>
+            {daemonStatus}
+          </span>
+          {daemonVersion && (
+            <span style={{ color: "var(--text-muted)", fontSize: 11 }}>v{daemonVersion}</span>
+          )}
+          {statusError && (
+            <span aria-live="assertive" role="alert" style={{ color: "var(--accent-red)", fontSize: 11 }}>
+              {statusError}
+            </span>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <TouchButton
+            aria-label="Refresh Maxwell status"
+            disabled={statusLoading || refreshing}
+            onClick={handleRefresh}
+            variant="default"
+            style={{ fontSize: 12, minHeight: 34, padding: "4px 10px" }}
+          >
+            {refreshing ? "Refreshing…" : "↻ Refresh"}
+          </TouchButton>
+          <TouchButton
+            aria-label="Open daemon controls"
+            data-testid="maxwell-settings-btn"
+            onClick={() => setControlSheetOpen(true)}
+            variant="default"
+            style={{ fontSize: 12, minHeight: 34, padding: "4px 10px" }}
+          >
+            ⚙ Controls
+          </TouchButton>
+        </div>
+      </div>
+    );
+  }
+
+  function renderTasks() {
+    if (tasksLoading) {
+      return (
+        <div style={{ display: "flex", gap: 8, overflowX: "auto", paddingBottom: 4 }}>
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              style={{
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                borderRadius: 10,
+                flexShrink: 0,
+                height: 72,
+                minWidth: 140,
+              }}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    if (tasks.length === 0) {
+      return (
+        <div
+          aria-label="No active tasks"
+          style={{ color: "var(--text-muted)", fontSize: 12, padding: "8px 0" }}
+        >
+          {isRunning ? "No active tasks." : "Daemon not running — no task history."}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        aria-label="Active tasks"
+        role="list"
+        style={{
+          display: "flex",
+          gap: 8,
+          overflowX: "auto",
+          paddingBottom: 6,
+          WebkitOverflowScrolling: "touch" as React.CSSProperties["WebkitOverflowScrolling"],
+        }}
+      >
+        {tasks.map((task) => (
+          <TaskCard key={task.task_id} task={task} />
+        ))}
+      </div>
+    );
+  }
+
+  function renderChat() {
+    return (
+      <div
+        className="maxwell-chat-section"
+        style={{ display: "flex", flexDirection: "column", flexGrow: 1, minHeight: 0 }}
+      >
+        <div
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: 12,
+            fontWeight: 600,
+            marginBottom: 8,
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+          }}
+        >
+          Chat
+        </div>
+
+        {/* Message history */}
+        <div
+          ref={chatListRef}
+          aria-label="Maxwell chat history"
+          aria-live="polite"
+          className="maxwell-chat-messages"
+          onScroll={onChatScroll}
+          style={{
+            border: "1px solid var(--border)",
+            borderRadius: 10,
+            display: "flex",
+            flexDirection: "column",
+            flexGrow: 1,
+            gap: 8,
+            minHeight: 180,
+            maxHeight: 280,
+            overflowY: "auto",
+            padding: "12px",
+            WebkitOverflowScrolling: "touch" as React.CSSProperties["WebkitOverflowScrolling"],
+          }}
+        >
+          {chatMessages.length === 0 ? (
+            <div
+              aria-label="No chat messages yet"
+              style={{ color: "var(--text-muted)", fontSize: 12, textAlign: "center", margin: "auto" }}
+            >
+              {status.http_reachable
+                ? "Ask Maxwell for fleet status, runner activity, or the next operator command."
+                : "Maxwell-Daemon is unreachable. Chat history is preserved; retry when daemon is reachable."}
+            </div>
+          ) : (
+            chatMessages.map((m) => <ChatBubble key={m.id} message={m} />)
+          )}
+        </div>
+
+        {/* Scroll-to-bottom button */}
+        {showScrollBtn && (
+          <TouchButton
+            aria-label="Scroll to latest chat message"
+            onClick={() => {
+              setShowScrollBtn(false);
+              if (chatListRef.current) {
+                chatListRef.current.scrollTop = chatListRef.current.scrollHeight;
+              }
+            }}
+            variant="default"
+            style={{ alignSelf: "center", fontSize: 11, marginTop: 4, minHeight: 30, padding: "2px 10px" }}
+          >
+            Latest ↓
+          </TouchButton>
+        )}
+
+        {/* Quick-action chips */}
+        <div
+          aria-label="Maxwell quick actions"
+          style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}
+        >
+          {QUICK_CHIPS.map((chip) => (
+            <TouchButton
+              key={chip}
+              aria-label={`Ask Maxwell: ${chip}`}
+              disabled={chatSending}
+              onClick={() => sendChat(chip)}
+              variant="default"
+              style={{ fontSize: 11, minHeight: 30, padding: "4px 10px" }}
+            >
+              {chip}
+            </TouchButton>
+          ))}
+          {!status.http_reachable && (
+            <TouchButton
+              aria-label="Retry Maxwell connection"
+              onClick={() => {
+                fetchStatus();
+                fetchTasks();
+                fetchVersion();
+              }}
+              variant="primary"
+              style={{ fontSize: 11, minHeight: 30, padding: "4px 10px" }}
+            >
+              Retry
+            </TouchButton>
+          )}
+        </div>
+
+        {/* Composer */}
+        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+          <textarea
+            aria-label="Message Maxwell"
+            disabled={chatSending || !status.http_reachable}
+            onChange={(e) => setChatInput(e.target.value)}
+            onKeyDown={onChatKeyDown}
+            placeholder={
+              status.http_reachable
+                ? "Message Maxwell…"
+                : "Daemon unreachable; retry before sending commands"
+            }
+            rows={1}
+            value={chatInput}
+            style={{
+              background: "var(--bg-tertiary)",
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              boxSizing: "border-box",
+              color: "var(--text-primary)",
+              flex: 1,
+              fontFamily: "inherit",
+              fontSize: 13,
+              minHeight: 40,
+              padding: "10px 12px",
+              resize: "none",
+            }}
+          />
+          <TouchButton
+            aria-label="Send message to Maxwell"
+            data-testid="maxwell-send-btn"
+            disabled={chatSending || !chatInput.trim() || !status.http_reachable}
+            onClick={() => sendChat()}
+            variant="primary"
+            style={{ flexShrink: 0, minHeight: 40, padding: "0 16px" }}
+          >
+            {chatSending ? "…" : "Send"}
+          </TouchButton>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Loading state
+  // ---------------------------------------------------------------------------
+
+  if (statusLoading) {
+    return (
+      <div
+        aria-busy="true"
+        aria-label="Loading Maxwell"
+        aria-live="polite"
+        className="maxwell-mobile-loading"
+        role="status"
+        style={{ display: "flex", flexDirection: "column", gap: 10, padding: "16px" }}
+      >
+        <SkeletonLine height={22} width="50%" />
+        <SkeletonLine height={18} width="30%" />
+        <SkeletonCard lines={2} />
+        <SkeletonCard lines={4} />
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Main render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <PullToRefresh disabled={refreshing} onRefresh={handleRefresh}>
+      <section
+        aria-label="Maxwell daemon"
+        className="maxwell-mobile"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+          padding: "12px 12px 80px",
+        }}
+      >
+        {/* Status header */}
+        {renderStatusHeader()}
+
+        {/* Daemon details */}
+        {(status.dashboard_url || (!status.binary_found && !status.service_running && !status.http_reachable)) && (
+          <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+            {status.dashboard_url ? (
+              <a
+                href={status.dashboard_url}
+                rel="noopener noreferrer"
+                style={{ color: "var(--accent-blue)" }}
+                target="_blank"
+              >
+                {status.dashboard_url} ↗
+              </a>
+            ) : (
+              "Maxwell-Daemon is not detected on this machine."
+            )}
+          </div>
+        )}
+
+        {/* Active tasks */}
+        <div>
+          <div
+            style={{
+              color: "var(--text-secondary)",
+              fontSize: 12,
+              fontWeight: 600,
+              marginBottom: 8,
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+            }}
+          >
+            Active Tasks
+          </div>
+          {renderTasks()}
+        </div>
+
+        {/* Chat */}
+        {renderChat()}
+
+        {/* Control result toast */}
+        {controlResult && (
+          <div
+            aria-live="polite"
+            role="status"
+            style={{
+              background: controlResult.ok ? "rgba(63,185,80,0.12)" : "rgba(248,81,73,0.12)",
+              border: `1px solid ${controlResult.ok ? "rgba(63,185,80,0.4)" : "rgba(248,81,73,0.35)"}`,
+              borderRadius: 8,
+              color: controlResult.ok ? "var(--accent-green)" : "var(--accent-red)",
+              fontSize: 12,
+              padding: "10px 12px",
+            }}
+          >
+            {controlResult.msg}
+          </div>
+        )}
+      </section>
+
+      {/* Control sheet */}
+      <BottomSheet
+        isOpen={controlSheetOpen}
+        onClose={() => {
+          if (!controlling) setControlSheetOpen(false);
+        }}
+        title="Daemon Controls"
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <TouchButton
+            aria-label="Start Maxwell daemon"
+            data-testid="maxwell-ctrl-start"
+            disabled={controlling || isRunning}
+            onClick={() => handleControl("start")}
+            variant="primary"
+            style={{ minHeight: 48, width: "100%" }}
+          >
+            {controlling ? "Working…" : "Start Maxwell"}
+          </TouchButton>
+          <TouchButton
+            aria-label="Stop Maxwell daemon"
+            data-testid="maxwell-ctrl-stop"
+            disabled={controlling || !isRunning}
+            onClick={() => handleControl("stop")}
+            variant="danger"
+            style={{ minHeight: 48, width: "100%" }}
+          >
+            {controlling ? "Working…" : "Stop Maxwell"}
+          </TouchButton>
+          <TouchButton
+            aria-label="Restart Maxwell daemon"
+            data-testid="maxwell-ctrl-restart"
+            disabled={controlling}
+            onClick={() => handleControl("restart")}
+            variant="default"
+            style={{ minHeight: 48, width: "100%" }}
+          >
+            {controlling ? "Working…" : "Restart Maxwell"}
+          </TouchButton>
+        </div>
+      </BottomSheet>
+    </PullToRefresh>
+  );
+}

--- a/frontend/src/pages/Maxwell/__tests__/Mobile.test.tsx
+++ b/frontend/src/pages/Maxwell/__tests__/Mobile.test.tsx
@@ -1,0 +1,443 @@
+// @vitest-environment jsdom
+/**
+ * Tests for Maxwell/Mobile.tsx — M11 of the mobile EPIC.
+ *
+ * Covers:
+ * 1. Renders the daemon status pill.
+ * 2. Shows active tasks from GET /api/maxwell/tasks.
+ * 3. Sends a chat message via POST /api/maxwell/chat.
+ * 4. Control sheet opens when the settings button is pressed.
+ */
+import "@testing-library/jest-dom/vitest";
+import React from "react";
+import { cleanup, render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MaxwellMobile } from "../Mobile";
+
+afterEach(cleanup);
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_STATUS = {
+  status: "running",
+  http_reachable: true,
+  binary_found: true,
+  service_running: true,
+  service_detail: "active (running)",
+  http_detail: "200 OK",
+  binary_path: "/usr/local/bin/maxwell",
+};
+
+const MOCK_TASKS = {
+  tasks: [
+    { task_id: "task-abc-001", status: "running", elapsed_seconds: 75 },
+    { task_id: "task-abc-002", status: "queued", elapsed_seconds: 12 },
+  ],
+};
+
+const MOCK_VERSION = { daemon: "1.4.2", contract: "1.4.2" };
+
+const MOCK_CHAT_RESPONSE = { response: "Fleet is healthy. 8 runners online." };
+
+// ---------------------------------------------------------------------------
+// Fetch mock helper
+// ---------------------------------------------------------------------------
+
+function setupFetch({
+  statusOk = true,
+  tasksOk = true,
+  versionOk = true,
+  chatOk = true,
+  controlOk = true,
+  statusData = MOCK_STATUS as object,
+  tasksData = MOCK_TASKS as object,
+}: {
+  statusOk?: boolean;
+  tasksOk?: boolean;
+  versionOk?: boolean;
+  chatOk?: boolean;
+  controlOk?: boolean;
+  statusData?: object;
+  tasksData?: object;
+} = {}) {
+  const fetchMock = vi.fn((url: string, options?: RequestInit) => {
+    if (url.includes("/api/maxwell/status")) {
+      return Promise.resolve({
+        ok: statusOk,
+        status: statusOk ? 200 : 500,
+        json: () => Promise.resolve(statusData),
+      } as Response);
+    }
+    if (url.includes("/api/maxwell/tasks")) {
+      return Promise.resolve({
+        ok: tasksOk,
+        status: tasksOk ? 200 : 500,
+        json: () => Promise.resolve(tasksData),
+      } as Response);
+    }
+    if (url.includes("/api/maxwell/version")) {
+      return Promise.resolve({
+        ok: versionOk,
+        status: versionOk ? 200 : 500,
+        json: () => Promise.resolve(MOCK_VERSION),
+      } as Response);
+    }
+    if (url.includes("/api/maxwell/chat") && options?.method === "POST") {
+      return Promise.resolve({
+        ok: chatOk,
+        status: chatOk ? 200 : 500,
+        // No streaming body in tests — fall through to JSON fallback
+        body: null,
+        json: () => Promise.resolve(chatOk ? MOCK_CHAT_RESPONSE : { detail: "Daemon error" }),
+      } as unknown as Response);
+    }
+    if (url.includes("/api/maxwell/control") && options?.method === "POST") {
+      return Promise.resolve({
+        ok: controlOk,
+        status: controlOk ? 200 : 500,
+        json: () => Promise.resolve(controlOk ? { status: "ok" } : { detail: "Control failed" }),
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({}),
+    } as Response);
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MaxwellMobile", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // jsdom does not implement window.matchMedia — provide a minimal stub.
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    // Stub sessionStorage
+    const store: Record<string, string> = {};
+    vi.stubGlobal("sessionStorage", {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+      clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Status pill
+  // -------------------------------------------------------------------------
+
+  it("renders the daemon status pill with correct label", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/maxwell daemon status: running/i)).toBeInTheDocument();
+    });
+
+    const pill = screen.getByLabelText(/maxwell daemon status: running/i);
+    expect(pill).toHaveTextContent("running");
+  });
+
+  it("shows a stopped pill when daemon is stopped", async () => {
+    setupFetch({ statusData: { status: "stopped", http_reachable: false } });
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/maxwell daemon status: stopped/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the daemon version next to the status pill", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/v1\.4\.2/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the refresh button", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /refresh maxwell status/i })).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Active tasks
+  // -------------------------------------------------------------------------
+
+  it("renders task cards with task_id, status, and elapsed", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Task task-abc-001/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/task-abc-001.*running/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/task-abc-002.*queued/i)).toBeInTheDocument();
+    // elapsed for 75s should render as "1m 15s"
+    expect(screen.getByText("1m 15s")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no tasks", async () => {
+    setupFetch({ tasksData: { tasks: [] } });
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no active tasks/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows task list container with role=list", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("list", { name: /active tasks/i })).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Chat interface
+  // -------------------------------------------------------------------------
+
+  it("renders the chat textarea and send button", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/message maxwell/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /send message to maxwell/i })).toBeInTheDocument();
+  });
+
+  it("send button is disabled when input is empty", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /send message to maxwell/i })).toBeDisabled();
+    });
+  });
+
+  it("sends a chat message and shows the response", async () => {
+    const fetchMock = setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/message maxwell/i)).toBeInTheDocument();
+    });
+
+    const textarea = screen.getByLabelText(/message maxwell/i);
+    fireEvent.change(textarea, { target: { value: "status" } });
+
+    const sendBtn = screen.getByRole("button", { name: /send message to maxwell/i });
+
+    await act(async () => {
+      fireEvent.click(sendBtn);
+    });
+
+    // User message should appear (there may be multiple "status" texts — chip and bubble)
+    await waitFor(() => {
+      const bubbles = screen.getAllByText("status");
+      expect(bubbles.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // POST should have been called
+    const chatCalls = (fetchMock.mock.calls as [string, RequestInit?][]).filter(
+      ([url, opts]) => url.includes("/api/maxwell/chat") && opts?.method === "POST",
+    );
+    expect(chatCalls).toHaveLength(1);
+
+    const body = JSON.parse(chatCalls[0][1]!.body as string);
+    expect(body.message).toBe("status");
+  });
+
+  it("shows chat response after sending", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/message maxwell/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/message maxwell/i), { target: { value: "status" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /send message to maxwell/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fleet is healthy/i)).toBeInTheDocument();
+    });
+  });
+
+  it("quick-action chips trigger chat when clicked", async () => {
+    const fetchMock = setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /ask maxwell: status/i })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /ask maxwell: status/i }));
+    });
+
+    await waitFor(() => {
+      const chatCalls = (fetchMock.mock.calls as [string, RequestInit?][]).filter(
+        ([url, opts]) => url.includes("/api/maxwell/chat") && opts?.method === "POST",
+      );
+      expect(chatCalls).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Control sheet
+  // -------------------------------------------------------------------------
+
+  it("control sheet opens when the settings button is pressed", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /open daemon controls/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /open daemon controls/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: /daemon controls/i })).toBeInTheDocument();
+    });
+  });
+
+  it("control sheet contains Start, Stop, and Restart buttons", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /open daemon controls/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /open daemon controls/i }));
+
+    await waitFor(() => {
+      // Use exact aria-labels to avoid matching "Restart Maxwell" for "start"
+      expect(screen.getByRole("button", { name: /^start maxwell daemon$/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^stop maxwell daemon$/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^restart maxwell daemon$/i })).toBeInTheDocument();
+    });
+  });
+
+  it("Start is disabled when daemon is already running", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /open daemon controls/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /open daemon controls/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^start maxwell daemon$/i })).toBeDisabled();
+    });
+  });
+
+  it("Stop is disabled when daemon is stopped", async () => {
+    setupFetch({ statusData: { status: "stopped", http_reachable: false } });
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /open daemon controls/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /open daemon controls/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^stop maxwell daemon$/i })).toBeDisabled();
+    });
+  });
+
+  it("clicking Restart posts to /api/maxwell/control", async () => {
+    const fetchMock = setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /open daemon controls/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /open daemon controls/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^restart maxwell daemon$/i })).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^restart maxwell daemon$/i }));
+    });
+
+    await waitFor(() => {
+      const controlCalls = (fetchMock.mock.calls as [string, RequestInit?][]).filter(
+        ([url, opts]) => url.includes("/api/maxwell/control") && opts?.method === "POST",
+      );
+      expect(controlCalls).toHaveLength(1);
+
+      const body = JSON.parse(controlCalls[0][1]!.body as string);
+      expect(body.action).toBe("restart");
+    });
+  });
+
+  it("control sheet closes on Escape key", async () => {
+    setupFetch();
+    render(<MaxwellMobile />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /open daemon controls/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /open daemon controls/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/Maxwell/index.ts
+++ b/frontend/src/pages/Maxwell/index.ts
@@ -1,0 +1,1 @@
+export { MaxwellMobile } from "./Mobile";

--- a/frontend/src/shell/MobileShell.tsx
+++ b/frontend/src/shell/MobileShell.tsx
@@ -93,7 +93,7 @@ function tabIndexForId(tabId: MainTabId): number {
   return mainTabs.findIndex((t) => t.id === tabId)
 }
 
-export function MobileShell({ children, currentTab, onTabChange }: MobileShellProps) {
+export function MobileShell({ children, currentTab, onTabChange, tabContent }: MobileShellProps) {
   const breakpoint = useBreakpoint()
   const isMobile = breakpoint !== 'lg' && breakpoint !== 'xl'
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -180,11 +180,22 @@ export function MobileShell({ children, currentTab, onTabChange }: MobileShellPr
     return <>{children}</>
   }
 
+  // Resolve native content for the active tab, if provided.
+  const nativeContent = tabContent?.[currentTab]
+
   return (
     <div className="mobile-shell">
-      {/* Main content area */}
+      {/* Main content area — native mobile component takes precedence when provided */}
       <div className="mobile-shell__content">
-        {children}
+        {nativeContent != null ? (
+          <>
+            {/* Keep legacy App mounted but hidden so it keeps its internal state */}
+            <div style={{ display: 'none' }} aria-hidden="true">{children}</div>
+            {nativeContent}
+          </>
+        ) : (
+          children
+        )}
       </div>
       <div className="visually-hidden" aria-live="polite" aria-atomic="true">
         {drawerAnnouncement}


### PR DESCRIPTION
Implements M11 of the runner-dashboard mobile EPIC (#186): compact native mobile view for the Maxwell daemon tab.

Features: status header (colored pill + version + refresh), horizontal-scroll active tasks, chat with SSE streaming + sessionStorage persistence, Start/Stop/Restart BottomSheet, PullToRefresh.

Files: Maxwell/Mobile.tsx, Maxwell/index.ts, Maxwell/__tests__/Mobile.test.tsx (18 tests pass), main.tsx (import + tabContent entry), shell/MobileShell.tsx (consume tabContent).

APIs: GET /api/maxwell/{status,version,tasks}, POST /api/maxwell/{chat,control}.

Implements M11 of EPIC #186.