### PR TITLE
fix(ci): update detect-secrets baseline line number drift

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -330,7 +330,7 @@
         "filename": "tests/api/test_linear_webhook.py",
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_verified": false,
-        "line_number": 115,
+        "line_number": 124,
         "type": "Secret Keyword"
       }
     ],


### PR DESCRIPTION
## Summary

The `detect-secrets (baseline diff)` CI check was failing because a secret-like keyword in `tests/api/test_linear_webhook.py` shifted line position (from 115 → 124) when code was added above it. The check compares the `line_number` field in the results block before/after scan.

- Update `"line_number": 115` → `"line_number": 124` for the `Secret Keyword` entry in `tests/api/test_linear_webhook.py`
- No secrets added or removed; purely a line number drift fix

## Test plan
- [ ] `detect-secrets (baseline diff)` check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)