### PR TITLE
test(coverage): raise fail_under 55 -> 60 (Phase 4 step 2, EPIC #1140)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,9 @@ markers = [
 ]
 
 [tool.coverage.report]
-# Phase 4 step 1 (EPIC #1140): raise fail_under from baseline 50 -> 55.
+# Phase 4 step 2 (EPIC #1140): raise fail_under 55 -> 60.
 # Applications tier target: 75%.
-fail_under = 55
+fail_under = 60
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary

Phase 4 step 2 for **Runner_Dashboard** under EPIC #1140 (Fleet Testing).

- Tier: **Applications** (target 75%).
- Raises `[tool.coverage.report] fail_under` from 55 to 60 in `pyproject.toml`.
- No source changes; coverage gate enforcement only.

## Refs

- EPIC #1140
- Step 1 PR: #614 (50 -> 55, merged)
- Applications tier target: **75%**

## Test plan

- [ ] CI `tests` job runs pytest with `--cov=backend` and passes the new `fail_under = 60` gate.
- [ ] Quality-gate and security-scan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)