### PR TITLE
test(coverage): raise fail_under 50 -> 55 (Phase 4 step 1, EPIC #1140)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ markers = [
     "heavy: resource-intensive tests",
 ]
 
+[tool.coverage.report]
+# Phase 4 step 1 (EPIC #1140): raise fail_under from baseline 50 -> 55.
+# Applications tier target: 75%.
+fail_under = 55
+
 [tool.ruff]
 target-version = "py311"
 line-length = 120


### PR DESCRIPTION
## Summary

Phase 4 step 1 for **Runner_Dashboard** under EPIC #1140 (Fleet Testing).

- Tier: **Applications** (target 75%).
- Adds `[tool.coverage.report] fail_under = 55` to `pyproject.toml`. `fail_under` was previously absent (treated as baseline 50); raised by +5 per step cadence.
- No source changes; coverage gate enforcement only.

## Refs

- EPIC #1140
- Applications tier target: **75%**

## Test plan

- [ ] CI `tests` job runs pytest with `--cov=backend` and passes the new `fail_under = 55` gate.
- [ ] Quality-gate and security-scan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)