### PR TITLE
refactor: split 5 oversize files to satisfy 500-line file-size cap (closes CI RED)

### DIFF
--- a/backend/routers/repos.py
+++ b/backend/routers/repos.py
@@ -8,8 +8,10 @@ Routes:
   GET /api/issues
   GET /api/tests/ci-results
   POST /api/tests/rerun
-  GET /api/stats
-  GET /api/usage
+
+Stats and usage routes (``/api/stats``, ``/api/usage``) live in
+:mod:`backend.routers.repos_stats` to keep this module under the 500-line cap.
+The companion router shares dependency state via :func:`set_dependencies`.
 """
 
 from __future__ import annotations
@@ -22,6 +24,8 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from identity import require_scope
 from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
+
+from .repos_stats import router as stats_router
 
 log = logging.getLogger("dashboard.repos")
 router = APIRouter(tags=["repos"])
@@ -405,101 +409,6 @@ async def rerun_ci_test(
         raise HTTPException(status_code=500, detail="Internal server error") from None
 
 
-@router.get("/api/stats")
-async def get_stats(request: Request) -> Any:
-    """Aggregate organization, runner, queue, and workflow statistics."""
-    if should_proxy_fleet_to_hub(request):
-        return await proxy_to_hub(request)
-
-    cached = _cache_get("stats", _STATS_TTL)
-    if cached is not None:
-        return cached
-
-    runners_data = _cache_get("runners", 25.0)
-    if runners_data is None:
-        runners_data = await _gh_api_admin(f"/orgs/{ORG}/actions/runners")
-        _cache_set("runners", runners_data)
-    runners = runners_data.get("runners", [])
-
-    repos = await _get_recent_org_repos(limit=30)
-
-    async def _fetch_repo_runs_local(repo_name: str, per_page: int = 10) -> list[dict]:
-        code, stdout, _ = await _run_cmd(
-            ["gh", "api", f"/repos/{ORG}/{repo_name}/actions/runs?per_page={per_page}"],
-            timeout=15,
-        )
-        if code != 0:
-            return []
-        try:
-            return json.loads(stdout).get("workflow_runs", [])
-        except (json.JSONDecodeError, ValueError):
-            return []
-
-    async def _github_search_total_local(query: str) -> int:
-        code, stdout, _ = await _run_cmd(
-            ["gh", "api", f"search/issues?q={query}&per_page=1"],
-            timeout=15,
-        )
-        if code != 0:
-            return 0
-        try:
-            return int(json.loads(stdout).get("total_count", 0))
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return 0
-
-    all_runs_nested = await asyncio.gather(*[_fetch_repo_runs_local(repo["name"], per_page=10) for repo in repos[:20]])
-    runs = [run for repo_runs in all_runs_nested for run in repo_runs]
-    runs.sort(key=lambda r: r.get("created_at", ""), reverse=True)
-    runs = runs[:100]
-
-    online = sum(1 for r in runners if r["status"] == "online")
-    busy = sum(1 for r in runners if r.get("busy"))
-    completed = [r for r in runs if r.get("conclusion")]
-    successes = sum(1 for r in completed if r["conclusion"] == "success")
-    failures = sum(1 for r in completed if r["conclusion"] == "failure")
-
-    org_open_issues, org_open_prs, queue_data, fleet_data = await asyncio.gather(
-        _github_search_total_local(f"org:{ORG}+is:open+is:issue"),
-        _github_search_total_local(f"org:{ORG}+is:open+is:pr"),
-        _queue_impl(),
-        _get_fleet_nodes_impl(),
-    )
-
-    result = {
-        "runners_total": len(runners),
-        "runners_online": online,
-        "runners_busy": busy,
-        "runners_idle": max(0, online - busy),
-        "runners_offline": max(0, len(runners) - online),
-        "runs_total": len(runs),
-        "runs_success": successes,
-        "runs_failure": failures,
-        "runs_completed": len(completed),
-        "success_rate": round(successes / len(completed) * 100) if completed else 0,
-        "in_progress": queue_data.get("in_progress_count", 0),
-        "queued": queue_data.get("queued_count", 0),
-        "queue_total": queue_data.get("total", 0),
-        "org_open_issues": org_open_issues,
-        "org_open_prs": org_open_prs,
-        "machines_total": fleet_data.get("count", 0),
-        "machines_online": fleet_data.get("online_count", 0),
-        "machines_offline": max(0, fleet_data.get("count", 0) - fleet_data.get("online_count", 0)),
-        "repos_sampled": len(repos[:20]),
-    }
-    _cache_set("stats", result)
-    return result
-
-
-@router.get("/api/usage")
-async def get_usage_monitoring(request: Request) -> dict:
-    """Return normalized subscription and local tool usage summaries."""
-    if should_proxy_fleet_to_hub(request):
-        return await proxy_to_hub(request)
-
-    cached = _cache_get("usage_monitoring", _USAGE_MONITORING_TTL)
-    if cached is not None:
-        return cached
-
-    summary = _usage_monitoring.normalize_usage_summary(_usage_monitoring.load_usage_sources_config())
-    _cache_set("usage_monitoring", summary)
-    return summary
+# /api/stats and /api/usage live in repos_stats.py — merge that router into
+# this module's APIRouter so callers continue to register a single router.
+router.include_router(stats_router)

--- a/backend/routers/repos_stats.py
+++ b/backend/routers/repos_stats.py
@@ -1,0 +1,147 @@
+"""Aggregate stats and usage monitoring routes.
+
+Extracted from ``backend/routers/repos.py`` to keep modules under the
+500-line soft cap. Routes:
+  GET /api/stats
+  GET /api/usage
+
+Depends on the dependency singletons injected by ``server.py`` via
+``repos.set_dependencies``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from fastapi import APIRouter, Request
+from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
+
+router = APIRouter(tags=["repos"])
+
+
+def _state() -> Any:
+    """Return the dependency state from :mod:`repos` lazily."""
+    # Imported lazily so that dependency injection in ``repos.set_dependencies``
+    # is honoured regardless of import order.
+    from . import repos as _repos
+
+    return _repos
+
+
+@router.get("/api/stats")
+async def get_stats(request: Request) -> Any:
+    """Aggregate organization, runner, queue, and workflow statistics."""
+    if should_proxy_fleet_to_hub(request):
+        return await proxy_to_hub(request)
+
+    repos_mod = _state()
+    cache_get = repos_mod._cache_get
+    cache_set = repos_mod._cache_set
+    gh_api_admin = repos_mod._gh_api_admin
+    run_cmd = repos_mod._run_cmd
+    get_recent_org_repos = repos_mod._get_recent_org_repos
+    get_fleet_nodes_impl = repos_mod._get_fleet_nodes_impl
+    queue_impl = repos_mod._queue_impl
+    org = repos_mod.ORG
+    stats_ttl = repos_mod._STATS_TTL
+
+    cached = cache_get("stats", stats_ttl)
+    if cached is not None:
+        return cached
+
+    runners_data = cache_get("runners", 25.0)
+    if runners_data is None:
+        runners_data = await gh_api_admin(f"/orgs/{org}/actions/runners")
+        cache_set("runners", runners_data)
+    runners = runners_data.get("runners", [])
+
+    repos = await get_recent_org_repos(limit=30)
+
+    async def _fetch_repo_runs_local(repo_name: str, per_page: int = 10) -> list[dict]:
+        code, stdout, _ = await run_cmd(
+            ["gh", "api", f"/repos/{org}/{repo_name}/actions/runs?per_page={per_page}"],
+            timeout=15,
+        )
+        if code != 0:
+            return []
+        try:
+            return json.loads(stdout).get("workflow_runs", [])
+        except (json.JSONDecodeError, ValueError):
+            return []
+
+    async def _github_search_total_local(query: str) -> int:
+        code, stdout, _ = await run_cmd(
+            ["gh", "api", f"search/issues?q={query}&per_page=1"],
+            timeout=15,
+        )
+        if code != 0:
+            return 0
+        try:
+            return int(json.loads(stdout).get("total_count", 0))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return 0
+
+    all_runs_nested = await asyncio.gather(*[_fetch_repo_runs_local(repo["name"], per_page=10) for repo in repos[:20]])
+    runs = [run for repo_runs in all_runs_nested for run in repo_runs]
+    runs.sort(key=lambda r: r.get("created_at", ""), reverse=True)
+    runs = runs[:100]
+
+    online = sum(1 for r in runners if r["status"] == "online")
+    busy = sum(1 for r in runners if r.get("busy"))
+    completed = [r for r in runs if r.get("conclusion")]
+    successes = sum(1 for r in completed if r["conclusion"] == "success")
+    failures = sum(1 for r in completed if r["conclusion"] == "failure")
+
+    org_open_issues, org_open_prs, queue_data, fleet_data = await asyncio.gather(
+        _github_search_total_local(f"org:{org}+is:open+is:issue"),
+        _github_search_total_local(f"org:{org}+is:open+is:pr"),
+        queue_impl(),
+        get_fleet_nodes_impl(),
+    )
+
+    result = {
+        "runners_total": len(runners),
+        "runners_online": online,
+        "runners_busy": busy,
+        "runners_idle": max(0, online - busy),
+        "runners_offline": max(0, len(runners) - online),
+        "runs_total": len(runs),
+        "runs_success": successes,
+        "runs_failure": failures,
+        "runs_completed": len(completed),
+        "success_rate": round(successes / len(completed) * 100) if completed else 0,
+        "in_progress": queue_data.get("in_progress_count", 0),
+        "queued": queue_data.get("queued_count", 0),
+        "queue_total": queue_data.get("total", 0),
+        "org_open_issues": org_open_issues,
+        "org_open_prs": org_open_prs,
+        "machines_total": fleet_data.get("count", 0),
+        "machines_online": fleet_data.get("online_count", 0),
+        "machines_offline": max(0, fleet_data.get("count", 0) - fleet_data.get("online_count", 0)),
+        "repos_sampled": len(repos[:20]),
+    }
+    cache_set("stats", result)
+    return result
+
+
+@router.get("/api/usage")
+async def get_usage_monitoring(request: Request) -> dict:
+    """Return normalized subscription and local tool usage summaries."""
+    if should_proxy_fleet_to_hub(request):
+        return await proxy_to_hub(request)
+
+    repos_mod = _state()
+    cache_get = repos_mod._cache_get
+    cache_set = repos_mod._cache_set
+    usage_monitoring = repos_mod._usage_monitoring
+    usage_ttl = repos_mod._USAGE_MONITORING_TTL
+
+    cached = cache_get("usage_monitoring", usage_ttl)
+    if cached is not None:
+        return cached
+
+    summary = usage_monitoring.normalize_usage_summary(usage_monitoring.load_usage_sources_config())
+    cache_set("usage_monitoring", summary)
+    return summary

