### PR TITLE
fix(workflows): repair Jules-Control-Tower and harden lint to prevent recurrence

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -265,7 +265,6 @@ jobs:
   # --- WORKER DISPATCH ---
 
   call-repair:
-    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'auto-repair'
     uses: ./.github/workflows/Jules-Auto-Repair.yml
@@ -278,7 +277,6 @@ jobs:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
 
   call-ci-remediation:
-    timeout-minutes: 30
     needs: triage
     if: needs.triage.outputs.target == 'ci-remediation'
     uses: ./.github/workflows/Jules-PR-AutoFix.yml

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Ensure PyYAML available
+        run: |
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml
+
       - name: Identify modified workflow files
         id: changed
         run: |
@@ -42,13 +46,46 @@ jobs:
         run: |
           set -eo pipefail
           [ -z "$FILES" ] && exit 0
+          # Per-job timeout-minutes checker (skips reusable-caller jobs which forbid it)
+          # See: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+          # Caller jobs (those with `uses:`) only allow:
+          #   name, uses, with, secrets, needs, if, permissions, concurrency, strategy
+          cat > /tmp/check_timeouts.py <<'PYEOF'
+          import sys, yaml
+          path = sys.argv[1]
+          try:
+              with open(path, encoding="utf-8") as fh:
+                  data = yaml.safe_load(fh)
+          except Exception as exc:
+              print(f"yaml-parse-error: {exc}")
+              sys.exit(0)
+          if not isinstance(data, dict) or "jobs" not in data:
+              sys.exit(0)
+          missing, forbidden = [], []
+          for name, job in data["jobs"].items():
+              if not isinstance(job, dict):
+                  continue
+              has_uses = "uses" in job
+              has_tm = "timeout-minutes" in job
+              if has_uses and has_tm:
+                  forbidden.append(name)
+              elif not has_uses and not has_tm:
+                  missing.append(name)
+          parts = []
+          if missing:
+              parts.append("missing timeout-minutes on jobs: " + ",".join(missing))
+          if forbidden:
+              parts.append("timeout-minutes forbidden on reusable-caller jobs: " + ",".join(forbidden))
+          if parts:
+              print("; ".join(parts))
+          PYEOF
           FAIL=""
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             [ ! -f "$f" ] && continue  # deleted file — skip
-            # Check timeout-minutes (anywhere in file)
-            if ! grep -q '^\s*timeout-minutes:' "$f"; then
-              FAIL="${FAIL}\n  - $f: missing timeout-minutes"
+            TM_ERR=$(python3 /tmp/check_timeouts.py "$f")
+            if [ -n "$TM_ERR" ]; then
+              FAIL="${FAIL}\n  - $f: $TM_ERR"
             fi
             # Check concurrency block
             if ! grep -q '^concurrency:' "$f"; then
@@ -70,7 +107,7 @@ jobs:
           done <<< "$FILES"
           if [ -n "$FAIL" ]; then
             printf "::error::Workflow lint failed:%b\n" "$FAIL"
-            COMMENT=$(printf "## Workflow lint failed\n\nThe following modified workflow files are missing required protections:%b\n\n### Required keys\n- \`timeout-minutes:\` at job level (e.g. 30 for tests, 60 for builds)\n- \`concurrency:\` block at workflow level\n- \`cancel-in-progress: true\` inside concurrency\n\n### Why\nThese protections prevent the queue-saturation pattern that clogged the fleet on 2026-05-15/16. See CLAUDE.md for the canonical YAML pattern." "$FAIL")
+            COMMENT=$(printf "## Workflow lint failed\n\nThe following modified workflow files are missing required protections:%b\n\n### Required keys\n- \`timeout-minutes:\` on every job EXCEPT reusable-caller jobs (jobs with \`uses: ./.github/workflows/...\`); GitHub forbids \`timeout-minutes\` on caller jobs\n- \`concurrency:\` block at workflow level\n- \`cancel-in-progress: true\` inside concurrency\n\n### Why\nThese protections prevent the queue-saturation pattern that clogged the fleet on 2026-05-15/16. See CLAUDE.md for the canonical YAML pattern." "$FAIL")
             gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$COMMENT" >/dev/null
             exit 1
           fi


### PR DESCRIPTION
## Why
GitHub Actions forbids `timeout-minutes` on reusable-caller jobs (jobs with `uses: ./.github/workflows/...`). The [workflow syntax spec](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iduses) permits only these keys on caller jobs:

```
name, uses, with, secrets, needs, if, permissions, concurrency, strategy
```

Setting `timeout-minutes` on a caller job makes the workflow file schema-invalid. The run fails to start with "This run likely failed because of a workflow file issue" and produces **zero log output**.

The Tools protection campaign (PR #2917) and equivalent PRs in UD / GM added `timeout-minutes: 30` to every job in `Jules-Control-Tower.yml` — including the caller jobs. The orchestrator has been broken in every affected repo since.

## What this PR changes
1. **Removes `timeout-minutes:` from every caller job** in `Jules-Control-Tower.yml` (jobs that have a `uses:` key). Non-caller jobs (`pick-runner`, `triage`, etc.) keep their `timeout-minutes:` as before.
2. **Hardens `lint-workflow-files.yml`** so the next protection campaign cannot reintroduce the bug. The old check (`grep -q '^\s*timeout-minutes:'`) was file-level — any single `timeout-minutes:` anywhere in the file made it pass. The new check is per-job:
   - Every non-caller job MUST have `timeout-minutes`
   - Caller jobs MUST NOT have `timeout-minutes`

## Effect
Unblocks Jules-Control-Tower so the auto-repair / auto-rebase / sentinel / etc. workers can run again.

## Sibling coordination
This PR is based on the `fix/lint-workflow-files-allowlist` branch when present so the two lint changes (cancel-in-progress allowlist + this per-job check) ship together without conflict.