### PR TITLE
fix(ui): rename non-functional Assistant panel to Chat

### DIFF
--- a/frontend/src/legacy/App.tsx
+++ b/frontend/src/legacy/App.tsx
@@ -13305,11 +13305,11 @@ function AssistantSidebar(props) {
       )
     : null;
 
-  return h("div", { style: sidebarStyle, "aria-label": "Assistant sidebar" },
+  return h("div", { style: sidebarStyle, "aria-label": "Chat sidebar" },
     open ? h("div", { style: dragHandleStyle, onMouseDown: startDrag }) : null,
     open ? h(React.Fragment, null,
       h("div", { style: headerStyle },
-        h("span", { style: { fontWeight: 600, fontSize: 13 } }, "✨ Assistant"),
+        h("span", { style: { fontWeight: 600, fontSize: 13 } }, "💬 Chat"),
         h("div", { style: { display: "flex", gap: 6 } },
           h("label", {
             title: "Save chat history",
@@ -16187,8 +16187,8 @@ function App({ initialTab, onTabChange }: { initialTab?: string; onTabChange?: (
           className: "btn",
           style: { marginLeft: 4, background: asstOpen ? "var(--accent-blue)" : undefined, color: asstOpen ? "#fff" : undefined },
           onClick: toggleAsst,
-          title: "Toggle Assistant sidebar",
-        }, "☰ Asst"),
+          title: "Toggle Chat sidebar",
+        }, "💬 Chat"),
         h(QuickDispatchPopover, null),
         h(
           "button",


### PR DESCRIPTION
Closes #630.

## Summary

Renames the user-facing Assistant sidebar label to Chat to align with the panel's intended use, per issue #630.

## Changes

frontend/src/legacy/App.tsx (4 lines):
- Sidebar header: ✨ Assistant → 💬 Chat
- Sidebar aria-label: Assistant sidebar → Chat sidebar
- Toggle button label: ☰ Asst → 💬 Chat
- Toggle button title: Toggle Assistant sidebar → Toggle Chat sidebar

## Scope

This is a label-only rename. Internal identifiers are intentionally preserved to avoid breakage: localStorage keys (assistant:open, assistant:saveHistory, etc.), the backend route /api/assistant/chat, function names (AssistantSidebar), and the chat-message role 'assistant'.

The issue notes the assistant chat send-path is non-functional. Wiring that up is out of scope for this PR (the issue calls out the rename as a distinct concern). A follow-up should address the functional wiring.

## Test plan

- [x] No tests assert on the literal Assistant UI label (verified)
- [x] Backend assistant_* tests untouched
- [ ] CI Standard passes
- [ ] Manual: toggle button reads 💬 Chat, sidebar header reads 💬 Chat