### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#609)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,16 +44,35 @@ test = [
 package = false
 [tool.pytest.ini_options]
 pythonpath = ["backend"]
+# Fleet Testing Standards Phase 1 (§2) — see Repository_Management
+# docs/FLEET_TESTING_STANDARDS.md. Tier: Applications (fail_under=75).
 # -ra: show short summary for all non-passing outcomes
 # -q: quiet mode
 # --strict-markers: fail when an unregistered marker is used (issue #401)
 # --strict-config: fail on unknown config options
-addopts = "-ra -q --strict-markers --strict-config"
+# Default lane: fast, deterministic, offline. Slow / integration / network /
+# playwright / e2e / live_simulation tests are excluded by default and run
+# in dedicated lanes (nightly, release).
+addopts = "-ra -q --strict-markers --strict-config -m \"not slow and not integration and not network and not playwright and not e2e and not live_simulation and not requires_network\""
 markers = [
+    # ---- legacy / pre-existing markers ----
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests that touch real external systems (network, GitHub API, etc.); excluded from PR CI, run nightly",
     "network: marks tests that require live network access (subset of integration)",
     "playwright: marks browser-driven Playwright tests; excluded from default PR CI",
+    # ---- fleet standard tier markers (§2) ----
+    "unit: pure logic, fully mocked, < 100 ms wall-clock",
+    "e2e: full-stack smoke tests; nightly + release gate only",
+    "live_simulation: requires a real physics / math engine; deselect by default",
+    # ---- environment markers ----
+    "requires_network: needs real outbound network; deselect by default",
+    "requires_gpu: needs CUDA / Metal / ROCm",
+    "requires_gl: needs OpenGL or a display",
+    "headless_safe: verified under QT_QPA_PLATFORM=offscreen",
+    # ---- workflow markers ----
+    "serial: must run with -n 0 (xdist parallel breaks this test)",
+    "benchmark: deterministic perf smoke; not a primary correctness gate",
+    "smoke: release-blocking smoke; subset of e2e",
 ]
 # filterwarnings: start permissive — escalate warning categories to errors only
 # once the warning surface is audited. The current backend (FastAPI/Pydantic v2,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,23 @@
+# ---------------------------------------------------------------------------
+# Fleet Testing Standards §5 — env vars MUST be set before heavy imports.
+# See Repository_Management/docs/FLEET_TESTING_STANDARDS.md.
+# ---------------------------------------------------------------------------
+import os  # noqa: E402
+
+# C-extension thread safety. Many "xdist worker crashed" failures
+# come from MKL/OpenBLAS forking under xdist. Pin to single-threaded
+# for tests; production code can re-thread itself if it needs to.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+# matplotlib headless backend, set before any matplotlib import.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+# Qt headless backend, for repos that import PyQt/PySide indirectly.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 import sys  # noqa: E402
 from pathlib import Path  # noqa: E402
 
@@ -8,6 +28,40 @@ if backend_dir not in sys.path:
 REPO_ROOT = Path(__file__).parent.parent
 
 import pytest  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fleet Testing Standards §5 — block real outbound HTTP in the unit lane.
+# This dashboard backend uses httpx + requests heavily; unit tests must mock.
+# Tests that genuinely need network must be marked `requires_network` (or
+# `integration` / `network`, which are already excluded from the default lane).
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _no_real_network_in_unit_lane(request, monkeypatch):
+    """Block real outbound HTTP from unit tests by default."""
+    if "unit" not in request.keywords:
+        return
+    if any(
+        m in request.keywords
+        for m in ("requires_network", "network", "integration", "e2e")
+    ):
+        return
+
+    def _refuse(*_a, **_kw):
+        raise RuntimeError(
+            "Unit test made a real network call. Mock with `respx` or "
+            "`pytest-httpx`, or mark the test "
+            "`@pytest.mark.requires_network`."
+        )
+
+    for module in ("httpx", "requests", "urllib.request"):
+        try:
+            mod = __import__(module, fromlist=["*"])
+            for attr in ("get", "post", "put", "delete", "request"):
+                if hasattr(mod, attr):
+                    monkeypatch.setattr(mod, attr, _refuse, raising=False)
+        except ImportError:
+            pass
 
 
 def _make_principal(principal_id: str, role: str):


### PR DESCRIPTION
## Summary

Additive Phase 1 merge of Fleet Testing Standards into `pyproject.toml` and `tests/conftest.py`. No test logic changed.

- **pyproject.toml (§2)**: Applications-tier marker set, default-lane exclusion (excludes `slow`, `integration`, `network`, `playwright`, `e2e`, `live_simulation`, `requires_network`), and standard tier / environment / workflow markers. Existing `--strict-markers --strict-config` retained.
- **tests/conftest.py (§5)**: pin C-extension thread vars (`OMP`/`OPENBLAS`/`MKL`/`NUMEXPR_NUM_THREADS=1`), set headless backends (`MPLBACKEND=Agg`, `QT_QPA_PLATFORM=offscreen`) before heavy imports. Autouse network-blocker fixture for the unit lane covering `httpx`, `requests`, `urllib.request` (the dashboard backend uses HTTP heavily). Tests opt-in via existing `requires_network` / `network` / `integration` / `e2e` markers.

Closes none — tracking issue #609 stays open for Phase 3 follow-up.

Refs:
- Issue: #609
- EPIC: D-sorganization/Repository_Management#1140

## Test plan

- [ ] CI green (lint, mypy, pytest)
- [ ] `pytest --collect-only -q` succeeds with `--strict-markers` (verified locally; only Windows-specific file-permission errors remain, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)