--- a/frontend/src/pages/Credentials/CredentialActionSheet.tsx
+++ b/frontend/src/pages/Credentials/CredentialActionSheet.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useState } from "react";
+import { BottomSheet } from "../../primitives/BottomSheet";
+import type { CredentialProbe } from "./mobileTypes";
+import { PROVIDER_MAP } from "./mobileTypes";
+
+interface CredentialActionSheetProps {
+  probe: CredentialProbe | null;
+  onClose: () => void;
+  onKeySet: () => void;
+}
+
+export function CredentialActionSheet({
+  probe,
+  onClose,
+  onKeySet,
+}: CredentialActionSheetProps) {
+  const [mode, setMode] = useState<"actions" | "set-key">("actions");
+  const [keyValue, setKeyValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  // Reset local state on each open
+  useEffect(() => {
+    if (probe) {
+      setMode("actions");
+      setKeyValue("");
+      setSubmitting(false);
+      setSubmitError(null);
+      setSubmitSuccess(false);
+    }
+  }, [probe]);
+
+  const handleSetKey = useCallback(async () => {
+    if (!probe || !probe.key_provider || !keyValue.trim()) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const resp = await fetch("/api/credentials/set-key", {
+        body: JSON.stringify({
+          key: keyValue.trim(),
+          provider: PROVIDER_MAP[probe.key_provider] ?? probe.key_provider,
+          restart_maxwell: true,
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+      if (!resp.ok) {
+        const err = await resp.json();
+        throw new Error(err.detail || `HTTP ${resp.status}`);
+      }
+      setSubmitSuccess(true);
+      setKeyValue("");
+      onKeySet();
+    } catch (e) {
+      setSubmitError(
+        (e instanceof Error ? e.message : String(e)) || "Failed to set key",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [probe, keyValue, onKeySet]);
+
+  const handleClearKey = useCallback(async () => {
+    if (!probe || !probe.key_provider) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const resp = await fetch("/api/credentials/clear-key", {
+        body: JSON.stringify({
+          provider: PROVIDER_MAP[probe.key_provider] ?? probe.key_provider,
+          restart_maxwell: true,
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+      if (!resp.ok) {
+        const err = await resp.json();
+        throw new Error(err.detail || `HTTP ${resp.status}`);
+      }
+      setSubmitSuccess(true);
+      onKeySet();
+    } catch (e) {
+      setSubmitError(
+        (e instanceof Error ? e.message : String(e)) || "Failed to clear key",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [probe, onKeySet]);
+
+  if (!probe) return null;
+
+  return (
+    <BottomSheet isOpen={probe !== null} onClose={onClose} title={probe.label}>
+      {mode === "actions" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          <div>
+            <div
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "13px",
+                marginBottom: "4px",
+              }}
+            >
+              {probe.detail}
+            </div>
+            {probe.setup_hint && probe.status !== "ready" && (
+              <div
+                style={{
+                  background: "var(--bg-tertiary, rgba(255,255,255,0.05))",
+                  borderRadius: "8px",
+                  color: "var(--text-secondary)",
+                  fontSize: "12px",
+                  marginTop: "4px",
+                  padding: "8px 12px",
+                }}
+              >
+                <strong>Hint:</strong> {probe.setup_hint}
+              </div>
+            )}
+          </div>
+
+          {submitError && (
+            <div style={{ color: "var(--accent-red)", fontSize: "13px" }}>
+              {submitError}
+            </div>
+          )}
+          {submitSuccess && (
+            <div
+              style={{
+                color: "var(--accent-green, #22c55e)",
+                fontSize: "13px",
+              }}
+            >
+              Key updated successfully.
+            </div>
+          )}
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            {probe.key_provider && (
+              <>
+                <button
+                  className="touch-button touch-button-primary"
+                  disabled={submitting}
+                  onClick={() => setMode("set-key")}
+                  style={{
+                    borderRadius: "8px",
+                    fontSize: "14px",
+                    minHeight: "44px",
+                  }}
+                  type="button"
+                >
+                  Set API Key
+                </button>
+                {probe.authenticated && (
+                  <button
+                    className="touch-button touch-button-danger"
+                    disabled={submitting}
+                    onClick={handleClearKey}
+                    style={{
+                      borderRadius: "8px",
+                      fontSize: "14px",
+                      minHeight: "44px",
+                    }}
+                    type="button"
+                  >
+                    {submitting ? "Clearing…" : "Clear Key"}
+                  </button>
+                )}
+              </>
+            )}
+            {probe.docs_url && (
+              <a
+                className="touch-button touch-button-secondary"
+                href={probe.docs_url}
+                rel="noreferrer"
+                style={{
+                  borderRadius: "8px",
+                  display: "block",
+                  fontSize: "14px",
+                  minHeight: "44px",
+                  padding: "10px 16px",
+                  textAlign: "center",
+                  textDecoration: "none",
+                }}
+                target="_blank"
+              >
+                View Docs
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+
+      {mode === "set-key" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          <p
+            style={{
+              color: "var(--text-secondary)",
+              fontSize: "13px",
+              margin: 0,
+            }}
+          >
+            Enter the API key for <strong>{probe.label}</strong>. It will be
+            written to the server-side env files and never returned to the
+            browser.
+          </p>
+
+          <label style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+            <span
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "12px",
+                fontWeight: 600,
+              }}
+            >
+              API Key
+            </span>
+            <input
+              autoComplete="off"
+              onChange={(e) => setKeyValue(e.target.value)}
+              placeholder="Paste your API key here"
+              spellCheck={false}
+              style={{
+                background: "var(--bg-tertiary, rgba(255,255,255,0.05))",
+                border: "1px solid var(--border)",
+                borderRadius: "8px",
+                color: "var(--text-primary)",
+                fontSize: "13px",
+                minHeight: "44px",
+                padding: "10px 12px",
+                width: "100%",
+              }}
+              type="password"
+              value={keyValue}
+            />
+          </label>
+
+          {submitError && (
+            <div style={{ color: "var(--accent-red)", fontSize: "13px" }}>
+              {submitError}
+            </div>
+          )}
+          {submitSuccess && (
+            <div
+              style={{
+                color: "var(--accent-green, #22c55e)",
+                fontSize: "13px",
+              }}
+            >
+              Key set successfully.
+            </div>
+          )}
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            <button
+              className="touch-button touch-button-primary"
+              disabled={submitting || !keyValue.trim()}
+              onClick={handleSetKey}
+              style={{
+                borderRadius: "8px",
+                fontSize: "14px",
+                minHeight: "44px",
+              }}
+              type="button"
+            >
+              {submitting ? "Saving…" : "Save Key"}
+            </button>
+            <button
+              className="touch-button touch-button-secondary"
+              disabled={submitting}
+              onClick={() => setMode("actions")}
+              style={{
+                borderRadius: "8px",
+                fontSize: "14px",
+                minHeight: "44px",
+              }}
+              type="button"
+            >
+              Back
+            </button>
+          </div>
+        </div>
+      )}
+    </BottomSheet>
+  );
+}

--- a/frontend/src/pages/Credentials/CredentialCard.tsx
+++ b/frontend/src/pages/Credentials/CredentialCard.tsx
@@ -1,0 +1,97 @@
+import type { CredentialProbe } from "./mobileTypes";
+
+function StatusBadge({ status }: { status: string }) {
+  const color =
+    status === "ready"
+      ? "var(--accent-green, #22c55e)"
+      : status === "missing_key" || status === "not_authed"
+        ? "var(--accent-yellow, #eab308)"
+        : "var(--accent-red, #ef4444)";
+
+  const label =
+    status === "ready"
+      ? "Ready"
+      : status === "missing_key"
+        ? "Missing Key"
+        : status === "not_authed"
+          ? "Not Authenticated"
+          : status === "not_installed"
+            ? "Not Installed"
+            : status;
+
+  return (
+    <span
+      style={{
+        background: color,
+        borderRadius: "4px",
+        color: "#fff",
+        flexShrink: 0,
+        fontSize: "10px",
+        fontWeight: 700,
+        padding: "2px 6px",
+        textTransform: "uppercase",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface CredentialCardProps {
+  probe: CredentialProbe;
+  onClick: (probe: CredentialProbe) => void;
+}
+
+export function CredentialCard({ probe, onClick }: CredentialCardProps) {
+  return (
+    <button
+      aria-label={`Credential: ${probe.label}`}
+      className="credential-card glass-card"
+      onClick={() => onClick(probe)}
+      style={{
+        alignItems: "flex-start",
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border)",
+        borderRadius: "12px",
+        cursor: "pointer",
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+        marginBottom: "10px",
+        padding: "14px 16px",
+        textAlign: "left",
+        width: "100%",
+      }}
+      type="button"
+    >
+      <div
+        style={{
+          alignItems: "center",
+          display: "flex",
+          gap: "8px",
+          justifyContent: "space-between",
+          width: "100%",
+        }}
+      >
+        <span
+          style={{
+            color: "var(--text-primary)",
+            fontSize: "14px",
+            fontWeight: 600,
+          }}
+        >
+          {probe.label}
+        </span>
+        <StatusBadge status={probe.status} />
+      </div>
+      <div style={{ color: "var(--text-secondary)", fontSize: "12px" }}>
+        {probe.detail}
+      </div>
+      {probe.config_source && probe.config_source !== "unavailable" && (
+        <div style={{ color: "var(--text-muted, #6b7280)", fontSize: "11px" }}>
+          Source: {probe.config_source}
+        </div>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/pages/Credentials/LockScreen.tsx
+++ b/frontend/src/pages/Credentials/LockScreen.tsx
@@ -1,0 +1,92 @@
+import type { LockState } from "./mobileTypes";
+
+interface LockScreenProps {
+  lockState: LockState;
+  lockError: string | null;
+  onUnlock: () => void;
+}
+
+export function LockScreen({ lockState, lockError, onUnlock }: LockScreenProps) {
+  return (
+    <div
+      aria-label="Credentials locked"
+      role="region"
+      style={{
+        alignItems: "center",
+        display: "flex",
+        flexDirection: "column",
+        gap: "16px",
+        justifyContent: "center",
+        minHeight: "60vh",
+        padding: "32px 24px",
+        textAlign: "center",
+      }}
+    >
+      <div style={{ fontSize: "56px" }}>🔒</div>
+      <div>
+        <h2
+          style={{
+            color: "var(--text-primary)",
+            fontSize: "18px",
+            fontWeight: 700,
+            margin: 0,
+          }}
+        >
+          Credentials Locked
+        </h2>
+        <p
+          style={{
+            color: "var(--text-secondary)",
+            fontSize: "13px",
+            margin: "8px 0 0",
+          }}
+        >
+          Biometric or device authentication required to view credential status.
+        </p>
+      </div>
+
+      {lockError && (
+        <div
+          aria-live="assertive"
+          role="alert"
+          style={{
+            background: "rgba(239,68,68,0.1)",
+            borderRadius: "8px",
+            color: "var(--accent-red, #ef4444)",
+            fontSize: "13px",
+            padding: "10px 14px",
+            width: "100%",
+          }}
+        >
+          {lockError}
+        </div>
+      )}
+
+      <button
+        className="touch-button touch-button-primary"
+        disabled={lockState === "unlocking"}
+        onClick={onUnlock}
+        style={{
+          borderRadius: "12px",
+          fontSize: "15px",
+          fontWeight: 600,
+          minHeight: "52px",
+          padding: "14px 28px",
+        }}
+        type="button"
+      >
+        {lockState === "unlocking" ? "Authenticating…" : "Unlock with Biometrics"}
+      </button>
+
+      <p
+        style={{
+          color: "var(--text-muted, #6b7280)",
+          fontSize: "11px",
+          margin: 0,
+        }}
+      >
+        Auto-locks after 60 seconds of inactivity.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Credentials/Mobile.tsx
+++ b/frontend/src/pages/Credentials/Mobile.tsx
@@ -7,476 +7,25 @@
  * - Each credential card: tap → BottomSheet with actions (Set Key, Clear Key, View Docs)
  * - Re-locks after 60 seconds of inactivity or when tab loses focus
  * - Add key via BottomSheet form
+ *
+ * Sub-components live in sibling files (CredentialCard, CredentialActionSheet,
+ * LockScreen) to keep this module under the 500-line file-size cap.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy API response shapes lack complete TypeScript definitions */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SkeletonCard, SkeletonLine } from "../../primitives/Skeleton";
 import { PullToRefresh } from "../../primitives/PullToRefresh";
-import { BottomSheet } from "../../primitives/BottomSheet";
 import { useHaptic } from "../../hooks/useHaptic";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface CredentialProbe {
-  id: string;
-  label: string;
-  icon: string;
-  installed: boolean;
-  authenticated: boolean;
-  reachable: boolean;
-  usable: boolean;
-  status: string;
-  detail: string;
-  config_source: string;
-  docs_url?: string;
-  setup_hint?: string;
-  key_provider?: string;
-}
-
-interface CredentialSummary {
-  total: number;
-  ready: number;
-  not_ready: number;
-}
-
-type LockState = "locked" | "unlocking" | "unlocked" | "error";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const INACTIVITY_TIMEOUT_MS = 60_000;
-
-const PROVIDER_MAP: Record<string, string> = {
-  claude: "claude",
-  claude_code_cli: "claude",
-  anthropic: "claude",
-  codex: "codex",
-  codex_cli: "codex",
-  openai: "codex",
-  gemini: "gemini",
-  gemini_cli: "gemini",
-  jules: "jules",
-  jules_api: "jules",
-  linear: "linear",
-};
-
-// ---------------------------------------------------------------------------
-// Status badge
-// ---------------------------------------------------------------------------
-
-function StatusBadge({ status }: { status: string }) {
-  const color =
-    status === "ready"
-      ? "var(--accent-green, #22c55e)"
-      : status === "missing_key" || status === "not_authed"
-        ? "var(--accent-yellow, #eab308)"
-        : "var(--accent-red, #ef4444)";
-
-  const label =
-    status === "ready"
-      ? "Ready"
-      : status === "missing_key"
-        ? "Missing Key"
-        : status === "not_authed"
-          ? "Not Authenticated"
-          : status === "not_installed"
-            ? "Not Installed"
-            : status;
-
-  return (
-    <span
-      style={{
-        background: color,
-        borderRadius: "4px",
-        color: "#fff",
-        flexShrink: 0,
-        fontSize: "10px",
-        fontWeight: 700,
-        padding: "2px 6px",
-        textTransform: "uppercase",
-      }}
-    >
-      {label}
-    </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Credential card
-// ---------------------------------------------------------------------------
-
-interface CredentialCardProps {
-  probe: CredentialProbe;
-  onClick: (probe: CredentialProbe) => void;
-}
-
-function CredentialCard({ probe, onClick }: CredentialCardProps) {
-  return (
-    <button
-      aria-label={`Credential: ${probe.label}`}
-      className="credential-card glass-card"
-      onClick={() => onClick(probe)}
-      style={{
-        alignItems: "flex-start",
-        background: "var(--bg-secondary)",
-        border: "1px solid var(--border)",
-        borderRadius: "12px",
-        cursor: "pointer",
-        display: "flex",
-        flexDirection: "column",
-        gap: "4px",
-        marginBottom: "10px",
-        padding: "14px 16px",
-        textAlign: "left",
-        width: "100%",
-      }}
-      type="button"
-    >
-      <div
-        style={{
-          alignItems: "center",
-          display: "flex",
-          gap: "8px",
-          justifyContent: "space-between",
-          width: "100%",
-        }}
-      >
-        <span
-          style={{
-            color: "var(--text-primary)",
-            fontSize: "14px",
-            fontWeight: 600,
-          }}
-        >
-          {probe.label}
-        </span>
-        <StatusBadge status={probe.status} />
-      </div>
-      <div style={{ color: "var(--text-secondary)", fontSize: "12px" }}>
-        {probe.detail}
-      </div>
-      {probe.config_source && probe.config_source !== "unavailable" && (
-        <div style={{ color: "var(--text-muted, #6b7280)", fontSize: "11px" }}>
-          Source: {probe.config_source}
-        </div>
-      )}
-    </button>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Detail / action sheet
-// ---------------------------------------------------------------------------
-
-interface CredentialActionSheetProps {
-  probe: CredentialProbe | null;
-  onClose: () => void;
-  onKeySet: () => void;
-}
-
-function CredentialActionSheet({ probe, onClose, onKeySet }: CredentialActionSheetProps) {
-  const [mode, setMode] = useState<"actions" | "set-key">("actions");
-  const [keyValue, setKeyValue] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [submitSuccess, setSubmitSuccess] = useState(false);
-
-  // Reset local state on each open
-  useEffect(() => {
-    if (probe) {
-      setMode("actions");
-      setKeyValue("");
-      setSubmitting(false);
-      setSubmitError(null);
-      setSubmitSuccess(false);
-    }
-  }, [probe]);
-
-  const handleSetKey = useCallback(async () => {
-    if (!probe || !probe.key_provider || !keyValue.trim()) return;
-    setSubmitting(true);
-    setSubmitError(null);
-    try {
-      const resp = await fetch("/api/credentials/set-key", {
-        body: JSON.stringify({
-          key: keyValue.trim(),
-          provider: PROVIDER_MAP[probe.key_provider] ?? probe.key_provider,
-          restart_maxwell: true,
-        }),
-        headers: { "Content-Type": "application/json" },
-        method: "POST",
-      });
-      if (!resp.ok) {
-        const err = await resp.json();
-        throw new Error(err.detail || `HTTP ${resp.status}`);
-      }
-      setSubmitSuccess(true);
-      setKeyValue("");
-      onKeySet();
-    } catch (e) {
-      setSubmitError((e instanceof Error ? e.message : String(e)) || "Failed to set key");
-    } finally {
-      setSubmitting(false);
-    }
-  }, [probe, keyValue, onKeySet]);
-
-  const handleClearKey = useCallback(async () => {
-    if (!probe || !probe.key_provider) return;
-    setSubmitting(true);
-    setSubmitError(null);
-    try {
-      const resp = await fetch("/api/credentials/clear-key", {
-        body: JSON.stringify({
-          provider: PROVIDER_MAP[probe.key_provider] ?? probe.key_provider,
-          restart_maxwell: true,
-        }),
-        headers: { "Content-Type": "application/json" },
-        method: "POST",
-      });
-      if (!resp.ok) {
-        const err = await resp.json();
-        throw new Error(err.detail || `HTTP ${resp.status}`);
-      }
-      setSubmitSuccess(true);
-      onKeySet();
-    } catch (e) {
-      setSubmitError((e instanceof Error ? e.message : String(e)) || "Failed to clear key");
-    } finally {
-      setSubmitting(false);
-    }
-  }, [probe, onKeySet]);
-
-  if (!probe) return null;
-
-  return (
-    <BottomSheet isOpen={probe !== null} onClose={onClose} title={probe.label}>
-      {mode === "actions" && (
-        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-          <div>
-            <div style={{ color: "var(--text-secondary)", fontSize: "13px", marginBottom: "4px" }}>
-              {probe.detail}
-            </div>
-            {probe.setup_hint && probe.status !== "ready" && (
-              <div
-                style={{
-                  background: "var(--bg-tertiary, rgba(255,255,255,0.05))",
-                  borderRadius: "8px",
-                  color: "var(--text-secondary)",
-                  fontSize: "12px",
-                  marginTop: "4px",
-                  padding: "8px 12px",
-                }}
-              >
-                <strong>Hint:</strong> {probe.setup_hint}
-              </div>
-            )}
-          </div>
-
-          {submitError && (
-            <div style={{ color: "var(--accent-red)", fontSize: "13px" }}>{submitError}</div>
-          )}
-          {submitSuccess && (
-            <div style={{ color: "var(--accent-green, #22c55e)", fontSize: "13px" }}>
-              Key updated successfully.
-            </div>
-          )}
-
-          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-            {probe.key_provider && (
-              <>
-                <button
-                  className="touch-button touch-button-primary"
-                  disabled={submitting}
-                  onClick={() => setMode("set-key")}
-                  style={{ borderRadius: "8px", fontSize: "14px", minHeight: "44px" }}
-                  type="button"
-                >
-                  Set API Key
-                </button>
-                {probe.authenticated && (
-                  <button
-                    className="touch-button touch-button-danger"
-                    disabled={submitting}
-                    onClick={handleClearKey}
-                    style={{ borderRadius: "8px", fontSize: "14px", minHeight: "44px" }}
-                    type="button"
-                  >
-                    {submitting ? "Clearing…" : "Clear Key"}
-                  </button>
-                )}
-              </>
-            )}
-            {probe.docs_url && (
-              <a
-                className="touch-button touch-button-secondary"
-                href={probe.docs_url}
-                rel="noreferrer"
-                style={{
-                  borderRadius: "8px",
-                  display: "block",
-                  fontSize: "14px",
-                  minHeight: "44px",
-                  padding: "10px 16px",
-                  textAlign: "center",
-                  textDecoration: "none",
-                }}
-                target="_blank"
-              >
-                View Docs
-              </a>
-            )}
-          </div>
-        </div>
-      )}
-
-      {mode === "set-key" && (
-        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-          <p style={{ color: "var(--text-secondary)", fontSize: "13px", margin: 0 }}>
-            Enter the API key for <strong>{probe.label}</strong>. It will be written to the
-            server-side env files and never returned to the browser.
-          </p>
-
-          <label style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
-            <span style={{ color: "var(--text-secondary)", fontSize: "12px", fontWeight: 600 }}>
-              API Key
-            </span>
-            <input
-              autoComplete="off"
-              onChange={(e) => setKeyValue(e.target.value)}
-              placeholder="Paste your API key here"
-              spellCheck={false}
-              style={{
-                background: "var(--bg-tertiary, rgba(255,255,255,0.05))",
-                border: "1px solid var(--border)",
-                borderRadius: "8px",
-                color: "var(--text-primary)",
-                fontSize: "13px",
-                minHeight: "44px",
-                padding: "10px 12px",
-                width: "100%",
-              }}
-              type="password"
-              value={keyValue}
-            />
-          </label>
-
-          {submitError && (
-            <div style={{ color: "var(--accent-red)", fontSize: "13px" }}>{submitError}</div>
-          )}
-          {submitSuccess && (
-            <div style={{ color: "var(--accent-green, #22c55e)", fontSize: "13px" }}>
-              Key set successfully.
-            </div>
-          )}
-
-          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-            <button
-              className="touch-button touch-button-primary"
-              disabled={submitting || !keyValue.trim()}
-              onClick={handleSetKey}
-              style={{ borderRadius: "8px", fontSize: "14px", minHeight: "44px" }}
-              type="button"
-            >
-              {submitting ? "Saving…" : "Save Key"}
-            </button>
-            <button
-              className="touch-button touch-button-secondary"
-              disabled={submitting}
-              onClick={() => setMode("actions")}
-              style={{ borderRadius: "8px", fontSize: "14px", minHeight: "44px" }}
-              type="button"
-            >
-              Back
-            </button>
-          </div>
-        </div>
-      )}
-    </BottomSheet>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Lock screen
-// ---------------------------------------------------------------------------
-
-interface LockScreenProps {
-  lockState: LockState;
-  lockError: string | null;
-  onUnlock: () => void;
-}
-
-function LockScreen({ lockState, lockError, onUnlock }: LockScreenProps) {
-  return (
-    <div
-      aria-label="Credentials locked"
-      role="region"
-      style={{
-        alignItems: "center",
-        display: "flex",
-        flexDirection: "column",
-        gap: "16px",
-        justifyContent: "center",
-        minHeight: "60vh",
-        padding: "32px 24px",
-        textAlign: "center",
-      }}
-    >
-      <div style={{ fontSize: "56px" }}>🔒</div>
-      <div>
-        <h2 style={{ color: "var(--text-primary)", fontSize: "18px", fontWeight: 700, margin: 0 }}>
-          Credentials Locked
-        </h2>
-        <p style={{ color: "var(--text-secondary)", fontSize: "13px", margin: "8px 0 0" }}>
-          Biometric or device authentication required to view credential status.
-        </p>
-      </div>
-
-      {lockError && (
-        <div
-          aria-live="assertive"
-          role="alert"
-          style={{
-            background: "rgba(239,68,68,0.1)",
-            borderRadius: "8px",
-            color: "var(--accent-red, #ef4444)",
-            fontSize: "13px",
-            padding: "10px 14px",
-            width: "100%",
-          }}
-        >
-          {lockError}
-        </div>
-      )}
-
-      <button
-        className="touch-button touch-button-primary"
-        disabled={lockState === "unlocking"}
-        onClick={onUnlock}
-        style={{
-          borderRadius: "12px",
-          fontSize: "15px",
-          fontWeight: 600,
-          minHeight: "52px",
-          padding: "14px 28px",
-        }}
-        type="button"
-      >
-        {lockState === "unlocking" ? "Authenticating…" : "Unlock with Biometrics"}
-      </button>
-
-      <p style={{ color: "var(--text-muted, #6b7280)", fontSize: "11px", margin: 0 }}>
-        Auto-locks after 60 seconds of inactivity.
-      </p>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
+import { CredentialActionSheet } from "./CredentialActionSheet";
+import { CredentialCard } from "./CredentialCard";
+import { LockScreen } from "./LockScreen";
+import type {
+  CredentialProbe,
+  CredentialSummary,
+  LockState,
+} from "./mobileTypes";
+import { INACTIVITY_TIMEOUT_MS, base64urlToBuffer } from "./mobileTypes";
 
 export function CredentialsMobile() {
   // Lock state
@@ -491,7 +40,9 @@ export function CredentialsMobile() {
   const [refreshing, setRefreshing] = useState(false);
 
   // Sheet state
-  const [selectedProbe, setSelectedProbe] = useState<CredentialProbe | null>(null);
+  const [selectedProbe, setSelectedProbe] = useState<CredentialProbe | null>(
+    null,
+  );
 
   const haptic = useHaptic();
 
@@ -570,8 +121,8 @@ export function CredentialsMobile() {
     const isWebAuthnAvailable =
       typeof window !== "undefined" &&
       "PublicKeyCredential" in window &&
-      typeof (window as any).PublicKeyCredential?.isUserVerifyingPlatformAuthenticatorAvailable ===
-        "function";
+      typeof (window as any).PublicKeyCredential
+        ?.isUserVerifyingPlatformAuthenticatorAvailable === "function";
 
     let unlocked = false;
 
@@ -596,10 +147,12 @@ export function CredentialsMobile() {
 
             const assertion = await (navigator as any).credentials.get({
               publicKey: {
-                allowCredentials: (options.allow_credentials || []).map((c: any) => ({
-                  id: base64urlToBuffer(c.id),
-                  type: c.type,
-                })),
+                allowCredentials: (options.allow_credentials || []).map(
+                  (c: any) => ({
+                    id: base64urlToBuffer(c.id),
+                    type: c.type,
+                  }),
+                ),
                 challenge,
                 timeout: options.timeout_ms ?? 60000,
                 userVerification: "required",
@@ -675,9 +228,17 @@ export function CredentialsMobile() {
   // Render: locked
   // ---------------------------------------------------------------------------
 
-  if (lockState === "locked" || lockState === "unlocking" || lockState === "error") {
+  if (
+    lockState === "locked" ||
+    lockState === "unlocking" ||
+    lockState === "error"
+  ) {
     return (
-      <LockScreen lockError={lockError} lockState={lockState} onUnlock={handleUnlock} />
+      <LockScreen
+        lockError={lockError}
+        lockState={lockState}
+        onUnlock={handleUnlock}
+      />
     );
   }
 
@@ -700,11 +261,24 @@ export function CredentialsMobile() {
         }}
       >
         <div>
-          <h1 style={{ color: "var(--text-primary)", fontSize: "18px", fontWeight: 700, margin: 0 }}>
+          <h1
+            style={{
+              color: "var(--text-primary)",
+              fontSize: "18px",
+              fontWeight: 700,
+              margin: 0,
+            }}
+          >
             Credentials
           </h1>
           {summary && (
-            <p style={{ color: "var(--text-secondary)", fontSize: "13px", margin: "4px 0 0" }}>
+            <p
+              style={{
+                color: "var(--text-secondary)",
+                fontSize: "13px",
+                margin: "4px 0 0",
+              }}
+            >
               {summary.ready} of {summary.total} ready
             </p>
           )}
@@ -729,7 +303,11 @@ export function CredentialsMobile() {
         <div
           aria-live="assertive"
           role="alert"
-          style={{ color: "var(--accent-red)", fontSize: "13px", padding: "8px 0" }}
+          style={{
+            color: "var(--accent-red)",
+            fontSize: "13px",
+            padding: "8px 0",
+          }}
         >
           {dataError}
         </div>
@@ -752,7 +330,11 @@ export function CredentialsMobile() {
           {refreshing && (
             <div
               aria-live="polite"
-              style={{ fontSize: "12px", padding: "8px 0", textAlign: "center" }}
+              style={{
+                fontSize: "12px",
+                padding: "8px 0",
+                textAlign: "center",
+              }}
             >
               Refreshing…
             </div>
@@ -770,15 +352,23 @@ export function CredentialsMobile() {
                     textAlign: "center",
                   }}
                 >
-                  <div style={{ fontSize: "36px", marginBottom: "12px" }}>🔑</div>
-                  <div style={{ fontSize: "15px", fontWeight: 600 }}>No credentials found</div>
+                  <div style={{ fontSize: "36px", marginBottom: "12px" }}>
+                    🔑
+                  </div>
+                  <div style={{ fontSize: "15px", fontWeight: 600 }}>
+                    No credentials found
+                  </div>
                   <div style={{ fontSize: "13px", marginTop: "6px" }}>
                     No provider credentials were detected.
                   </div>
                 </div>
               ) : (
                 probes.map((probe) => (
-                  <CredentialCard key={probe.id} onClick={handleCardClick} probe={probe} />
+                  <CredentialCard
+                    key={probe.id}
+                    onClick={handleCardClick}
+                    probe={probe}
+                  />
                 ))
               )}
             </div>
@@ -793,20 +383,4 @@ export function CredentialsMobile() {
       />
     </section>
   );
-}
-
-// ---------------------------------------------------------------------------
-// WebAuthn helpers
-// ---------------------------------------------------------------------------
-
-function base64urlToBuffer(base64url: string): ArrayBuffer {
-  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
-  const binary = atob(base64 + padding);
-  const buffer = new ArrayBuffer(binary.length);
-  const view = new Uint8Array(buffer);
-  for (let i = 0; i < binary.length; i++) {
-    view[i] = binary.charCodeAt(i);
-  }
-  return buffer;
 }

--- a/frontend/src/pages/Credentials/mobileTypes.ts
+++ b/frontend/src/pages/Credentials/mobileTypes.ts
@@ -1,0 +1,54 @@
+// Shared types, constants, and small utilities for the Credentials mobile view.
+// Extracted from Mobile.tsx to keep that file under the 500-line cap.
+
+export interface CredentialProbe {
+  id: string;
+  label: string;
+  icon: string;
+  installed: boolean;
+  authenticated: boolean;
+  reachable: boolean;
+  usable: boolean;
+  status: string;
+  detail: string;
+  config_source: string;
+  docs_url?: string;
+  setup_hint?: string;
+  key_provider?: string;
+}
+
+export interface CredentialSummary {
+  total: number;
+  ready: number;
+  not_ready: number;
+}
+
+export type LockState = "locked" | "unlocking" | "unlocked" | "error";
+
+export const INACTIVITY_TIMEOUT_MS = 60_000;
+
+export const PROVIDER_MAP: Record<string, string> = {
+  claude: "claude",
+  claude_code_cli: "claude",
+  anthropic: "claude",
+  codex: "codex",
+  codex_cli: "codex",
+  openai: "codex",
+  gemini: "gemini",
+  gemini_cli: "gemini",
+  jules: "jules",
+  jules_api: "jules",
+  linear: "linear",
+};
+
+export function base64urlToBuffer(base64url: string): ArrayBuffer {
+  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(base64 + padding);
+  const buffer = new ArrayBuffer(binary.length);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < binary.length; i++) {
+    view[i] = binary.charCodeAt(i);
+  }
+  return buffer;
+}

--- a/frontend/src/pages/Maxwell/ChatBubble.tsx
+++ b/frontend/src/pages/Maxwell/ChatBubble.tsx
@@ -1,0 +1,45 @@
+import type { ChatMessage } from "./mobileTypes";
+
+interface ChatBubbleProps {
+  message: ChatMessage;
+}
+
+export function ChatBubble({ message }: ChatBubbleProps) {
+  const isOperator = message.role === "operator";
+  return (
+    <div
+      className={`maxwell-chat-bubble ${message.role}${message.error ? " error" : ""}`}
+      style={{
+        alignSelf: isOperator ? "flex-end" : "flex-start",
+        background: isOperator
+          ? "var(--accent-blue)"
+          : message.error
+            ? "rgba(248,81,73,0.12)"
+            : "var(--bg-secondary)",
+        border: message.error ? "1px solid rgba(248,81,73,0.35)" : undefined,
+        borderRadius: isOperator ? "16px 16px 4px 16px" : "16px 16px 16px 4px",
+        color: isOperator
+          ? "#fff"
+          : message.error
+            ? "var(--accent-red)"
+            : "var(--text-primary)",
+        fontSize: 13,
+        maxWidth: "84%",
+        padding: "10px 14px",
+        wordBreak: "break-word",
+      }}
+    >
+      {message.content || (message.streaming ? "Receiving…" : "")}
+      {message.streaming && (
+        <span
+          aria-hidden="true"
+          style={{
+            color: isOperator ? "rgba(255,255,255,0.6)" : "var(--text-muted)",
+          }}
+        >
+          {" ▌"}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Maxwell/MaxwellChat.tsx
+++ b/frontend/src/pages/Maxwell/MaxwellChat.tsx
@@ -1,0 +1,262 @@
+import React, { useEffect, useRef, useState } from "react";
+import { TouchButton } from "../../primitives/TouchButton";
+import { useVoiceInput } from "../../hooks/useVoiceInput";
+import { ChatBubble } from "./ChatBubble";
+import type { ChatMessage, MaxwellStatus } from "./mobileTypes";
+import { QUICK_CHIPS } from "./mobileTypes";
+
+interface MaxwellChatProps {
+  status: MaxwellStatus;
+  chatMessages: ChatMessage[];
+  chatInput: string;
+  setChatInput: (v: string) => void;
+  chatSending: boolean;
+  sendChat: (text?: string) => void;
+  onRetry: () => void;
+}
+
+export function MaxwellChat({
+  status,
+  chatMessages,
+  chatInput,
+  setChatInput,
+  chatSending,
+  sendChat,
+  onRetry,
+}: MaxwellChatProps) {
+  const chatListRef = useRef<HTMLDivElement>(null);
+  const [showScrollBtn, setShowScrollBtn] = useState(false);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+
+  const voice = useVoiceInput({
+    onTranscript: (text) => {
+      setChatInput(chatInput ? `${chatInput} ${text}` : text);
+      setVoiceError(null);
+    },
+    onError: (msg) => setVoiceError(msg),
+  });
+
+  // Auto-scroll chat when new messages arrive (unless user scrolled up)
+  useEffect(() => {
+    if (showScrollBtn) return;
+    const el = chatListRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [chatMessages, showScrollBtn]);
+
+  function isNearBottom(): boolean {
+    const el = chatListRef.current;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 56;
+  }
+
+  function onChatScroll() {
+    setShowScrollBtn(!isNearBottom());
+  }
+
+  function onChatKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChat();
+    }
+  }
+
+  return (
+    <div
+      className="maxwell-chat-section"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flexGrow: 1,
+        minHeight: 0,
+      }}
+    >
+      <div
+        style={{
+          color: "var(--text-secondary)",
+          fontSize: 12,
+          fontWeight: 600,
+          marginBottom: 8,
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+        }}
+      >
+        Chat
+      </div>
+
+      {/* Message history */}
+      <div
+        ref={chatListRef}
+        aria-label="Maxwell chat history"
+        aria-live="polite"
+        className="maxwell-chat-messages"
+        onScroll={onChatScroll}
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: 10,
+          display: "flex",
+          flexDirection: "column",
+          flexGrow: 1,
+          gap: 8,
+          minHeight: 180,
+          maxHeight: 280,
+          overflowY: "auto",
+          padding: "12px",
+          WebkitOverflowScrolling:
+            "touch" as React.CSSProperties["WebkitOverflowScrolling"],
+        }}
+      >
+        {chatMessages.length === 0 ? (
+          <div
+            aria-label="No chat messages yet"
+            style={{
+              color: "var(--text-muted)",
+              fontSize: 12,
+              textAlign: "center",
+              margin: "auto",
+            }}
+          >
+            {status.http_reachable
+              ? "Ask Maxwell for fleet status, runner activity, or the next operator command."
+              : "Maxwell-Daemon is unreachable. Chat history is preserved; retry when daemon is reachable."}
+          </div>
+        ) : (
+          chatMessages.map((m) => <ChatBubble key={m.id} message={m} />)
+        )}
+      </div>
+
+      {/* Scroll-to-bottom button */}
+      {showScrollBtn && (
+        <TouchButton
+          aria-label="Scroll to latest chat message"
+          onClick={() => {
+            setShowScrollBtn(false);
+            if (chatListRef.current) {
+              chatListRef.current.scrollTop = chatListRef.current.scrollHeight;
+            }
+          }}
+          variant="default"
+          style={{
+            alignSelf: "center",
+            fontSize: 11,
+            marginTop: 4,
+            minHeight: 30,
+            padding: "2px 10px",
+          }}
+        >
+          Latest ↓
+        </TouchButton>
+      )}
+
+      {/* Quick-action chips */}
+      <div
+        aria-label="Maxwell quick actions"
+        style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}
+      >
+        {QUICK_CHIPS.map((chip) => (
+          <TouchButton
+            key={chip}
+            aria-label={`Ask Maxwell: ${chip}`}
+            disabled={chatSending}
+            onClick={() => sendChat(chip)}
+            variant="default"
+            style={{ fontSize: 11, minHeight: 30, padding: "4px 10px" }}
+          >
+            {chip}
+          </TouchButton>
+        ))}
+        {!status.http_reachable && (
+          <TouchButton
+            aria-label="Retry Maxwell connection"
+            onClick={onRetry}
+            variant="primary"
+            style={{ fontSize: 11, minHeight: 30, padding: "4px 10px" }}
+          >
+            Retry
+          </TouchButton>
+        )}
+      </div>
+
+      {/* Composer */}
+      {voiceError && (
+        <div
+          aria-live="polite"
+          role="alert"
+          style={{
+            background: "rgba(248,81,73,0.12)",
+            border: "1px solid rgba(248,81,73,0.35)",
+            borderRadius: 6,
+            color: "var(--accent-red)",
+            fontSize: 11,
+            marginTop: 6,
+            padding: "4px 8px",
+          }}
+        >
+          {voiceError}
+        </div>
+      )}
+      <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+        <textarea
+          aria-label="Message Maxwell"
+          disabled={chatSending || !status.http_reachable}
+          onChange={(e) => setChatInput(e.target.value)}
+          onKeyDown={onChatKeyDown}
+          placeholder={
+            status.http_reachable
+              ? "Message Maxwell…"
+              : "Daemon unreachable; retry before sending commands"
+          }
+          rows={1}
+          value={chatInput}
+          style={{
+            background: "var(--bg-tertiary)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            boxSizing: "border-box",
+            color: "var(--text-primary)",
+            flex: 1,
+            fontFamily: "inherit",
+            fontSize: 13,
+            minHeight: 40,
+            padding: "10px 12px",
+            resize: "none",
+          }}
+        />
+        {voice.available && (
+          <TouchButton
+            aria-label={
+              voice.recording ? "Stop voice recording" : "Start voice input"
+            }
+            aria-pressed={voice.recording}
+            data-testid="maxwell-mic-btn"
+            disabled={chatSending || !status.http_reachable}
+            onClick={voice.toggle}
+            variant={voice.recording ? "primary" : "default"}
+            style={{
+              flexShrink: 0,
+              minHeight: 40,
+              minWidth: 40,
+              padding: "0 10px",
+              outline: voice.recording
+                ? "2px solid var(--accent-green)"
+                : undefined,
+            }}
+          >
+            {voice.recording ? "[REC]" : "🎙"}
+          </TouchButton>
+        )}
+        <TouchButton
+          aria-label="Send message to Maxwell"
+          data-testid="maxwell-send-btn"
+          disabled={chatSending || !chatInput.trim() || !status.http_reachable}
+          onClick={() => sendChat()}
+          variant="primary"
+          style={{ flexShrink: 0, minHeight: 40, padding: "0 16px" }}
+        >
+          {chatSending ? "…" : "Send"}
+        </TouchButton>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Maxwell/MaxwellControlSheet.tsx
+++ b/frontend/src/pages/Maxwell/MaxwellControlSheet.tsx
@@ -1,0 +1,56 @@
+import { BottomSheet } from "../../primitives/BottomSheet";
+import { TouchButton } from "../../primitives/TouchButton";
+import type { ControlAction } from "./mobileTypes";
+
+interface MaxwellControlSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  controlling: boolean;
+  isRunning: boolean;
+  onControl: (action: ControlAction) => void;
+}
+
+export function MaxwellControlSheet({
+  isOpen,
+  onClose,
+  controlling,
+  isRunning,
+  onControl,
+}: MaxwellControlSheetProps) {
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose} title="Daemon Controls">
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <TouchButton
+          aria-label="Start Maxwell daemon"
+          data-testid="maxwell-ctrl-start"
+          disabled={controlling || isRunning}
+          onClick={() => onControl("start")}
+          variant="primary"
+          style={{ minHeight: 48, width: "100%" }}
+        >
+          {controlling ? "Working…" : "Start Maxwell"}
+        </TouchButton>
+        <TouchButton
+          aria-label="Stop Maxwell daemon"
+          data-testid="maxwell-ctrl-stop"
+          disabled={controlling || !isRunning}
+          onClick={() => onControl("stop")}
+          variant="danger"
+          style={{ minHeight: 48, width: "100%" }}
+        >
+          {controlling ? "Working…" : "Stop Maxwell"}
+        </TouchButton>
+        <TouchButton
+          aria-label="Restart Maxwell daemon"
+          data-testid="maxwell-ctrl-restart"
+          disabled={controlling}
+          onClick={() => onControl("restart")}
+          variant="default"
+          style={{ minHeight: 48, width: "100%" }}
+        >
+          {controlling ? "Working…" : "Restart Maxwell"}
+        </TouchButton>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/frontend/src/pages/Maxwell/MaxwellStatusHeader.tsx
+++ b/frontend/src/pages/Maxwell/MaxwellStatusHeader.tsx
@@ -1,0 +1,98 @@
+import type { CSSProperties } from "react";
+import { TouchButton } from "../../primitives/TouchButton";
+import { statusEmoji, statusPillStyle } from "./mobileTypes";
+
+interface MaxwellStatusHeaderProps {
+  daemonStatus: string;
+  daemonVersion: string;
+  statusError: string | null;
+  statusLoading: boolean;
+  refreshing: boolean;
+  onRefresh: () => void;
+  onOpenControls: () => void;
+}
+
+export function MaxwellStatusHeader({
+  daemonStatus,
+  daemonVersion,
+  statusError,
+  statusLoading,
+  refreshing,
+  onRefresh,
+  onOpenControls,
+}: MaxwellStatusHeaderProps) {
+  const pillStyle: CSSProperties = {
+    ...statusPillStyle(daemonStatus),
+    borderRadius: 20,
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 5,
+    fontSize: 12,
+    fontWeight: 600,
+    padding: "4px 10px",
+  };
+
+  return (
+    <div
+      style={{
+        alignItems: "center",
+        display: "flex",
+        gap: 8,
+        justifyContent: "space-between",
+        marginBottom: 14,
+        flexWrap: "wrap",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flexWrap: "wrap",
+        }}
+      >
+        <span
+          aria-label={`Maxwell daemon status: ${daemonStatus}`}
+          style={pillStyle}
+        >
+          <span aria-hidden="true">{statusEmoji(daemonStatus)}</span>
+          {daemonStatus}
+        </span>
+        {daemonVersion && (
+          <span style={{ color: "var(--text-muted)", fontSize: 11 }}>
+            v{daemonVersion}
+          </span>
+        )}
+        {statusError && (
+          <span
+            aria-live="assertive"
+            role="alert"
+            style={{ color: "var(--accent-red)", fontSize: 11 }}
+          >
+            {statusError}
+          </span>
+        )}
+      </div>
+      <div style={{ display: "flex", gap: 6 }}>
+        <TouchButton
+          aria-label="Refresh Maxwell status"
+          disabled={statusLoading || refreshing}
+          onClick={onRefresh}
+          variant="default"
+          style={{ fontSize: 12, minHeight: 34, padding: "4px 10px" }}
+        >
+          {refreshing ? "Refreshing…" : "↻ Refresh"}
+        </TouchButton>
+        <TouchButton
+          aria-label="Open daemon controls"
+          data-testid="maxwell-settings-btn"
+          onClick={onOpenControls}
+          variant="default"
+          style={{ fontSize: 12, minHeight: 34, padding: "4px 10px" }}
+        >
+          ⚙ Controls
+        </TouchButton>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Maxwell/MaxwellTasks.tsx
+++ b/frontend/src/pages/Maxwell/MaxwellTasks.tsx
@@ -1,0 +1,76 @@
+import type { CSSProperties } from "react";
+import { TaskCard } from "./TaskCard";
+import type { MaxwellTask } from "./mobileTypes";
+
+interface MaxwellTasksProps {
+  tasksLoading: boolean;
+  tasks: MaxwellTask[];
+  isRunning: boolean;
+}
+
+export function MaxwellTasks({
+  tasksLoading,
+  tasks,
+  isRunning,
+}: MaxwellTasksProps) {
+  if (tasksLoading) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          overflowX: "auto",
+          paddingBottom: 4,
+        }}
+      >
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            style={{
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              borderRadius: 10,
+              flexShrink: 0,
+              height: 72,
+              minWidth: 140,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <div
+        aria-label="No active tasks"
+        style={{
+          color: "var(--text-muted)",
+          fontSize: 12,
+          padding: "8px 0",
+        }}
+      >
+        {isRunning ? "No active tasks." : "Daemon not running — no task history."}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      aria-label="Active tasks"
+      role="list"
+      style={{
+        display: "flex",
+        gap: 8,
+        overflowX: "auto",
+        paddingBottom: 6,
+        WebkitOverflowScrolling:
+          "touch" as CSSProperties["WebkitOverflowScrolling"],
+      }}
+    >
+      {tasks.map((task) => (
+        <TaskCard key={task.task_id} task={task} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/Maxwell/Mobile.tsx
+++ b/frontend/src/pages/Maxwell/Mobile.tsx
@@ -7,217 +7,26 @@
  * - Chat interface: scrollable history + text input + send; sessionStorage persistence
  * - Control sheet: Start / Stop / Restart via BottomSheet triggered by settings icon
  * - PullToRefresh refreshes status + tasks
+ *
+ * Sub-components are siblings (MaxwellStatusHeader, MaxwellTasks, MaxwellChat,
+ * MaxwellControlSheet, TaskCard, ChatBubble) so this file fits the 500-line cap.
  */
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import { BottomSheet } from "../../primitives/BottomSheet";
+import { useCallback, useEffect, useState } from "react";
 import { PullToRefresh } from "../../primitives/PullToRefresh";
 import { SkeletonCard, SkeletonLine } from "../../primitives/Skeleton";
-import { TouchButton } from "../../primitives/TouchButton";
 import { useHaptic } from "../../hooks/useHaptic";
-import { useVoiceInput } from "../../hooks/useVoiceInput";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface MaxwellStatus {
-  status?: "running" | "stopped" | "error" | string;
-  http_reachable?: boolean;
-  binary_found?: boolean;
-  service_running?: boolean;
-  service_detail?: string;
-  http_detail?: string;
-  binary_path?: string;
-  dashboard_url?: string;
-}
-
-interface MaxwellTask {
-  task_id: string;
-  status: string;
-  started_at?: string | number;
-  elapsed_seconds?: number;
-}
-
-interface ChatMessage {
-  id: number;
-  role: "operator" | "maxwell";
-  content: string;
-  streaming?: boolean;
-  error?: boolean;
-}
-
-type ControlAction = "start" | "stop" | "restart";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const CHAT_STORE_KEY = "maxwellMobileChatHistory";
-const MAX_HISTORY = 40;
-const QUICK_CHIPS = ["status", "summarize last hour", "which runners are blocked?"];
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function elapsedLabel(task: MaxwellTask): string {
-  if (task.elapsed_seconds !== undefined) {
-    const s = Math.floor(task.elapsed_seconds);
-    if (s < 60) return `${s}s`;
-    const m = Math.floor(s / 60);
-    if (m < 60) return `${m}m ${s % 60}s`;
-    return `${Math.floor(m / 60)}h ${m % 60}m`;
-  }
-  if (task.started_at) {
-    const start = typeof task.started_at === "number"
-      ? task.started_at
-      : new Date(task.started_at).getTime();
-    if (!isNaN(start)) {
-      const s = Math.floor((Date.now() - start) / 1000);
-      if (s < 60) return `${s}s`;
-      const m = Math.floor(s / 60);
-      if (m < 60) return `${m}m ${s % 60}s`;
-      return `${Math.floor(m / 60)}h ${m % 60}m`;
-    }
-  }
-  return "—";
-}
-
-function statusPillStyle(status: string): React.CSSProperties {
-  const s = status.toLowerCase();
-  if (s === "running") {
-    return { background: "rgba(63,185,80,0.15)", color: "var(--accent-green)", border: "1px solid rgba(63,185,80,0.4)" };
-  }
-  if (s === "error") {
-    return { background: "rgba(248,81,73,0.12)", color: "var(--accent-red)", border: "1px solid rgba(248,81,73,0.35)" };
-  }
-  // stopped / unknown
-  return { background: "rgba(139,148,158,0.12)", color: "var(--text-muted)", border: "1px solid rgba(139,148,158,0.3)" };
-}
-
-function statusEmoji(status: string): string {
-  const s = status.toLowerCase();
-  if (s === "running") return "🟢";
-  if (s === "error") return "🔴";
-  return "🟡";
-}
-
-function loadChatHistory(): ChatMessage[] {
-  try {
-    return JSON.parse(sessionStorage.getItem(CHAT_STORE_KEY) || "[]");
-  } catch {
-    return [];
-  }
-}
-
-function saveChatHistory(messages: ChatMessage[]): void {
-  try {
-    sessionStorage.setItem(CHAT_STORE_KEY, JSON.stringify(messages.slice(-MAX_HISTORY)));
-  } catch {
-    // sessionStorage may be unavailable in some contexts
-  }
-}
-
-// ---------------------------------------------------------------------------
-// TaskCard sub-component
-// ---------------------------------------------------------------------------
-
-interface TaskCardProps {
-  task: MaxwellTask;
-}
-
-function TaskCard({ task }: TaskCardProps) {
-  const s = task.status?.toLowerCase() ?? "unknown";
-  const accent =
-    s === "running" || s === "active"
-      ? "var(--accent-green)"
-      : s === "error" || s === "failed"
-      ? "var(--accent-red)"
-      : "var(--text-muted)";
-
-  return (
-    <div
-      aria-label={`Task ${task.task_id}, status ${task.status}`}
-      className="maxwell-task-card"
-      role="listitem"
-      style={{
-        background: "var(--bg-secondary)",
-        border: "1px solid var(--border)",
-        borderLeft: `3px solid ${accent}`,
-        borderRadius: 10,
-        flexShrink: 0,
-        minWidth: 140,
-        padding: "10px 12px",
-      }}
-    >
-      <div
-        style={{
-          color: "var(--text-primary)",
-          fontSize: 12,
-          fontWeight: 600,
-          marginBottom: 4,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-          maxWidth: 120,
-        }}
-        title={task.task_id}
-      >
-        {task.task_id}
-      </div>
-      <div style={{ color: accent, fontSize: 11, marginBottom: 2 }}>{task.status}</div>
-      <div style={{ color: "var(--text-muted)", fontSize: 11 }}>{elapsedLabel(task)}</div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ChatBubble sub-component
-// ---------------------------------------------------------------------------
-
-interface ChatBubbleProps {
-  message: ChatMessage;
-}
-
-function ChatBubble({ message }: ChatBubbleProps) {
-  const isOperator = message.role === "operator";
-  return (
-    <div
-      className={`maxwell-chat-bubble ${message.role}${message.error ? " error" : ""}`}
-      style={{
-        alignSelf: isOperator ? "flex-end" : "flex-start",
-        background: isOperator
-          ? "var(--accent-blue)"
-          : message.error
-          ? "rgba(248,81,73,0.12)"
-          : "var(--bg-secondary)",
-        border: message.error ? "1px solid rgba(248,81,73,0.35)" : undefined,
-        borderRadius: isOperator ? "16px 16px 4px 16px" : "16px 16px 16px 4px",
-        color: isOperator ? "#fff" : message.error ? "var(--accent-red)" : "var(--text-primary)",
-        fontSize: 13,
-        maxWidth: "84%",
-        padding: "10px 14px",
-        wordBreak: "break-word",
-      }}
-    >
-      {message.content || (message.streaming ? "Receiving…" : "")}
-      {message.streaming && (
-        <span aria-hidden="true" style={{ color: isOperator ? "rgba(255,255,255,0.6)" : "var(--text-muted)" }}>
-          {" ▌"}
-        </span>
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
+import { MaxwellChat } from "./MaxwellChat";
+import { MaxwellControlSheet } from "./MaxwellControlSheet";
+import { MaxwellStatusHeader } from "./MaxwellStatusHeader";
+import { MaxwellTasks } from "./MaxwellTasks";
+import type {
+  ChatMessage,
+  ControlAction,
+  MaxwellStatus,
+  MaxwellTask,
+} from "./mobileTypes";
+import { loadChatHistory, saveChatHistory } from "./mobileTypes";
 
 export function MaxwellMobile() {
   const haptic = useHaptic();
@@ -237,22 +46,13 @@ export function MaxwellMobile() {
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(loadChatHistory);
   const [chatInput, setChatInput] = useState("");
   const [chatSending, setChatSending] = useState(false);
-  const [showScrollBtn, setShowScrollBtn] = useState(false);
-  const chatListRef = useRef<HTMLDivElement>(null);
-  const [voiceError, setVoiceError] = useState<string | null>(null);
-
-  const voice = useVoiceInput({
-    onTranscript: (text) => {
-      setChatInput((prev) => (prev ? `${prev} ${text}` : text));
-      setVoiceError(null);
-    },
-    onError: (msg) => setVoiceError(msg),
-  });
 
   // -- Control sheet state ----------------------------------------------------
   const [controlSheetOpen, setControlSheetOpen] = useState(false);
   const [controlling, setControlling] = useState(false);
-  const [controlResult, setControlResult] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [controlResult, setControlResult] = useState<
+    { ok: boolean; msg: string } | null
+  >(null);
 
   // ---------------------------------------------------------------------------
   // Data fetching
@@ -266,7 +66,9 @@ export function MaxwellMobile() {
       setStatus(data);
       setStatusError(null);
     } catch (e: unknown) {
-      setStatusError(e instanceof Error ? e.message : "Failed to load Maxwell status");
+      setStatusError(
+        e instanceof Error ? e.message : "Failed to load Maxwell status",
+      );
     } finally {
       setStatusLoading(false);
     }
@@ -309,15 +111,6 @@ export function MaxwellMobile() {
     saveChatHistory(chatMessages);
   }, [chatMessages]);
 
-  // Auto-scroll chat when new messages arrive (unless user scrolled up)
-  useEffect(() => {
-    if (showScrollBtn) return;
-    const el = chatListRef.current;
-    if (el) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [chatMessages, showScrollBtn]);
-
   // ---------------------------------------------------------------------------
   // Pull-to-refresh
   // ---------------------------------------------------------------------------
@@ -334,28 +127,20 @@ export function MaxwellMobile() {
   // Chat
   // ---------------------------------------------------------------------------
 
-  function isNearBottom(): boolean {
-    const el = chatListRef.current;
-    if (!el) return true;
-    return el.scrollHeight - el.scrollTop - el.clientHeight < 56;
-  }
-
-  function onChatScroll() {
-    setShowScrollBtn(!isNearBottom());
-  }
-
-  function updateMessage(id: number, patch: Partial<ChatMessage>) {
-    setChatMessages((prev) =>
-      prev.map((m) => (m.id === id ? { ...m, ...patch } : m)),
-    );
-  }
+  const updateMessage = useCallback(
+    (id: number, patch: Partial<ChatMessage>) => {
+      setChatMessages((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, ...patch } : m)),
+      );
+    },
+    [],
+  );
 
   const sendChat = useCallback(
     async (text?: string) => {
       const msg = (text ?? chatInput).trim();
       if (!msg || chatSending) return;
       setChatInput("");
-      setShowScrollBtn(false);
 
       const now = Date.now();
       const userMsg: ChatMessage = { id: now, role: "operator", content: msg };
@@ -370,8 +155,14 @@ export function MaxwellMobile() {
       try {
         const resp = await fetch("/api/maxwell/chat", {
           method: "POST",
-          headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
-          body: JSON.stringify({ message: msg, history: chatMessages.slice(-12) }),
+          headers: {
+            "Content-Type": "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+          },
+          body: JSON.stringify({
+            message: msg,
+            history: chatMessages.slice(-12),
+          }),
         });
 
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
@@ -385,7 +176,10 @@ export function MaxwellMobile() {
             const { done, value } = await reader.read();
             if (done) return acc;
             acc += decoder.decode(value, { stream: true });
-            updateMessage(assistantId, { content: acc || "Receiving…", streaming: true });
+            updateMessage(assistantId, {
+              content: acc || "Receiving…",
+              streaming: true,
+            });
             return pump();
           };
           const finalText = await pump();
@@ -397,13 +191,17 @@ export function MaxwellMobile() {
           // Fallback: plain JSON
           const data = await resp.json();
           updateMessage(assistantId, {
-            content: data.response ?? data.message ?? "Maxwell returned an empty response.",
+            content:
+              data.response ??
+              data.message ??
+              "Maxwell returned an empty response.",
             streaming: false,
           });
         }
-      } catch (e: unknown) {
+      } catch {
         updateMessage(assistantId, {
-          content: "Maxwell-Daemon is unreachable. Check daemon status above, then retry.",
+          content:
+            "Maxwell-Daemon is unreachable. Check daemon status above, then retry.",
           streaming: false,
           error: true,
         });
@@ -411,15 +209,8 @@ export function MaxwellMobile() {
         setChatSending(false);
       }
     },
-    [chatInput, chatSending, chatMessages],
+    [chatInput, chatSending, chatMessages, updateMessage],
   );
-
-  function onChatKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      sendChat();
-    }
-  }
 
   // ---------------------------------------------------------------------------
   // Daemon control
@@ -432,7 +223,10 @@ export function MaxwellMobile() {
       try {
         const resp = await fetch("/api/maxwell/control", {
           method: "POST",
-          headers: { "Content-Type": "application/json", "X-Requested-With": "XMLHttpRequest" },
+          headers: {
+            "Content-Type": "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+          },
           body: JSON.stringify({ action }),
         });
         if (!resp.ok) {
@@ -445,7 +239,10 @@ export function MaxwellMobile() {
           fetchTasks();
         }, 1000);
       } catch (e: unknown) {
-        setControlResult({ ok: false, msg: e instanceof Error ? e.message : "Control failed" });
+        setControlResult({
+          ok: false,
+          msg: e instanceof Error ? e.message : "Control failed",
+        });
       } finally {
         setControlling(false);
       }
@@ -453,313 +250,18 @@ export function MaxwellMobile() {
     [fetchStatus, fetchTasks],
   );
 
+  const retryConnection = useCallback(() => {
+    fetchStatus();
+    fetchTasks();
+    fetchVersion();
+  }, [fetchStatus, fetchTasks, fetchVersion]);
+
   // ---------------------------------------------------------------------------
-  // Render helpers
+  // Render
   // ---------------------------------------------------------------------------
 
   const daemonStatus = (status.status ?? "unknown").toLowerCase();
   const isRunning = daemonStatus === "running";
-
-  function renderStatusHeader() {
-    const pillStyle: React.CSSProperties = {
-      ...statusPillStyle(daemonStatus),
-      borderRadius: 20,
-      display: "inline-flex",
-      alignItems: "center",
-      gap: 5,
-      fontSize: 12,
-      fontWeight: 600,
-      padding: "4px 10px",
-    };
-
-    return (
-      <div
-        style={{
-          alignItems: "center",
-          display: "flex",
-          gap: 8,
-          justifyContent: "space-between",
-          marginBottom: 14,
-          flexWrap: "wrap",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-          <span aria-label={`Maxwell daemon status: ${daemonStatus}`} style={pillStyle}>
-            <span aria-hidden="true">{statusEmoji(daemonStatus)}</span>
-            {daemonStatus}
-          </span>
-          {daemonVersion && (
-            <span style={{ color: "var(--text-muted)", fontSize: 11 }}>v{daemonVersion}</span>
-          )}
-          {statusError && (
-            <span aria-live="assertive" role="alert" style={{ color: "var(--accent-red)", fontSize: 11 }}>
-              {statusError}
-            </span>
-          )}
-        </div>
-        <div style={{ display: "flex", gap: 6 }}>
-          <TouchButton
-            aria-label="Refresh Maxwell status"
-            disabled={statusLoading || refreshing}
-            onClick={handleRefresh}
-            variant="default"
-            style={{ fontSize: 12, minHeight: 34, padding: "4px 10px" }}
-          >
-            {refreshing ? "Refreshing…" : "↻ Refresh"}
-          </TouchButton>
-          <TouchButton
-            aria-label="Open daemon controls"
-            data-testid="maxwell-settings-btn"
-            onClick={() => setControlSheetOpen(true)}
-            variant="default"
-            style={{ fontSize: 12, minHeight: 34, padding: "4px 10px" }}
-          >
-            ⚙ Controls
-          </TouchButton>
-        </div>
-      </div>
-    );
-  }
-
-  function renderTasks() {
-    if (tasksLoading) {
-      return (
-        <div style={{ display: "flex", gap: 8, overflowX: "auto", paddingBottom: 4 }}>
-          {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              style={{
-                background: "var(--bg-secondary)",
-                border: "1px solid var(--border)",
-                borderRadius: 10,
-                flexShrink: 0,
-                height: 72,
-                minWidth: 140,
-              }}
-            />
-          ))}
-        </div>
-      );
-    }
-
-    if (tasks.length === 0) {
-      return (
-        <div
-          aria-label="No active tasks"
-          style={{ color: "var(--text-muted)", fontSize: 12, padding: "8px 0" }}
-        >
-          {isRunning ? "No active tasks." : "Daemon not running — no task history."}
-        </div>
-      );
-    }
-
-    return (
-      <div
-        aria-label="Active tasks"
-        role="list"
-        style={{
-          display: "flex",
-          gap: 8,
-          overflowX: "auto",
-          paddingBottom: 6,
-          WebkitOverflowScrolling: "touch" as React.CSSProperties["WebkitOverflowScrolling"],
-        }}
-      >
-        {tasks.map((task) => (
-          <TaskCard key={task.task_id} task={task} />
-        ))}
-      </div>
-    );
-  }
-
-  function renderChat() {
-    return (
-      <div
-        className="maxwell-chat-section"
-        style={{ display: "flex", flexDirection: "column", flexGrow: 1, minHeight: 0 }}
-      >
-        <div
-          style={{
-            color: "var(--text-secondary)",
-            fontSize: 12,
-            fontWeight: 600,
-            marginBottom: 8,
-            textTransform: "uppercase",
-            letterSpacing: "0.04em",
-          }}
-        >
-          Chat
-        </div>
-
-        {/* Message history */}
-        <div
-          ref={chatListRef}
-          aria-label="Maxwell chat history"
-          aria-live="polite"
-          className="maxwell-chat-messages"
-          onScroll={onChatScroll}
-          style={{
-            border: "1px solid var(--border)",
-            borderRadius: 10,
-            display: "flex",
-            flexDirection: "column",
-            flexGrow: 1,
-            gap: 8,
-            minHeight: 180,
-            maxHeight: 280,
-            overflowY: "auto",
-            padding: "12px",
-            WebkitOverflowScrolling: "touch" as React.CSSProperties["WebkitOverflowScrolling"],
-          }}
-        >
-          {chatMessages.length === 0 ? (
-            <div
-              aria-label="No chat messages yet"
-              style={{ color: "var(--text-muted)", fontSize: 12, textAlign: "center", margin: "auto" }}
-            >
-              {status.http_reachable
-                ? "Ask Maxwell for fleet status, runner activity, or the next operator command."
-                : "Maxwell-Daemon is unreachable. Chat history is preserved; retry when daemon is reachable."}
-            </div>
-          ) : (
-            chatMessages.map((m) => <ChatBubble key={m.id} message={m} />)
-          )}
-        </div>
-
-        {/* Scroll-to-bottom button */}
-        {showScrollBtn && (
-          <TouchButton
-            aria-label="Scroll to latest chat message"
-            onClick={() => {
-              setShowScrollBtn(false);
-              if (chatListRef.current) {
-                chatListRef.current.scrollTop = chatListRef.current.scrollHeight;
-              }
-            }}
-            variant="default"
-            style={{ alignSelf: "center", fontSize: 11, marginTop: 4, minHeight: 30, padding: "2px 10px" }}
-          >
-            Latest ↓
-          </TouchButton>
-        )}
-
-        {/* Quick-action chips */}
-        <div
-          aria-label="Maxwell quick actions"
-          style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}
-        >
-          {QUICK_CHIPS.map((chip) => (
-            <TouchButton
-              key={chip}
-              aria-label={`Ask Maxwell: ${chip}`}
-              disabled={chatSending}
-              onClick={() => sendChat(chip)}
-              variant="default"
-              style={{ fontSize: 11, minHeight: 30, padding: "4px 10px" }}
-            >
-              {chip}
-            </TouchButton>
-          ))}
-          {!status.http_reachable && (
-            <TouchButton
-              aria-label="Retry Maxwell connection"
-              onClick={() => {
-                fetchStatus();
-                fetchTasks();
-                fetchVersion();
-              }}
-              variant="primary"
-              style={{ fontSize: 11, minHeight: 30, padding: "4px 10px" }}
-            >
-              Retry
-            </TouchButton>
-          )}
-        </div>
-
-        {/* Composer */}
-        {voiceError && (
-          <div
-            aria-live="polite"
-            role="alert"
-            style={{
-              background: "rgba(248,81,73,0.12)",
-              border: "1px solid rgba(248,81,73,0.35)",
-              borderRadius: 6,
-              color: "var(--accent-red)",
-              fontSize: 11,
-              marginTop: 6,
-              padding: "4px 8px",
-            }}
-          >
-            {voiceError}
-          </div>
-        )}
-        <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-          <textarea
-            aria-label="Message Maxwell"
-            disabled={chatSending || !status.http_reachable}
-            onChange={(e) => setChatInput(e.target.value)}
-            onKeyDown={onChatKeyDown}
-            placeholder={
-              status.http_reachable
-                ? "Message Maxwell…"
-                : "Daemon unreachable; retry before sending commands"
-            }
-            rows={1}
-            value={chatInput}
-            style={{
-              background: "var(--bg-tertiary)",
-              border: "1px solid var(--border)",
-              borderRadius: 8,
-              boxSizing: "border-box",
-              color: "var(--text-primary)",
-              flex: 1,
-              fontFamily: "inherit",
-              fontSize: 13,
-              minHeight: 40,
-              padding: "10px 12px",
-              resize: "none",
-            }}
-          />
-          {voice.available && (
-            <TouchButton
-              aria-label={voice.recording ? "Stop voice recording" : "Start voice input"}
-              aria-pressed={voice.recording}
-              data-testid="maxwell-mic-btn"
-              disabled={chatSending || !status.http_reachable}
-              onClick={voice.toggle}
-              variant={voice.recording ? "primary" : "default"}
-              style={{
-                flexShrink: 0,
-                minHeight: 40,
-                minWidth: 40,
-                padding: "0 10px",
-                outline: voice.recording
-                  ? "2px solid var(--accent-green)"
-                  : undefined,
-              }}
-            >
-              {voice.recording ? "[REC]" : "🎙"}
-            </TouchButton>
-          )}
-          <TouchButton
-            aria-label="Send message to Maxwell"
-            data-testid="maxwell-send-btn"
-            disabled={chatSending || !chatInput.trim() || !status.http_reachable}
-            onClick={() => sendChat()}
-            variant="primary"
-            style={{ flexShrink: 0, minHeight: 40, padding: "0 16px" }}
-          >
-            {chatSending ? "…" : "Send"}
-          </TouchButton>
-        </div>
-      </div>
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Loading state
-  // ---------------------------------------------------------------------------
 
   if (statusLoading) {
     return (
@@ -769,7 +271,12 @@ export function MaxwellMobile() {
         aria-live="polite"
         className="maxwell-mobile-loading"
         role="status"
-        style={{ display: "flex", flexDirection: "column", gap: 10, padding: "16px" }}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+          padding: "16px",
+        }}
       >
         <SkeletonLine height={22} width="50%" />
         <SkeletonLine height={18} width="30%" />
@@ -779,9 +286,9 @@ export function MaxwellMobile() {
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Main render
-  // ---------------------------------------------------------------------------
+  const showDaemonDetails =
+    status.dashboard_url ||
+    (!status.binary_found && !status.service_running && !status.http_reachable);
 
   return (
     <PullToRefresh disabled={refreshing} onRefresh={handleRefresh}>
@@ -795,11 +302,18 @@ export function MaxwellMobile() {
           padding: "12px 12px 80px",
         }}
       >
-        {/* Status header */}
-        {renderStatusHeader()}
+        <MaxwellStatusHeader
+          daemonStatus={daemonStatus}
+          daemonVersion={daemonVersion}
+          statusError={statusError}
+          statusLoading={statusLoading}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          onOpenControls={() => setControlSheetOpen(true)}
+        />
 
         {/* Daemon details */}
-        {(status.dashboard_url || (!status.binary_found && !status.service_running && !status.http_reachable)) && (
+        {showDaemonDetails && (
           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
             {status.dashboard_url ? (
               <a
@@ -830,11 +344,23 @@ export function MaxwellMobile() {
           >
             Active Tasks
           </div>
-          {renderTasks()}
+          <MaxwellTasks
+            tasksLoading={tasksLoading}
+            tasks={tasks}
+            isRunning={isRunning}
+          />
         </div>
 
         {/* Chat */}
-        {renderChat()}
+        <MaxwellChat
+          status={status}
+          chatMessages={chatMessages}
+          chatInput={chatInput}
+          setChatInput={setChatInput}
+          chatSending={chatSending}
+          sendChat={sendChat}
+          onRetry={retryConnection}
+        />
 
         {/* Control result toast */}
         {controlResult && (
@@ -842,10 +368,14 @@ export function MaxwellMobile() {
             aria-live="polite"
             role="status"
             style={{
-              background: controlResult.ok ? "rgba(63,185,80,0.12)" : "rgba(248,81,73,0.12)",
+              background: controlResult.ok
+                ? "rgba(63,185,80,0.12)"
+                : "rgba(248,81,73,0.12)",
               border: `1px solid ${controlResult.ok ? "rgba(63,185,80,0.4)" : "rgba(248,81,73,0.35)"}`,
               borderRadius: 8,
-              color: controlResult.ok ? "var(--accent-green)" : "var(--accent-red)",
+              color: controlResult.ok
+                ? "var(--accent-green)"
+                : "var(--accent-red)",
               fontSize: 12,
               padding: "10px 12px",
             }}
@@ -855,47 +385,15 @@ export function MaxwellMobile() {
         )}
       </section>
 
-      {/* Control sheet */}
-      <BottomSheet
+      <MaxwellControlSheet
         isOpen={controlSheetOpen}
         onClose={() => {
           if (!controlling) setControlSheetOpen(false);
         }}
-        title="Daemon Controls"
-      >
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          <TouchButton
-            aria-label="Start Maxwell daemon"
-            data-testid="maxwell-ctrl-start"
-            disabled={controlling || isRunning}
-            onClick={() => handleControl("start")}
-            variant="primary"
-            style={{ minHeight: 48, width: "100%" }}
-          >
-            {controlling ? "Working…" : "Start Maxwell"}
-          </TouchButton>
-          <TouchButton
-            aria-label="Stop Maxwell daemon"
-            data-testid="maxwell-ctrl-stop"
-            disabled={controlling || !isRunning}
-            onClick={() => handleControl("stop")}
-            variant="danger"
-            style={{ minHeight: 48, width: "100%" }}
-          >
-            {controlling ? "Working…" : "Stop Maxwell"}
-          </TouchButton>
-          <TouchButton
-            aria-label="Restart Maxwell daemon"
-            data-testid="maxwell-ctrl-restart"
-            disabled={controlling}
-            onClick={() => handleControl("restart")}
-            variant="default"
-            style={{ minHeight: 48, width: "100%" }}
-          >
-            {controlling ? "Working…" : "Restart Maxwell"}
-          </TouchButton>
-        </div>
-      </BottomSheet>
+        controlling={controlling}
+        isRunning={isRunning}
+        onControl={handleControl}
+      />
     </PullToRefresh>
   );
 }

--- a/frontend/src/pages/Maxwell/TaskCard.tsx
+++ b/frontend/src/pages/Maxwell/TaskCard.tsx
@@ -1,0 +1,55 @@
+import type { MaxwellTask } from "./mobileTypes";
+import { elapsedLabel } from "./mobileTypes";
+
+interface TaskCardProps {
+  task: MaxwellTask;
+}
+
+export function TaskCard({ task }: TaskCardProps) {
+  const s = task.status?.toLowerCase() ?? "unknown";
+  const accent =
+    s === "running" || s === "active"
+      ? "var(--accent-green)"
+      : s === "error" || s === "failed"
+        ? "var(--accent-red)"
+        : "var(--text-muted)";
+
+  return (
+    <div
+      aria-label={`Task ${task.task_id}, status ${task.status}`}
+      className="maxwell-task-card"
+      role="listitem"
+      style={{
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border)",
+        borderLeft: `3px solid ${accent}`,
+        borderRadius: 10,
+        flexShrink: 0,
+        minWidth: 140,
+        padding: "10px 12px",
+      }}
+    >
+      <div
+        style={{
+          color: "var(--text-primary)",
+          fontSize: 12,
+          fontWeight: 600,
+          marginBottom: 4,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          maxWidth: 120,
+        }}
+        title={task.task_id}
+      >
+        {task.task_id}
+      </div>
+      <div style={{ color: accent, fontSize: 11, marginBottom: 2 }}>
+        {task.status}
+      </div>
+      <div style={{ color: "var(--text-muted)", fontSize: 11 }}>
+        {elapsedLabel(task)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Maxwell/mobileTypes.ts
+++ b/frontend/src/pages/Maxwell/mobileTypes.ts
@@ -1,0 +1,113 @@
+// Shared types, constants, and helpers for the Maxwell mobile view.
+// Extracted from Mobile.tsx to keep that file under the 500-line cap.
+import type { CSSProperties } from "react";
+
+export interface MaxwellStatus {
+  status?: "running" | "stopped" | "error" | string;
+  http_reachable?: boolean;
+  binary_found?: boolean;
+  service_running?: boolean;
+  service_detail?: string;
+  http_detail?: string;
+  binary_path?: string;
+  dashboard_url?: string;
+}
+
+export interface MaxwellTask {
+  task_id: string;
+  status: string;
+  started_at?: string | number;
+  elapsed_seconds?: number;
+}
+
+export interface ChatMessage {
+  id: number;
+  role: "operator" | "maxwell";
+  content: string;
+  streaming?: boolean;
+  error?: boolean;
+}
+
+export type ControlAction = "start" | "stop" | "restart";
+
+export const CHAT_STORE_KEY = "maxwellMobileChatHistory";
+export const MAX_HISTORY = 40;
+export const QUICK_CHIPS = [
+  "status",
+  "summarize last hour",
+  "which runners are blocked?",
+];
+
+export function elapsedLabel(task: MaxwellTask): string {
+  if (task.elapsed_seconds !== undefined) {
+    const s = Math.floor(task.elapsed_seconds);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m ${s % 60}s`;
+    return `${Math.floor(m / 60)}h ${m % 60}m`;
+  }
+  if (task.started_at) {
+    const start =
+      typeof task.started_at === "number"
+        ? task.started_at
+        : new Date(task.started_at).getTime();
+    if (!isNaN(start)) {
+      const s = Math.floor((Date.now() - start) / 1000);
+      if (s < 60) return `${s}s`;
+      const m = Math.floor(s / 60);
+      if (m < 60) return `${m}m ${s % 60}s`;
+      return `${Math.floor(m / 60)}h ${m % 60}m`;
+    }
+  }
+  return "—";
+}
+
+export function statusPillStyle(status: string): CSSProperties {
+  const s = status.toLowerCase();
+  if (s === "running") {
+    return {
+      background: "rgba(63,185,80,0.15)",
+      color: "var(--accent-green)",
+      border: "1px solid rgba(63,185,80,0.4)",
+    };
+  }
+  if (s === "error") {
+    return {
+      background: "rgba(248,81,73,0.12)",
+      color: "var(--accent-red)",
+      border: "1px solid rgba(248,81,73,0.35)",
+    };
+  }
+  // stopped / unknown
+  return {
+    background: "rgba(139,148,158,0.12)",
+    color: "var(--text-muted)",
+    border: "1px solid rgba(139,148,158,0.3)",
+  };
+}
+
+export function statusEmoji(status: string): string {
+  const s = status.toLowerCase();
+  if (s === "running") return "🟢";
+  if (s === "error") return "🔴";
+  return "🟡";
+}
+
+export function loadChatHistory(): ChatMessage[] {
+  try {
+    return JSON.parse(sessionStorage.getItem(CHAT_STORE_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+
+export function saveChatHistory(messages: ChatMessage[]): void {
+  try {
+    sessionStorage.setItem(
+      CHAT_STORE_KEY,
+      JSON.stringify(messages.slice(-MAX_HISTORY)),
+    );
+  } catch {
+    // sessionStorage may be unavailable in some contexts
+  }
+}

--- a/frontend/src/pages/Queue/Mobile.tsx
+++ b/frontend/src/pages/Queue/Mobile.tsx
@@ -1,176 +1,23 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { SegmentedControl } from "../../primitives/SegmentedControl";
-import { Badge } from "../../primitives/Badge";
 import { TouchButton } from "../../primitives/TouchButton";
 import { SkeletonCard, SkeletonLine } from "../../primitives/Skeleton";
 import { PullToRefresh } from "../../primitives/PullToRefresh";
-import { BottomSheet } from "../../primitives/BottomSheet";
 import { useHaptic } from "../../hooks/useHaptic";
 
-// -- Types -----------------------------------------------------------------------
-
-interface WorkflowRun {
-  id: string | number;
-  name?: string;
-  head_branch?: string;
-  html_url?: string;
-  run_started_at?: string;
-  created_at?: string;
-  runner_name?: string;
-  runner?: { name?: string };
-  triggering_actor?: { login?: string };
-  actor?: { login?: string };
-  repository?: { name?: string };
-}
-
-interface QueueData {
-  in_progress?: WorkflowRun[];
-  queued?: WorkflowRun[];
-  total?: number;
-}
-
-type FilterValue = "all" | "running" | "queued" | "failed";
-
-interface RunDetail {
-  run: WorkflowRun;
-  status: FilterValue;
-  repo: string;
-  elapsed: string;
-}
-
-// -- Constants -------------------------------------------------------------------
-
-const FILTER_OPTIONS = [
-  { label: "All", value: "all" },
-  { label: "Running", value: "running" },
-  { label: "Queued", value: "queued" },
-  { label: "Failed", value: "failed" },
-];
-
-const POLL_INTERVAL_MS = 15_000;
-
-// -- Helpers ---------------------------------------------------------------------
-
-function formatDuration(seconds: number): string {
-  if (!seconds || seconds < 0) return "-";
-  if (seconds < 60) return `${seconds}s`;
-  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
-}
-
-function elapsedSeconds(run: WorkflowRun): number {
-  const start = run.run_started_at ?? run.created_at;
-  if (!start) return 0;
-  return Math.round((Date.now() - new Date(start).getTime()) / 1000);
-}
-
-function elapsedLabel(run: WorkflowRun): string {
-  return formatDuration(elapsedSeconds(run));
-}
-
-function runRepo(run: WorkflowRun): string {
-  return run.repository?.name ?? "";
-}
-
-function triggeredBy(run: WorkflowRun): string {
-  return run.triggering_actor?.login ?? run.actor?.login ?? "unknown";
-}
-
-function runnerName(run: WorkflowRun): string {
-  return run.runner_name ?? run.runner?.name ?? "-";
-}
-
-function statusTone(
-  status: FilterValue,
-): "warning" | "info" | "danger" | "neutral" {
-  if (status === "running") return "warning";
-  if (status === "queued") return "info";
-  if (status === "failed") return "danger";
-  return "neutral";
-}
-
-function statusLabel(status: FilterValue): string {
-  if (status === "running") return "running";
-  if (status === "queued") return "queued";
-  if (status === "failed") return "failed";
-  return "unknown";
-}
-
-// -- Sub-components --------------------------------------------------------------
-
-interface RunCardProps {
-  elapsed: string;
-  repo: string;
-  run: WorkflowRun;
-  status: FilterValue;
-  onClick: () => void;
-}
-
-function RunCard({ elapsed, repo, run, status, onClick }: RunCardProps) {
-  return (
-    <button
-      aria-label={`${run.name ?? "Workflow run"} in ${repo}, ${statusLabel(status)}, ${elapsed}`}
-      className="queue-mobile-run-card"
-      onClick={onClick}
-      style={{
-        background: "var(--bg-secondary)",
-        border: "1px solid var(--border)",
-        borderRadius: 10,
-        cursor: "pointer",
-        display: "block",
-        marginBottom: 10,
-        padding: "12px 14px",
-        textAlign: "left",
-        width: "100%",
-      }}
-      type="button"
-    >
-      <div
-        style={{
-          alignItems: "center",
-          display: "flex",
-          justifyContent: "space-between",
-          marginBottom: 6,
-        }}
-      >
-        <span
-          style={{
-            color: "var(--text-primary)",
-            fontSize: 13,
-            fontWeight: 600,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            maxWidth: "60%",
-          }}
-        >
-          {run.name ?? "Workflow run"}
-        </span>
-        <Badge tone={statusTone(status)} size="sm">
-          {statusLabel(status)}
-        </Badge>
-      </div>
-      <div
-        style={{
-          color: "var(--text-secondary)",
-          display: "flex",
-          fontSize: 12,
-          gap: 8,
-          flexWrap: "wrap",
-        }}
-      >
-        <span>{repo || "unknown repo"}</span>
-        {run.head_branch && (
-          <span style={{ color: "var(--text-muted)" }}>{run.head_branch}</span>
-        )}
-        <span style={{ color: "var(--text-muted)", marginLeft: "auto" }}>
-          {elapsed}
-        </span>
-      </div>
-    </button>
-  );
-}
-
-// -- Main component --------------------------------------------------------------
+import { MobileRunCard } from "./MobileRunCard";
+import { MobileRunDetail } from "./MobileRunDetail";
+import type {
+  FilterValue,
+  QueueData,
+  RunDetail,
+} from "./mobileTypes";
+import {
+  FILTER_OPTIONS,
+  POLL_INTERVAL_MS,
+  elapsedLabel,
+  runRepo,
+} from "./mobileTypes";
 
 export function QueueMobile() {
   const [queueData, setQueueData] = useState<QueueData>({});
@@ -332,10 +179,6 @@ export function QueueMobile() {
     );
   }
 
-  const selectedKey = selectedRun
-    ? `${selectedRun.repo}/${selectedRun.run.id}`
-    : null;
-
   return (
     <section
       aria-label="Queue and Workflows"
@@ -431,7 +274,7 @@ export function QueueMobile() {
             </div>
           ) : (
             filtered.map((item) => (
-              <RunCard
+              <MobileRunCard
                 key={`${item.repo}/${item.run.id}`}
                 elapsed={item.elapsed}
                 repo={item.repo}
@@ -448,118 +291,14 @@ export function QueueMobile() {
       </div>
 
       {/* Detail BottomSheet */}
-      <BottomSheet
-        isOpen={!!selectedRun}
+      <MobileRunDetail
+        selectedRun={selectedRun}
         onClose={() => setSelectedRun(null)}
-        title={selectedRun?.run.name ?? "Workflow run"}
-      >
-        {selectedRun && (
-          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-            {/* Meta rows */}
-            <div
-              style={{
-                background: "var(--bg-tertiary)",
-                borderRadius: 8,
-                display: "flex",
-                flexDirection: "column",
-                gap: 8,
-                padding: "12px 14px",
-              }}
-            >
-              {[
-                { label: "Repo", value: selectedRun.repo || "-" },
-                {
-                  label: "Branch",
-                  value: selectedRun.run.head_branch || "-",
-                },
-                {
-                  label: "Triggered by",
-                  value: triggeredBy(selectedRun.run),
-                },
-                { label: "Runner", value: runnerName(selectedRun.run) },
-                { label: "Elapsed", value: selectedRun.elapsed },
-                { label: "Status", value: statusLabel(selectedRun.status) },
-              ].map(({ label, value }) => (
-                <div
-                  key={label}
-                  style={{
-                    alignItems: "center",
-                    display: "flex",
-                    justifyContent: "space-between",
-                  }}
-                >
-                  <span
-                    style={{ color: "var(--text-muted)", fontSize: 12 }}
-                  >
-                    {label}
-                  </span>
-                  <span
-                    style={{
-                      color: "var(--text-primary)",
-                      fontSize: 13,
-                      fontWeight: 500,
-                    }}
-                  >
-                    {value}
-                  </span>
-                </div>
-              ))}
-            </div>
-
-            {/* Action buttons */}
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              {selectedRun.run.html_url && (
-                <TouchButton
-                  aria-label="View run on GitHub"
-                  onClick={() => {
-                    window.open(
-                      selectedRun.run.html_url,
-                      "_blank",
-                      "noopener,noreferrer",
-                    );
-                  }}
-                  variant="default"
-                  style={{ minHeight: 48, width: "100%" }}
-                >
-                  View on GitHub
-                </TouchButton>
-              )}
-
-              <TouchButton
-                aria-label="Re-run workflow"
-                disabled={
-                  !selectedRun.repo ||
-                  cancelDone[selectedKey!] === true
-                }
-                onClick={() => handleRerunRun(selectedRun)}
-                variant="primary"
-                style={{ minHeight: 48, width: "100%" }}
-              >
-                Re-run
-              </TouchButton>
-
-              {selectedRun.status === "running" && selectedRun.repo && (
-                <TouchButton
-                  aria-label="Cancel run"
-                  disabled={
-                    cancelling[selectedKey!] === true ||
-                    cancelDone[selectedKey!] === true
-                  }
-                  onClick={() => handleCancelRun(selectedRun)}
-                  variant="danger"
-                  style={{ minHeight: 48, width: "100%" }}
-                >
-                  {cancelDone[selectedKey!]
-                    ? "Cancelled"
-                    : cancelling[selectedKey!]
-                      ? "Cancelling..."
-                      : "Cancel"}
-                </TouchButton>
-              )}
-            </div>
-          </div>
-        )}
-      </BottomSheet>
+        onRerun={handleRerunRun}
+        onCancel={handleCancelRun}
+        cancelling={cancelling}
+        cancelDone={cancelDone}
+      />
     </section>
   );
 }

--- a/frontend/src/pages/Queue/MobileRunCard.tsx
+++ b/frontend/src/pages/Queue/MobileRunCard.tsx
@@ -1,0 +1,82 @@
+import { Badge } from "../../primitives/Badge";
+import type { FilterValue, WorkflowRun } from "./mobileTypes";
+import { statusLabel, statusTone } from "./mobileTypes";
+
+interface RunCardProps {
+  elapsed: string;
+  repo: string;
+  run: WorkflowRun;
+  status: FilterValue;
+  onClick: () => void;
+}
+
+export function MobileRunCard({
+  elapsed,
+  repo,
+  run,
+  status,
+  onClick,
+}: RunCardProps) {
+  return (
+    <button
+      aria-label={`${run.name ?? "Workflow run"} in ${repo}, ${statusLabel(status)}, ${elapsed}`}
+      className="queue-mobile-run-card"
+      onClick={onClick}
+      style={{
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border)",
+        borderRadius: 10,
+        cursor: "pointer",
+        display: "block",
+        marginBottom: 10,
+        padding: "12px 14px",
+        textAlign: "left",
+        width: "100%",
+      }}
+      type="button"
+    >
+      <div
+        style={{
+          alignItems: "center",
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 6,
+        }}
+      >
+        <span
+          style={{
+            color: "var(--text-primary)",
+            fontSize: 13,
+            fontWeight: 600,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            maxWidth: "60%",
+          }}
+        >
+          {run.name ?? "Workflow run"}
+        </span>
+        <Badge tone={statusTone(status)} size="sm">
+          {statusLabel(status)}
+        </Badge>
+      </div>
+      <div
+        style={{
+          color: "var(--text-secondary)",
+          display: "flex",
+          fontSize: 12,
+          gap: 8,
+          flexWrap: "wrap",
+        }}
+      >
+        <span>{repo || "unknown repo"}</span>
+        {run.head_branch && (
+          <span style={{ color: "var(--text-muted)" }}>{run.head_branch}</span>
+        )}
+        <span style={{ color: "var(--text-muted)", marginLeft: "auto" }}>
+          {elapsed}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/pages/Queue/MobileRunDetail.tsx
+++ b/frontend/src/pages/Queue/MobileRunDetail.tsx
@@ -1,0 +1,132 @@
+import { BottomSheet } from "../../primitives/BottomSheet";
+import { TouchButton } from "../../primitives/TouchButton";
+import type { RunDetail } from "./mobileTypes";
+import { runnerName, statusLabel, triggeredBy } from "./mobileTypes";
+
+interface MobileRunDetailProps {
+  selectedRun: RunDetail | null;
+  onClose: () => void;
+  onRerun: (detail: RunDetail) => void;
+  onCancel: (detail: RunDetail) => void;
+  cancelling: Record<string, boolean>;
+  cancelDone: Record<string, boolean>;
+}
+
+export function MobileRunDetail({
+  selectedRun,
+  onClose,
+  onRerun,
+  onCancel,
+  cancelling,
+  cancelDone,
+}: MobileRunDetailProps) {
+  const selectedKey = selectedRun
+    ? `${selectedRun.repo}/${selectedRun.run.id}`
+    : null;
+
+  return (
+    <BottomSheet
+      isOpen={!!selectedRun}
+      onClose={onClose}
+      title={selectedRun?.run.name ?? "Workflow run"}
+    >
+      {selectedRun && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {/* Meta rows */}
+          <div
+            style={{
+              background: "var(--bg-tertiary)",
+              borderRadius: 8,
+              display: "flex",
+              flexDirection: "column",
+              gap: 8,
+              padding: "12px 14px",
+            }}
+          >
+            {[
+              { label: "Repo", value: selectedRun.repo || "-" },
+              { label: "Branch", value: selectedRun.run.head_branch || "-" },
+              { label: "Triggered by", value: triggeredBy(selectedRun.run) },
+              { label: "Runner", value: runnerName(selectedRun.run) },
+              { label: "Elapsed", value: selectedRun.elapsed },
+              { label: "Status", value: statusLabel(selectedRun.status) },
+            ].map(({ label, value }) => (
+              <div
+                key={label}
+                style={{
+                  alignItems: "center",
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span style={{ color: "var(--text-muted)", fontSize: 12 }}>
+                  {label}
+                </span>
+                <span
+                  style={{
+                    color: "var(--text-primary)",
+                    fontSize: 13,
+                    fontWeight: 500,
+                  }}
+                >
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/* Action buttons */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {selectedRun.run.html_url && (
+              <TouchButton
+                aria-label="View run on GitHub"
+                onClick={() => {
+                  window.open(
+                    selectedRun.run.html_url,
+                    "_blank",
+                    "noopener,noreferrer",
+                  );
+                }}
+                variant="default"
+                style={{ minHeight: 48, width: "100%" }}
+              >
+                View on GitHub
+              </TouchButton>
+            )}
+
+            <TouchButton
+              aria-label="Re-run workflow"
+              disabled={
+                !selectedRun.repo || cancelDone[selectedKey!] === true
+              }
+              onClick={() => onRerun(selectedRun)}
+              variant="primary"
+              style={{ minHeight: 48, width: "100%" }}
+            >
+              Re-run
+            </TouchButton>
+
+            {selectedRun.status === "running" && selectedRun.repo && (
+              <TouchButton
+                aria-label="Cancel run"
+                disabled={
+                  cancelling[selectedKey!] === true ||
+                  cancelDone[selectedKey!] === true
+                }
+                onClick={() => onCancel(selectedRun)}
+                variant="danger"
+                style={{ minHeight: 48, width: "100%" }}
+              >
+                {cancelDone[selectedKey!]
+                  ? "Cancelled"
+                  : cancelling[selectedKey!]
+                    ? "Cancelling..."
+                    : "Cancel"}
+              </TouchButton>
+            )}
+          </div>
+        </div>
+      )}
+    </BottomSheet>
+  );
+}

--- a/frontend/src/pages/Queue/mobileTypes.ts
+++ b/frontend/src/pages/Queue/mobileTypes.ts
@@ -1,0 +1,84 @@
+// Shared types and helpers for the Queue mobile view.
+// Extracted from Mobile.tsx to keep that file under the 500-line cap.
+
+export interface WorkflowRun {
+  id: string | number;
+  name?: string;
+  head_branch?: string;
+  html_url?: string;
+  run_started_at?: string;
+  created_at?: string;
+  runner_name?: string;
+  runner?: { name?: string };
+  triggering_actor?: { login?: string };
+  actor?: { login?: string };
+  repository?: { name?: string };
+}
+
+export interface QueueData {
+  in_progress?: WorkflowRun[];
+  queued?: WorkflowRun[];
+  total?: number;
+}
+
+export type FilterValue = "all" | "running" | "queued" | "failed";
+
+export interface RunDetail {
+  run: WorkflowRun;
+  status: FilterValue;
+  repo: string;
+  elapsed: string;
+}
+
+export const FILTER_OPTIONS = [
+  { label: "All", value: "all" },
+  { label: "Running", value: "running" },
+  { label: "Queued", value: "queued" },
+  { label: "Failed", value: "failed" },
+];
+
+export const POLL_INTERVAL_MS = 15_000;
+
+export function formatDuration(seconds: number): string {
+  if (!seconds || seconds < 0) return "-";
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+export function elapsedSeconds(run: WorkflowRun): number {
+  const start = run.run_started_at ?? run.created_at;
+  if (!start) return 0;
+  return Math.round((Date.now() - new Date(start).getTime()) / 1000);
+}
+
+export function elapsedLabel(run: WorkflowRun): string {
+  return formatDuration(elapsedSeconds(run));
+}
+
+export function runRepo(run: WorkflowRun): string {
+  return run.repository?.name ?? "";
+}
+
+export function triggeredBy(run: WorkflowRun): string {
+  return run.triggering_actor?.login ?? run.actor?.login ?? "unknown";
+}
+
+export function runnerName(run: WorkflowRun): string {
+  return run.runner_name ?? run.runner?.name ?? "-";
+}
+
+export function statusTone(
+  status: FilterValue,
+): "warning" | "info" | "danger" | "neutral" {
+  if (status === "running") return "warning";
+  if (status === "queued") return "info";
+  if (status === "failed") return "danger";
+  return "neutral";
+}
+
+export function statusLabel(status: FilterValue): string {
+  if (status === "running") return "running";
+  if (status === "queued") return "queued";
+  if (status === "failed") return "failed";
+  return "unknown";
+}

--- a/frontend/src/pages/Remediation/ActionSheet.tsx
+++ b/frontend/src/pages/Remediation/ActionSheet.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useState } from "react";
+import { Badge } from "../../primitives/Badge";
+import { BottomSheet } from "../../primitives/BottomSheet";
+import { TouchButton } from "../../primitives/TouchButton";
+import type { AgentProvider, ProviderAvailability } from "./mobileTypes";
+import { DEFAULT_PROVIDER_ORDER, getProviderLabel } from "./mobileTypes";
+
+interface ActionSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  itemTitle: string;
+  itemHtmlUrl: string;
+  recommendedProviderId: string;
+  providers: Record<string, AgentProvider>;
+  availability: Record<string, ProviderAvailability>;
+  onDispatch: (providerId: string) => void;
+  dispatching: boolean;
+}
+
+export function ActionSheet({
+  isOpen,
+  onClose,
+  itemTitle,
+  itemHtmlUrl,
+  recommendedProviderId,
+  providers,
+  availability,
+  onDispatch,
+  dispatching,
+}: ActionSheetProps) {
+  const [showAgentPicker, setShowAgentPicker] = useState(false);
+
+  const handleOpenDesktop = useCallback(() => {
+    window.open(itemHtmlUrl, "_blank", "noopener,noreferrer");
+    onClose();
+  }, [itemHtmlUrl, onClose]);
+
+  const sortedProviders = Object.entries(providers)
+    .map(([id, p]) => ({
+      id,
+      label: p.label ?? id,
+      available: availability[id]?.available ?? false,
+    }))
+    .sort((a, b) => {
+      if (a.available !== b.available) return a.available ? -1 : 1;
+      const ai = DEFAULT_PROVIDER_ORDER.indexOf(a.id);
+      const bi = DEFAULT_PROVIDER_ORDER.indexOf(b.id);
+      if (ai !== -1 && bi !== -1) return ai - bi;
+      if (ai !== -1) return -1;
+      if (bi !== -1) return 1;
+      return a.label.localeCompare(b.label);
+    });
+
+  return (
+    <>
+      <BottomSheet
+        isOpen={isOpen && !showAgentPicker}
+        onClose={onClose}
+        title={itemTitle}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <TouchButton
+            aria-label={`Dispatch ${getProviderLabel(providers, recommendedProviderId)} for ${itemTitle}`}
+            disabled={
+              dispatching || !availability[recommendedProviderId]?.available
+            }
+            onClick={() => onDispatch(recommendedProviderId)}
+            variant="primary"
+            style={{ width: "100%", minHeight: 48, fontSize: 15 }}
+          >
+            {dispatching
+              ? "Dispatching..."
+              : `Dispatch ${getProviderLabel(providers, recommendedProviderId)}`}
+          </TouchButton>
+
+          <TouchButton
+            aria-label="Pick a different agent"
+            disabled={dispatching}
+            onClick={() => setShowAgentPicker(true)}
+            variant="default"
+            style={{ width: "100%", minHeight: 48 }}
+          >
+            Pick agent...
+          </TouchButton>
+
+          <TouchButton
+            aria-label="Open on desktop in new tab"
+            onClick={handleOpenDesktop}
+            variant="default"
+            style={{ width: "100%", minHeight: 48 }}
+          >
+            Open on desktop
+          </TouchButton>
+        </div>
+      </BottomSheet>
+
+      <BottomSheet
+        isOpen={isOpen && showAgentPicker}
+        onClose={() => setShowAgentPicker(false)}
+        title="Pick agent"
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {sortedProviders.map(({ id, label, available }) => (
+            <TouchButton
+              key={id}
+              aria-label={`Dispatch ${label}`}
+              disabled={dispatching || !available}
+              onClick={() => {
+                setShowAgentPicker(false);
+                onDispatch(id);
+              }}
+              variant={id === recommendedProviderId ? "primary" : "default"}
+              style={{
+                width: "100%",
+                minHeight: 44,
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+              }}
+            >
+              <span>{label}</span>
+              <Badge tone={available ? "success" : "danger"} size="sm">
+                {available ? "Ready" : "Unavailable"}
+              </Badge>
+            </TouchButton>
+          ))}
+        </div>
+      </BottomSheet>
+    </>
+  );
+}

--- a/frontend/src/pages/Remediation/InFlightTile.tsx
+++ b/frontend/src/pages/Remediation/InFlightTile.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { Badge } from "../../primitives/Badge";
+import type { InFlightDispatch } from "./mobileTypes";
+import { elapsedLabel } from "./mobileTypes";
+
+interface InFlightTileProps {
+  dispatch: InFlightDispatch;
+}
+
+export function InFlightTile({ dispatch }: InFlightTileProps) {
+  const [, forceUpdate] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => forceUpdate((n) => n + 1), 5000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const tone =
+    dispatch.status === "done"
+      ? "success"
+      : dispatch.status === "error"
+        ? "danger"
+        : "info";
+
+  return (
+    <div
+      aria-label={`In-flight dispatch: ${dispatch.itemTitle}`}
+      className="remediation-inflight-tile"
+      role="status"
+      style={{
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border)",
+        borderLeft: "4px solid var(--accent-blue)",
+        borderRadius: 10,
+        marginBottom: 10,
+        padding: "12px 14px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 6,
+        }}
+      >
+        <span
+          style={{
+            color: "var(--text-primary)",
+            fontWeight: 600,
+            fontSize: 13,
+          }}
+        >
+          {dispatch.itemTitle}
+        </span>
+        <Badge tone={tone}>{dispatch.status}</Badge>
+      </div>
+      <div
+        style={{
+          color: "var(--text-secondary)",
+          fontSize: 12,
+          display: "flex",
+          gap: 10,
+          flexWrap: "wrap",
+        }}
+      >
+        <span>Agent: {dispatch.providerLabel}</span>
+        <span>Repo: {dispatch.repository}</span>
+        <span>Elapsed: {elapsedLabel(dispatch.startedAt)}</span>
+        <span>Heartbeat: {elapsedLabel(dispatch.lastHeartbeat)} ago</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Remediation/Mobile.tsx
+++ b/frontend/src/pages/Remediation/Mobile.tsx
@@ -1,293 +1,29 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { SegmentedControl } from "../../primitives/SegmentedControl";
-import { Badge } from "../../primitives/Badge";
 import { TouchButton } from "../../primitives/TouchButton";
 import { SkeletonCard, SkeletonLine } from "../../primitives/Skeleton";
 import { useToast } from "../../primitives/Toaster";
-import { BottomSheet } from "../../primitives/BottomSheet";
 
-// -- Types ---------------------------------------------------------------------
+import { ActionSheet } from "./ActionSheet";
+import { AutomationsList, IssuesList, PRsList } from "./RemediationLists";
+import type {
+  ActionSheetItem,
+  AgentProvider,
+  FailedRun,
+  InFlightDispatch,
+  OpenIssue,
+  OpenPR,
+  ProviderAvailability,
+  RemediationSubtab,
+} from "./mobileTypes";
+import {
+  SUBTAB_OPTIONS,
+  getProviderLabel,
+  pickRecommendedProvider,
+} from "./mobileTypes";
 
-interface AgentProvider {
-  provider_id: string;
-  label: string;
-  execution_mode: string;
-  dispatch_mode: string;
-  notes: string;
-  experimental: boolean;
-  remote: boolean;
-  editable: boolean;
-}
-
-interface ProviderAvailability {
-  provider_id: string;
-  available: boolean;
-  status: string;
-  detail: string;
-}
-
-interface FailedRun {
-  id: number;
-  name: string;
-  workflow_name: string;
-  head_branch: string;
-  conclusion: string;
-  html_url: string;
-  created_at: string;
-  run_number?: number;
-  repository: { name: string; full_name?: string };
-}
-
-interface OpenPR {
-  id: number;
-  number: number;
-  title: string;
-  html_url: string;
-  head: { ref: string };
-  base: { repo: { name: string; full_name?: string } };
-  draft: boolean;
-  labels: Array<{ name: string }>;
-  updated_at: string;
-}
-
-interface OpenIssue {
-  id: number;
-  number: number;
-  title: string;
-  html_url: string;
-  repository_url: string;
-  labels: Array<{ name: string }>;
-  updated_at: string;
-}
-
-type RemediationSubtab = "automations" | "prs" | "issues";
-
-export interface InFlightDispatch {
-  id: string;
-  itemId: number;
-  itemTitle: string;
-  provider: string;
-  providerLabel: string;
-  repository: string;
-  startedAt: number;
-  lastHeartbeat: number;
-  status: "dispatched" | "running" | "done" | "error";
-  fingerprint?: string;
-}
-
-// -- Constants -----------------------------------------------------------------
-
-const SUBTAB_OPTIONS = [
-  { label: "Automations", value: "automations" },
-  { label: "PRs", value: "prs" },
-  { label: "Issues", value: "issues" },
-];
-
-const DEFAULT_PROVIDER_ORDER = [
-  "jules_api",
-  "codex_cli",
-  "claude_code_cli",
-  "gemini_cli",
-  "ollama",
-  "cline",
-];
-
-// -- Helpers -------------------------------------------------------------------
-
-function pickRecommendedProvider(
-  providers: Record<string, AgentProvider>,
-  availability: Record<string, ProviderAvailability>,
-): string {
-  for (const id of DEFAULT_PROVIDER_ORDER) {
-    if (providers[id] && availability[id]?.available) return id;
-  }
-  const first = Object.keys(providers).find((id) => availability[id]?.available);
-  return first ?? "claude_code_cli";
-}
-
-function getProviderLabel(
-  providers: Record<string, AgentProvider>,
-  providerId: string,
-): string {
-  return providers[providerId]?.label ?? providerId;
-}
-
-function elapsedLabel(startedAt: number): string {
-  const secs = Math.floor((Date.now() - startedAt) / 1000);
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ${secs % 60}s`;
-  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
-}
-
-// -- Sub-components ------------------------------------------------------------
-
-interface InFlightTileProps {
-  dispatch: InFlightDispatch;
-}
-
-function InFlightTile({ dispatch }: InFlightTileProps) {
-  const [, forceUpdate] = useState(0);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    intervalRef.current = setInterval(() => forceUpdate((n) => n + 1), 5000);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, []);
-
-  const tone =
-    dispatch.status === "done"
-      ? "success"
-      : dispatch.status === "error"
-      ? "danger"
-      : "info";
-
-  return (
-    <div
-      aria-label={`In-flight dispatch: ${dispatch.itemTitle}`}
-      className="remediation-inflight-tile"
-      role="status"
-      style={{
-        background: "var(--bg-secondary)",
-        border: "1px solid var(--border)",
-        borderLeft: "4px solid var(--accent-blue)",
-        borderRadius: 10,
-        marginBottom: 10,
-        padding: "12px 14px",
-      }}
-    >
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
-        <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
-          {dispatch.itemTitle}
-        </span>
-        <Badge tone={tone}>{dispatch.status}</Badge>
-      </div>
-      <div style={{ color: "var(--text-secondary)", fontSize: 12, display: "flex", gap: 10, flexWrap: "wrap" }}>
-        <span>Agent: {dispatch.providerLabel}</span>
-        <span>Repo: {dispatch.repository}</span>
-        <span>Elapsed: {elapsedLabel(dispatch.startedAt)}</span>
-        <span>Heartbeat: {elapsedLabel(dispatch.lastHeartbeat)} ago</span>
-      </div>
-    </div>
-  );
-}
-
-interface ActionSheetProps {
-  isOpen: boolean;
-  onClose: () => void;
-  itemTitle: string;
-  itemHtmlUrl: string;
-  recommendedProviderId: string;
-  providers: Record<string, AgentProvider>;
-  availability: Record<string, ProviderAvailability>;
-  onDispatch: (providerId: string) => void;
-  dispatching: boolean;
-}
-
-function ActionSheet({
-  isOpen,
-  onClose,
-  itemTitle,
-  itemHtmlUrl,
-  recommendedProviderId,
-  providers,
-  availability,
-  onDispatch,
-  dispatching,
-}: ActionSheetProps) {
-  const [showAgentPicker, setShowAgentPicker] = useState(false);
-
-  const handleOpenDesktop = useCallback(() => {
-    window.open(itemHtmlUrl, "_blank", "noopener,noreferrer");
-    onClose();
-  }, [itemHtmlUrl, onClose]);
-
-  const sortedProviders = Object.entries(providers)
-    .map(([id, p]) => ({
-      id,
-      label: p.label ?? id,
-      available: availability[id]?.available ?? false,
-    }))
-    .sort((a, b) => {
-      if (a.available !== b.available) return a.available ? -1 : 1;
-      const ai = DEFAULT_PROVIDER_ORDER.indexOf(a.id);
-      const bi = DEFAULT_PROVIDER_ORDER.indexOf(b.id);
-      if (ai !== -1 && bi !== -1) return ai - bi;
-      if (ai !== -1) return -1;
-      if (bi !== -1) return 1;
-      return a.label.localeCompare(b.label);
-    });
-
-  return (
-    <>
-      <BottomSheet isOpen={isOpen && !showAgentPicker} onClose={onClose} title={itemTitle}>
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          <TouchButton
-            aria-label={`Dispatch ${getProviderLabel(providers, recommendedProviderId)} for ${itemTitle}`}
-            disabled={dispatching || !(availability[recommendedProviderId]?.available)}
-            onClick={() => onDispatch(recommendedProviderId)}
-            variant="primary"
-            style={{ width: "100%", minHeight: 48, fontSize: 15 }}
-          >
-            {dispatching
-              ? "Dispatching..."
-              : `Dispatch ${getProviderLabel(providers, recommendedProviderId)}`}
-          </TouchButton>
-
-          <TouchButton
-            aria-label="Pick a different agent"
-            disabled={dispatching}
-            onClick={() => setShowAgentPicker(true)}
-            variant="default"
-            style={{ width: "100%", minHeight: 48 }}
-          >
-            Pick agent...
-          </TouchButton>
-
-          <TouchButton
-            aria-label="Open on desktop in new tab"
-            onClick={handleOpenDesktop}
-            variant="default"
-            style={{ width: "100%", minHeight: 48 }}
-          >
-            Open on desktop
-          </TouchButton>
-        </div>
-      </BottomSheet>
-
-      <BottomSheet
-        isOpen={isOpen && showAgentPicker}
-        onClose={() => setShowAgentPicker(false)}
-        title="Pick agent"
-      >
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {sortedProviders.map(({ id, label, available }) => (
-            <TouchButton
-              key={id}
-              aria-label={`Dispatch ${label}`}
-              disabled={dispatching || !available}
-              onClick={() => {
-                setShowAgentPicker(false);
-                onDispatch(id);
-              }}
-              variant={id === recommendedProviderId ? "primary" : "default"}
-              style={{ width: "100%", minHeight: 44, display: "flex", justifyContent: "space-between", alignItems: "center" }}
-            >
-              <span>{label}</span>
-              <Badge tone={available ? "success" : "danger"} size="sm">
-                {available ? "Ready" : "Unavailable"}
-              </Badge>
-            </TouchButton>
-          ))}
-        </div>
-      </BottomSheet>
-    </>
-  );
-}
-
-// -- Main component ------------------------------------------------------------
+// Re-export InFlightDispatch for callers that imported it from this file pre-refactor.
+export type { InFlightDispatch } from "./mobileTypes";
 
 export interface RemediationMobileProps {
   /** In-flight dispatches are kept at parent level for persistence across tab switches. */
@@ -295,27 +31,26 @@ export interface RemediationMobileProps {
   onAddInFlight: (dispatch: InFlightDispatch) => void;
 }
 
-export function RemediationMobile({ inFlightDispatches, onAddInFlight }: RemediationMobileProps) {
+export function RemediationMobile({
+  inFlightDispatches,
+  onAddInFlight,
+}: RemediationMobileProps) {
   const { showToast } = useToast();
 
   const [subtab, setSubtab] = useState<RemediationSubtab>("automations");
   const [providers, setProviders] = useState<Record<string, AgentProvider>>({});
-  const [availability, setAvailability] = useState<Record<string, ProviderAvailability>>({});
+  const [availability, setAvailability] = useState<
+    Record<string, ProviderAvailability>
+  >({});
   const [failedRuns, setFailedRuns] = useState<FailedRun[]>([]);
   const [openPRs, setOpenPRs] = useState<OpenPR[]>([]);
   const [openIssues, setOpenIssues] = useState<OpenIssue[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [actionSheetItem, setActionSheetItem] = useState<{
-    id: number;
-    title: string;
-    htmlUrl: string;
-    repository: string;
-    workflowName?: string;
-    branch?: string;
-    runId?: number;
-  } | null>(null);
+  const [actionSheetItem, setActionSheetItem] = useState<ActionSheetItem | null>(
+    null,
+  );
   const [dispatching, setDispatching] = useState(false);
 
   const recommendedProviderId = pickRecommendedProvider(providers, availability);
@@ -352,10 +87,13 @@ export function RemediationMobile({ inFlightDispatches, onAddInFlight }: Remedia
 
       if (issuesResp.ok) {
         const issuesData = await issuesResp.json();
-        setOpenIssues(Array.isArray(issuesData) ? issuesData : (issuesData.items ?? []));
+        setOpenIssues(
+          Array.isArray(issuesData) ? issuesData : (issuesData.items ?? []),
+        );
       }
     } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : "Failed to load remediation data";
+      const message =
+        e instanceof Error ? e.message : "Failed to load remediation data";
       setError(message);
     } finally {
       setLoading(false);
@@ -411,7 +149,8 @@ export function RemediationMobile({ inFlightDispatches, onAddInFlight }: Remedia
         onAddInFlight(inflight);
 
         showToast(
-          data.note ?? `Dispatched ${getProviderLabel(providers, providerId)} for ${actionSheetItem.title}`,
+          data.note ??
+            `Dispatched ${getProviderLabel(providers, providerId)} for ${actionSheetItem.title}`,
           { variant: "success", title: "Dispatch submitted" },
         );
         setActionSheetItem(null);
@@ -425,205 +164,6 @@ export function RemediationMobile({ inFlightDispatches, onAddInFlight }: Remedia
     [actionSheetItem, providers, onAddInFlight, showToast],
   );
 
-  function renderAutomations() {
-    const inflight = inFlightDispatches.filter((d) => d.status !== "done");
-    return (
-      <>
-        {inflight.map((d) => (
-          <InFlightTile key={d.id} dispatch={d} />
-        ))}
-        {failedRuns.length === 0 ? (
-          <div
-            aria-label="No failed runs"
-            className="remediation-empty"
-            style={{ color: "var(--text-muted)", padding: "32px 0", textAlign: "center" }}
-          >
-            No failed runs found.
-          </div>
-        ) : (
-          failedRuns.map((run) => {
-            const repoName = run.repository?.name ?? "repo";
-            const isInflight = inFlightDispatches.some((d) => d.itemId === run.id);
-            if (isInflight) return null;
-            return (
-              <button
-                key={run.id}
-                aria-label={`Failed run: ${run.name ?? run.workflow_name} in ${repoName}`}
-                className="remediation-card"
-                onClick={() =>
-                  setActionSheetItem({
-                    id: run.id,
-                    title: `${repoName}: ${run.name ?? run.workflow_name}`,
-                    htmlUrl: run.html_url,
-                    repository: repoName,
-                    workflowName: run.workflow_name ?? run.name,
-                    branch: run.head_branch ?? "main",
-                    runId: run.id,
-                  })
-                }
-                style={{
-                  background: "var(--bg-secondary)",
-                  border: "1px solid var(--border)",
-                  borderRadius: 10,
-                  cursor: "pointer",
-                  display: "block",
-                  marginBottom: 10,
-                  padding: "12px 14px",
-                  textAlign: "left",
-                  width: "100%",
-                }}
-                type="button"
-              >
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
-                  <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
-                    {repoName}: {run.name ?? run.workflow_name}
-                  </span>
-                  <Badge tone="danger" size="sm">failure</Badge>
-                </div>
-                <div style={{ color: "var(--text-secondary)", fontSize: 12, marginBottom: 4 }}>
-                  {run.head_branch ?? "main"} · #{run.run_number ?? run.id}
-                </div>
-                <Badge tone="info" size="sm">
-                  Recommended: {getProviderLabel(providers, recommendedProviderId)}
-                </Badge>
-              </button>
-            );
-          })
-        )}
-      </>
-    );
-  }
-
-  function renderPRs() {
-    return (
-      <>
-        {openPRs.length === 0 ? (
-          <div
-            aria-label="No open PRs"
-            className="remediation-empty"
-            style={{ color: "var(--text-muted)", padding: "32px 0", textAlign: "center" }}
-          >
-            No open PRs found.
-          </div>
-        ) : (
-          openPRs.map((pr) => {
-            const repoName = pr.base?.repo?.name ?? "repo";
-            const isInflight = inFlightDispatches.some((d) => d.itemId === pr.id);
-            if (isInflight) return null;
-            return (
-              <button
-                key={pr.id}
-                aria-label={`Open PR: ${pr.title} in ${repoName}`}
-                className="remediation-card"
-                onClick={() =>
-                  setActionSheetItem({
-                    id: pr.id,
-                    title: `PR #${pr.number}: ${pr.title}`,
-                    htmlUrl: pr.html_url,
-                    repository: repoName,
-                    workflowName: "pr-remediation",
-                    branch: pr.head?.ref ?? "main",
-                  })
-                }
-                style={{
-                  background: "var(--bg-secondary)",
-                  border: "1px solid var(--border)",
-                  borderRadius: 10,
-                  cursor: "pointer",
-                  display: "block",
-                  marginBottom: 10,
-                  padding: "12px 14px",
-                  textAlign: "left",
-                  width: "100%",
-                }}
-                type="button"
-              >
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
-                  <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
-                    PR #{pr.number}: {pr.title}
-                  </span>
-                  {pr.draft && <Badge tone="neutral" size="sm">Draft</Badge>}
-                </div>
-                <div style={{ color: "var(--text-secondary)", fontSize: 12, marginBottom: 4 }}>
-                  {repoName} · {pr.head?.ref ?? "unknown branch"}
-                </div>
-                <Badge tone="info" size="sm">
-                  Recommended: {getProviderLabel(providers, recommendedProviderId)}
-                </Badge>
-              </button>
-            );
-          })
-        )}
-      </>
-    );
-  }
-
-  function renderIssues() {
-    return (
-      <>
-        {openIssues.length === 0 ? (
-          <div
-            aria-label="No open issues"
-            className="remediation-empty"
-            style={{ color: "var(--text-muted)", padding: "32px 0", textAlign: "center" }}
-          >
-            No open issues found.
-          </div>
-        ) : (
-          openIssues.map((issue) => {
-            const repoName = issue.repository_url?.split("/").pop() ?? "repo";
-            const isInflight = inFlightDispatches.some((d) => d.itemId === issue.id);
-            if (isInflight) return null;
-            return (
-              <button
-                key={issue.id}
-                aria-label={`Open issue: ${issue.title}`}
-                className="remediation-card"
-                onClick={() =>
-                  setActionSheetItem({
-                    id: issue.id,
-                    title: `Issue #${issue.number}: ${issue.title}`,
-                    htmlUrl: issue.html_url,
-                    repository: repoName,
-                    workflowName: "issue-remediation",
-                    branch: "main",
-                  })
-                }
-                style={{
-                  background: "var(--bg-secondary)",
-                  border: "1px solid var(--border)",
-                  borderRadius: 10,
-                  cursor: "pointer",
-                  display: "block",
-                  marginBottom: 10,
-                  padding: "12px 14px",
-                  textAlign: "left",
-                  width: "100%",
-                }}
-                type="button"
-              >
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
-                  <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 13 }}>
-                    #{issue.number}: {issue.title}
-                  </span>
-                </div>
-                <div style={{ color: "var(--text-secondary)", fontSize: 12, marginBottom: 4 }}>
-                  {repoName}
-                  {issue.labels.length > 0 && (
-                    <> {issue.labels.map((l) => l.name).join(", ")}</>
-                  )}
-                </div>
-                <Badge tone="info" size="sm">
-                  Recommended: {getProviderLabel(providers, recommendedProviderId)}
-                </Badge>
-              </button>
-            );
-          })
-        )}
-      </>
-    );
-  }
-
   if (loading) {
     return (
       <div
@@ -632,7 +172,12 @@ export function RemediationMobile({ inFlightDispatches, onAddInFlight }: Remedia
         aria-live="polite"
         className="remediation-mobile-loading"
         role="status"
-        style={{ padding: "16px", display: "flex", flexDirection: "column", gap: 12 }}
+        style={{
+          padding: "16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+        }}
       >
         <SkeletonLine height={20} width="60%" />
         <SkeletonLine height={36} width="100%" />
@@ -649,7 +194,11 @@ export function RemediationMobile({ inFlightDispatches, onAddInFlight }: Remedia
         aria-live="assertive"
         className="remediation-mobile-error"
         role="alert"
-        style={{ color: "var(--accent-red)", padding: "24px", textAlign: "center" }}
+        style={{
+          color: "var(--accent-red)",
+          padding: "24px",
+          textAlign: "center",
+        }}
       >
         <div style={{ marginBottom: 12 }}>{error}</div>
         <TouchButton onClick={fetchData} variant="primary">
@@ -658,6 +207,13 @@ export function RemediationMobile({ inFlightDispatches, onAddInFlight }: Remedia
       </div>
     );
   }
+
+  const commonListProps = {
+    inFlightDispatches,
+    providers,
+    recommendedProviderId,
+    onSelect: setActionSheetItem,
+  };
 
   return (
     <section
@@ -677,9 +233,15 @@ export function RemediationMobile({ inFlightDispatches, onAddInFlight }: Remedia
         className="remediation-list"
         style={{ marginTop: 14 }}
       >
-        {subtab === "automations" && renderAutomations()}
-        {subtab === "prs" && renderPRs()}
-        {subtab === "issues" && renderIssues()}
+        {subtab === "automations" && (
+          <AutomationsList {...commonListProps} failedRuns={failedRuns} />
+        )}
+        {subtab === "prs" && (
+          <PRsList {...commonListProps} openPRs={openPRs} />
+        )}
+        {subtab === "issues" && (
+          <IssuesList {...commonListProps} openIssues={openIssues} />
+        )}
       </div>
 
       {actionSheetItem && (

--- a/frontend/src/pages/Remediation/RemediationLists.tsx
+++ b/frontend/src/pages/Remediation/RemediationLists.tsx
@@ -1,0 +1,302 @@
+import { Badge } from "../../primitives/Badge";
+import { InFlightTile } from "./InFlightTile";
+import type {
+  ActionSheetItem,
+  AgentProvider,
+  FailedRun,
+  InFlightDispatch,
+  OpenIssue,
+  OpenPR,
+} from "./mobileTypes";
+import { getProviderLabel } from "./mobileTypes";
+
+interface CommonProps {
+  inFlightDispatches: InFlightDispatch[];
+  providers: Record<string, AgentProvider>;
+  recommendedProviderId: string;
+  onSelect: (item: ActionSheetItem) => void;
+}
+
+const CARD_STYLE: React.CSSProperties = {
+  background: "var(--bg-secondary)",
+  border: "1px solid var(--border)",
+  borderRadius: 10,
+  cursor: "pointer",
+  display: "block",
+  marginBottom: 10,
+  padding: "12px 14px",
+  textAlign: "left",
+  width: "100%",
+};
+
+const EMPTY_STYLE: React.CSSProperties = {
+  color: "var(--text-muted)",
+  padding: "32px 0",
+  textAlign: "center",
+};
+
+interface AutomationsListProps extends CommonProps {
+  failedRuns: FailedRun[];
+}
+
+export function AutomationsList({
+  inFlightDispatches,
+  failedRuns,
+  providers,
+  recommendedProviderId,
+  onSelect,
+}: AutomationsListProps) {
+  const inflight = inFlightDispatches.filter((d) => d.status !== "done");
+  return (
+    <>
+      {inflight.map((d) => (
+        <InFlightTile key={d.id} dispatch={d} />
+      ))}
+      {failedRuns.length === 0 ? (
+        <div
+          aria-label="No failed runs"
+          className="remediation-empty"
+          style={EMPTY_STYLE}
+        >
+          No failed runs found.
+        </div>
+      ) : (
+        failedRuns.map((run) => {
+          const repoName = run.repository?.name ?? "repo";
+          const isInflight = inFlightDispatches.some(
+            (d) => d.itemId === run.id,
+          );
+          if (isInflight) return null;
+          return (
+            <button
+              key={run.id}
+              aria-label={`Failed run: ${run.name ?? run.workflow_name} in ${repoName}`}
+              className="remediation-card"
+              onClick={() =>
+                onSelect({
+                  id: run.id,
+                  title: `${repoName}: ${run.name ?? run.workflow_name}`,
+                  htmlUrl: run.html_url,
+                  repository: repoName,
+                  workflowName: run.workflow_name ?? run.name,
+                  branch: run.head_branch ?? "main",
+                  runId: run.id,
+                })
+              }
+              style={CARD_STYLE}
+              type="button"
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  marginBottom: 6,
+                }}
+              >
+                <span
+                  style={{
+                    color: "var(--text-primary)",
+                    fontWeight: 600,
+                    fontSize: 13,
+                  }}
+                >
+                  {repoName}: {run.name ?? run.workflow_name}
+                </span>
+                <Badge tone="danger" size="sm">
+                  failure
+                </Badge>
+              </div>
+              <div
+                style={{
+                  color: "var(--text-secondary)",
+                  fontSize: 12,
+                  marginBottom: 4,
+                }}
+              >
+                {run.head_branch ?? "main"} · #{run.run_number ?? run.id}
+              </div>
+              <Badge tone="info" size="sm">
+                Recommended: {getProviderLabel(providers, recommendedProviderId)}
+              </Badge>
+            </button>
+          );
+        })
+      )}
+    </>
+  );
+}
+
+interface PRsListProps extends CommonProps {
+  openPRs: OpenPR[];
+}
+
+export function PRsList({
+  inFlightDispatches,
+  openPRs,
+  providers,
+  recommendedProviderId,
+  onSelect,
+}: PRsListProps) {
+  return (
+    <>
+      {openPRs.length === 0 ? (
+        <div
+          aria-label="No open PRs"
+          className="remediation-empty"
+          style={EMPTY_STYLE}
+        >
+          No open PRs found.
+        </div>
+      ) : (
+        openPRs.map((pr) => {
+          const repoName = pr.base?.repo?.name ?? "repo";
+          const isInflight = inFlightDispatches.some((d) => d.itemId === pr.id);
+          if (isInflight) return null;
+          return (
+            <button
+              key={pr.id}
+              aria-label={`Open PR: ${pr.title} in ${repoName}`}
+              className="remediation-card"
+              onClick={() =>
+                onSelect({
+                  id: pr.id,
+                  title: `PR #${pr.number}: ${pr.title}`,
+                  htmlUrl: pr.html_url,
+                  repository: repoName,
+                  workflowName: "pr-remediation",
+                  branch: pr.head?.ref ?? "main",
+                })
+              }
+              style={CARD_STYLE}
+              type="button"
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  marginBottom: 6,
+                }}
+              >
+                <span
+                  style={{
+                    color: "var(--text-primary)",
+                    fontWeight: 600,
+                    fontSize: 13,
+                  }}
+                >
+                  PR #{pr.number}: {pr.title}
+                </span>
+                {pr.draft && (
+                  <Badge tone="neutral" size="sm">
+                    Draft
+                  </Badge>
+                )}
+              </div>
+              <div
+                style={{
+                  color: "var(--text-secondary)",
+                  fontSize: 12,
+                  marginBottom: 4,
+                }}
+              >
+                {repoName} · {pr.head?.ref ?? "unknown branch"}
+              </div>
+              <Badge tone="info" size="sm">
+                Recommended: {getProviderLabel(providers, recommendedProviderId)}
+              </Badge>
+            </button>
+          );
+        })
+      )}
+    </>
+  );
+}
+
+interface IssuesListProps extends CommonProps {
+  openIssues: OpenIssue[];
+}
+
+export function IssuesList({
+  inFlightDispatches,
+  openIssues,
+  providers,
+  recommendedProviderId,
+  onSelect,
+}: IssuesListProps) {
+  return (
+    <>
+      {openIssues.length === 0 ? (
+        <div
+          aria-label="No open issues"
+          className="remediation-empty"
+          style={EMPTY_STYLE}
+        >
+          No open issues found.
+        </div>
+      ) : (
+        openIssues.map((issue) => {
+          const repoName = issue.repository_url?.split("/").pop() ?? "repo";
+          const isInflight = inFlightDispatches.some(
+            (d) => d.itemId === issue.id,
+          );
+          if (isInflight) return null;
+          return (
+            <button
+              key={issue.id}
+              aria-label={`Open issue: ${issue.title}`}
+              className="remediation-card"
+              onClick={() =>
+                onSelect({
+                  id: issue.id,
+                  title: `Issue #${issue.number}: ${issue.title}`,
+                  htmlUrl: issue.html_url,
+                  repository: repoName,
+                  workflowName: "issue-remediation",
+                  branch: "main",
+                })
+              }
+              style={CARD_STYLE}
+              type="button"
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  marginBottom: 6,
+                }}
+              >
+                <span
+                  style={{
+                    color: "var(--text-primary)",
+                    fontWeight: 600,
+                    fontSize: 13,
+                  }}
+                >
+                  #{issue.number}: {issue.title}
+                </span>
+              </div>
+              <div
+                style={{
+                  color: "var(--text-secondary)",
+                  fontSize: 12,
+                  marginBottom: 4,
+                }}
+              >
+                {repoName}
+                {issue.labels.length > 0 && (
+                  <> {issue.labels.map((l) => l.name).join(", ")}</>
+                )}
+              </div>
+              <Badge tone="info" size="sm">
+                Recommended: {getProviderLabel(providers, recommendedProviderId)}
+              </Badge>
+            </button>
+          );
+        })
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Remediation/mobileTypes.ts
+++ b/frontend/src/pages/Remediation/mobileTypes.ts
@@ -1,0 +1,122 @@
+// Shared types, constants, and small helpers for the Remediation mobile view.
+// Extracted from Mobile.tsx to keep that file under the 500-line cap.
+
+export interface AgentProvider {
+  provider_id: string;
+  label: string;
+  execution_mode: string;
+  dispatch_mode: string;
+  notes: string;
+  experimental: boolean;
+  remote: boolean;
+  editable: boolean;
+}
+
+export interface ProviderAvailability {
+  provider_id: string;
+  available: boolean;
+  status: string;
+  detail: string;
+}
+
+export interface FailedRun {
+  id: number;
+  name: string;
+  workflow_name: string;
+  head_branch: string;
+  conclusion: string;
+  html_url: string;
+  created_at: string;
+  run_number?: number;
+  repository: { name: string; full_name?: string };
+}
+
+export interface OpenPR {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  head: { ref: string };
+  base: { repo: { name: string; full_name?: string } };
+  draft: boolean;
+  labels: Array<{ name: string }>;
+  updated_at: string;
+}
+
+export interface OpenIssue {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  repository_url: string;
+  labels: Array<{ name: string }>;
+  updated_at: string;
+}
+
+export type RemediationSubtab = "automations" | "prs" | "issues";
+
+export interface InFlightDispatch {
+  id: string;
+  itemId: number;
+  itemTitle: string;
+  provider: string;
+  providerLabel: string;
+  repository: string;
+  startedAt: number;
+  lastHeartbeat: number;
+  status: "dispatched" | "running" | "done" | "error";
+  fingerprint?: string;
+}
+
+export interface ActionSheetItem {
+  id: number;
+  title: string;
+  htmlUrl: string;
+  repository: string;
+  workflowName?: string;
+  branch?: string;
+  runId?: number;
+}
+
+export const SUBTAB_OPTIONS = [
+  { label: "Automations", value: "automations" },
+  { label: "PRs", value: "prs" },
+  { label: "Issues", value: "issues" },
+];
+
+export const DEFAULT_PROVIDER_ORDER = [
+  "jules_api",
+  "codex_cli",
+  "claude_code_cli",
+  "gemini_cli",
+  "ollama",
+  "cline",
+];
+
+export function pickRecommendedProvider(
+  providers: Record<string, AgentProvider>,
+  availability: Record<string, ProviderAvailability>,
+): string {
+  for (const id of DEFAULT_PROVIDER_ORDER) {
+    if (providers[id] && availability[id]?.available) return id;
+  }
+  const first = Object.keys(providers).find(
+    (id) => availability[id]?.available,
+  );
+  return first ?? "claude_code_cli";
+}
+
+export function getProviderLabel(
+  providers: Record<string, AgentProvider>,
+  providerId: string,
+): string {
+  return providers[providerId]?.label ?? providerId;
+}
+
+export function elapsedLabel(startedAt: number): string {
+  const secs = Math.floor((Date.now() - startedAt) / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ${secs % 60}s`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}


### PR DESCRIPTION
## Summary

Phase 5B CI audit identified Runner_Dashboard as RED on main because
`file-size-budget` (`.github/workflows/ci-standard.yml` line 100) enforces
a 500-line soft cap that these 5 files exceeded:

| File | Before | After (main) | Sub-components extracted |
|---|---|---|---|
| `frontend/src/pages/Maxwell/Mobile.tsx` | 901 | 399 | `mobileTypes`, `TaskCard`, `ChatBubble`, `MaxwellStatusHeader`, `MaxwellTasks`, `MaxwellChat`, `MaxwellControlSheet` |
| `frontend/src/pages/Credentials/Mobile.tsx` | 812 | 386 | `mobileTypes`, `CredentialCard`, `CredentialActionSheet`, `LockScreen` |
| `frontend/src/pages/Remediation/Mobile.tsx` | 700 | 262 | `mobileTypes`, `InFlightTile`, `ActionSheet`, `RemediationLists` |
| `frontend/src/pages/Queue/Mobile.tsx` | 565 | 304 | `mobileTypes`, `MobileRunCard`, `MobileRunDetail` |
| `backend/routers/repos.py` | 505 | 414 | `repos_stats.py` (extracted `/api/stats`, `/api/usage`) |

Each main file is now well under 500 lines, and every new sibling file is also under 500. No non-exempt source file exceeds the cap.

## Approach

- **Pure refactoring** — no functionality changes, no API changes, no test changes.
- **Public exports preserved** — `MaxwellMobile`, `CredentialsMobile`, `RemediationMobile`, `InFlightDispatch`, `QueueMobile`, and `repos.router` all keep their original import paths.
- **One commit per file** — each refactor is reviewable in isolation.
- **Backend pattern**: `repos.py` re-includes `stats_router` from `repos_stats.py` so `server.py` still registers a single router, and dependency injection still flows through `repos.set_dependencies`.

## Test plan

- [ ] CI `file-size-budget` step passes (was the blocker)
- [ ] CI `quality-gate` (ruff + ruff-format + mypy) passes
- [ ] Existing vitest tests for the 4 mobile views pass without modification (imports unchanged)
- [ ] Backend pytest suite passes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>