### PR TITLE
fix(deploy): widen ReadWritePaths for new ReplayStore paths + document EROFS triage

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -378,7 +378,15 @@ app.add_middleware(_prometheus_metrics_router.PrometheusMiddleware)
 from replay_store import ReplayStore, migrate_json_to_sqlite  # noqa: E402
 
 _PROCESSED_ENVELOPES_PATH = Path.home() / "actions-runners" / "dashboard" / "processed_envelopes.json"
-_REPLAY_STORE_PATH = Path.home() / "actions-runners" / "dashboard" / "replay.db"
+# Path is overridable via RUNNER_DASHBOARD_REPLAY_DB so operators with
+# constrained systemd sandboxes (ProtectHome=read-only) can relocate the DB
+# to any directory in their ReadWritePaths list without editing this file.
+_REPLAY_STORE_PATH = Path(
+    os.environ.get(
+        "RUNNER_DASHBOARD_REPLAY_DB",
+        str(Path.home() / "actions-runners" / "dashboard" / "replay.db"),
+    )
+)
 _replay_store: ReplayStore = ReplayStore(_REPLAY_STORE_PATH)
 
 # One-shot migration: import any live entries from the legacy JSON file.

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -62,7 +62,9 @@ _integrity_status() {
 
 if [[ "$LIST_ONLY" == "true" ]]; then
     info "Available backups for $DEPLOY_DIR:"
-    backups=$(ls -d "${DEPLOY_DIR}.bak."* 2>/dev/null | sort -r || true)
+    # fix: ls -d also matches *.manifest.sha256 files, which then fail the
+    # require_dir check downstream. find -type d is the correct filter.
+    backups=$(find "$(dirname "$DEPLOY_DIR")" -maxdepth 1 -type d -name "$(basename "$DEPLOY_DIR").bak.*" 2>/dev/null | sort -r || true)
     if [[ -z "$backups" ]]; then
         warn "No backups found for $DEPLOY_DIR"
         exit 0
@@ -87,7 +89,7 @@ fi
 # ─── Select backup ────────────────────────────────────────────────────────────
 
 if [[ -z "$BACKUP_PATH" ]]; then
-    BACKUP_PATH=$(ls -d "${DEPLOY_DIR}.bak."* 2>/dev/null | sort -r | head -1 || true)
+    BACKUP_PATH=$(find "$(dirname "$DEPLOY_DIR")" -maxdepth 1 -type d -name "$(basename "$DEPLOY_DIR").bak.*" 2>/dev/null | sort -r | head -1 || true)
     [[ -n "$BACKUP_PATH" ]] || fail "No backup found. Run update-deployed.sh first."
     info "Auto-selected: $BACKUP_PATH"
 fi

--- a/deploy/runner-dashboard.service
+++ b/deploy/runner-dashboard.service
@@ -80,6 +80,12 @@ TasksMax=512
 WatchdogSec=120
 # Allow the dashboard to read/write runner secrets and config from HOME.
 ReadWritePaths=/home/YOUR_USER/.config/runner-dashboard
+# ReplayStore SQLite locations introduced in #344 (issue #243 also writes
+# under .local/share). Both paths must be on this list, or the service
+# crash-loops at module import with OSError [Errno 30] Read-only file
+# system. See docs/deployment-model.md "systemd Sandboxing".
+ReadWritePaths=/home/YOUR_USER/.local/share/runner-dashboard
+ReadWritePaths=/home/YOUR_USER/actions-runners/dashboard
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/deployment-model.md
+++ b/docs/deployment-model.md
@@ -196,6 +196,58 @@ at service start. The file is owned by the runner user with mode `0600`.
 
 ---
 
+## systemd Sandboxing
+
+The installed unit (`/etc/systemd/system/runner-dashboard.service`) is
+hardened with `ProtectHome=read-only`, which makes the entire `$HOME` tree
+read-only from the service's point of view, with exceptions allowed only via
+explicit `ReadWritePaths=` entries.
+
+The current canonical list of paths the service must be able to write:
+
+| Path | Why it must be writable |
+|---|---|
+| `~/.config/runner-dashboard/` | Token cache, session secret, scheduler config, env file |
+| `~/.local/share/runner-dashboard/` | SQLite replay store for the Linear webhook receiver (issue #243) |
+| `~/actions-runners/dashboard/` | SQLite replay store for dispatch envelopes (issue #344), push-subscription DB, orchestration audit log |
+
+These paths are baked into `deploy/runner-dashboard.service`, the template
+that `setup.sh` substitutes per machine. **If you upgraded an existing
+deployment whose installed unit was generated before this list was extended,
+re-run `bash deploy/setup.sh ...` to regenerate the unit.** The unit is not
+patched in place; it is regenerated from the template.
+
+### Diagnosis: `EROFS` at startup
+
+If the service crash-loops with a Python traceback ending in:
+
+```
+OSError: [Errno 30] Read-only file system: '/home/<user>/.local/share/runner-dashboard'
+```
+
+(or any other path under `$HOME`), this is **not** a filesystem-permissions
+issue. It is the systemd sandbox refusing the write because the path is not
+on the `ReadWritePaths=` list. See
+[`docs/runbooks/dashboard-down.md` § "EROFS at startup"](runbooks/dashboard-down.md#pattern-erofs--read-only-filesystem-at-startup)
+for the full triage and the per-host drop-in workaround.
+
+### Overriding replay-store paths
+
+Both `ReplayStore` instances respect environment variables for their
+database location, so an operator on a fleet machine with a constrained
+sandbox policy can move them onto an already-allowlisted path without
+editing the unit file:
+
+| Variable | Default | Used by |
+|---|---|---|
+| `RUNNER_DASHBOARD_REPLAY_DB` | `~/actions-runners/dashboard/replay.db` | dispatch envelope replay store (`backend/server.py`) |
+| `LINEAR_WEBHOOK_REPLAY_DB` | `~/.local/share/runner-dashboard/linear_webhook_replay.db` | Linear webhook replay store (`backend/routers/linear_webhook.py`) |
+
+Set these in `~/.config/runner-dashboard/env` (which is loaded by systemd at
+service start) to point both DBs at a single writable directory.
+
+---
+
 ## Token Refresh
 
 GitHub PATs expire. When the dashboard reports `github_api: disconnected`, refresh

--- a/docs/runbooks/dashboard-down.md
+++ b/docs/runbooks/dashboard-down.md
@@ -95,6 +95,59 @@ After mitigation, investigate the **root cause** before closing:
   cron; restore it if the cron entry was lost.
 - File a postmortem.
 
+## Pattern: EROFS / Read-only filesystem at startup
+
+A specific class of crash-loop deserves callout because the surface error
+message is misleading. If `journalctl -u runner-dashboard -n 100 --no-pager`
+shows:
+
+```
+OSError: [Errno 30] Read-only file system: '/home/<user>/.local/share/runner-dashboard'
+```
+
+(or any other path under `$HOME`), this is **not** a filesystem-permissions
+problem on the directory itself. The systemd sandbox sets
+`ProtectHome=read-only`, which makes `$HOME` read-only from the service's
+view except for explicit `ReadWritePaths=` entries. New code paths that
+write to home directories outside that allowlist hit `EROFS`, even if the
+target directory is mode `0755` and owned by the service user.
+
+### Quick triage
+
+```bash
+# 1. Identify which path the service is failing to write.
+journalctl -u runner-dashboard -n 100 --no-pager | grep -B2 -i "Read-only file system"
+
+# 2. Compare against the installed unit's ReadWritePaths.
+sudo grep -nE 'ReadWritePaths|ProtectHome' \
+    /etc/systemd/system/runner-dashboard.service \
+    /etc/systemd/system/runner-dashboard.service.d/*.conf 2>/dev/null
+```
+
+### Quick fix (per-host, drop-in — survives `setup.sh` re-runs)
+
+```bash
+sudo mkdir -p /etc/systemd/system/runner-dashboard.service.d
+sudo tee /etc/systemd/system/runner-dashboard.service.d/99-rw-paths.conf <<EOF
+[Service]
+ReadWritePaths=/home/$USER/.local/share/runner-dashboard
+ReadWritePaths=/home/$USER/actions-runners/dashboard
+EOF
+sudo systemctl daemon-reload
+sudo systemctl restart runner-dashboard
+```
+
+Drop-ins are layered additively on top of the main unit; they survive a
+`setup.sh` re-install of the main unit file.
+
+### Permanent fix
+
+The deploy template (`deploy/runner-dashboard.service`) carries the canonical
+`ReadWritePaths=` list. New code that writes to a path not on the list
+should land alongside an update to the template. See
+[`docs/deployment-model.md` § "systemd Sandboxing"](../deployment-model.md#systemd-sandboxing)
+for the current list.
+
 ## Postmortem Template
 
 [`postmortem-template.md`](./postmortem-template.md)


### PR DESCRIPTION
## Summary

Restores the deploy template to a state where it doesn't crash-loop on first
boot after the post-#344 main is shipped to a host with a hardened systemd
unit. Also documents the systemd sandbox so future write-path additions are
caught at PR review.

## Root cause

The installed systemd unit sets `ProtectHome=read-only` and lists exactly one
`ReadWritePaths=` entry (`~/.config/runner-dashboard`). After the recent
refactor, two `ReplayStore` instances are constructed at module-import time:

- `backend/server.py:381` mkdir's `~/actions-runners/dashboard/replay.db`
- `backend/routers/linear_webhook.py:54` mkdir's `~/.local/share/runner-dashboard/linear_webhook_replay.db`

Both fail with `OSError [Errno 30] Read-only file system` before the FastAPI
app is even constructed. Net effect: any fresh-from-main `setup.sh` install
on the current template crashes the service at startup.

## Changes

### Code

| File | Change |
|---|---|
| `deploy/runner-dashboard.service` | Add `ReadWritePaths=` entries for the two new locations. |
| `backend/server.py` | Make `_REPLAY_STORE_PATH` honour the `RUNNER_DASHBOARD_REPLAY_DB` env var (default unchanged), mirroring `LINEAR_WEBHOOK_REPLAY_DB`. |
| `deploy/rollback.sh` | Fix two `ls -d "${DEPLOY_DIR}.bak."*` globs that picked up `*.manifest.sha256` files as candidate backup directories. Replaced with `find -maxdepth 1 -type d`. |

### Documentation

| File | Change |
|---|---|
| `docs/deployment-model.md` | New "systemd Sandboxing" section listing canonical `ReadWritePaths=` and the override env vars. |
| `docs/runbooks/dashboard-down.md` | New "EROFS at startup" triage section with a per-host drop-in workaround. |

## Verification

Tested on OGLaptop:

1. Reproduced the crash by deploying current main on top of an installed unit that lacked the new paths — `journalctl` showed `OSError [Errno 30] EROFS` on `replay_store.py:41` at module import.
2. Installed a `/etc/systemd/system/runner-dashboard.service.d/99-replay-paths.conf` drop-in mirroring the lines this PR adds to the template.
3. Re-ran `deploy/update-deployed.sh`; `/api/health` returned 200 on the first verify attempt.
4. Validated the rollback.sh fix by listing backups in a deploy dir with sibling `.manifest.sha256` files — `find -type d` correctly filters.

## Risk

Low. Three of the changes are pure additions (new `ReadWritePaths=` lines, new env-var fallback, new docs). The `rollback.sh` change preserves existing behavior on directories and only filters out the previously-mis-selected `.manifest.sha256` files.

## Related

- Companion PR in `Repository_Management` will land the fleet-wide deployment-guide update once this is merged.
- Worth filing a separate issue to enforce a `ReadWritePaths` lint at PR time so future `Path.home()` writes are caught before they reach production.
