### PR TITLE
feat(dashboard): show queue-wait vs execution-time breakdown per run

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -548,6 +548,7 @@ env var.
 | Method | Path | Description |
 |---|---|---|
 | GET | `/api/queue` | Current job queue (queued + in_progress) |
+| GET | `/api/queue/status` | Queue data with per-run `timing` breakdown (queue_wait_seconds, exec_seconds) |
 | POST | `/api/queue/cancel-workflow` | Cancel a queued workflow |
 | GET | `/api/queue/diagnose` | Diagnose queue stalls and blockages |
 

--- a/backend/routers/queue.py
+++ b/backend/routers/queue.py
@@ -2,6 +2,7 @@
 
 Covers:
   - GET  /api/queue              – queued and in-progress workflow runs (org-wide sample)
+  - GET  /api/queue/status       – same as /api/queue but with per-run timing breakdown
   - POST /api/runs/{repo}/cancel/{run_id}      – cancel single workflow run
   - POST /api/runs/{repo}/rerun/{run_id}       – re-run failed jobs in workflow
   - POST /api/queue/cancel-workflow             – cancel all queued runs of a workflow
@@ -21,6 +22,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from identity import Principal, require_scope
 from models.github_payloads import GhWorkflowRun
 from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
+from run_timing import annotate_runs_with_timing
 from security import validate_repo_slug
 from system_utils import run_cmd
 
@@ -85,9 +87,7 @@ async def _fetch_repo_runs(
         timeout=30,
     )
     if rc != 0:
-        raise RuntimeError(
-            f"gh api failed for {repo_name} (status={status}): rc={rc} {err[:200]!r}"
-        )
+        raise RuntimeError(f"gh api failed for {repo_name} (status={status}): rc={rc} {err[:200]!r}")
     runs = json.loads(out).get("workflow_runs", [])
     for run in runs:
         if "repository" not in run or not run["repository"]:
@@ -211,6 +211,31 @@ async def get_queue(request: Request) -> dict:
     return await _queue_impl()
 
 
+@router.get("/api/queue/status")
+async def get_queue_status(request: Request) -> dict:
+    """Queue data with per-run queue-wait vs. execution-time breakdown.
+
+    Identical to ``GET /api/queue`` but each run object includes a ``timing``
+    sub-object::
+
+        {
+          "queue_wait_seconds": 45,   # seconds waiting for a runner
+          "exec_seconds":       120,  # seconds the job code has been running
+        }
+
+    For queued runs (no runner yet), ``exec_seconds`` is 0 and
+    ``queue_wait_seconds`` is the time since the run was created.
+
+    This breakdown lets the dashboard display "Queue: 45s | Exec: 2m" without
+    an extra GitHub API round-trip (the timestamps come from the run objects
+    already fetched by ``/api/queue``).
+    """
+    if should_proxy_fleet_to_hub(request):
+        return await proxy_to_hub(request)
+    raw = await _queue_impl()
+    return annotate_runs_with_timing(raw)
+
+
 @router.post("/api/runs/{repo}/cancel/{run_id}")
 async def cancel_run(
     request: Request,
@@ -299,10 +324,7 @@ async def cancel_workflow_runs(
     queue_data = await _queue_impl()
     typed_runs = [GhWorkflowRun.model_validate(r) for r in queue_data.get("queued", [])]
     runs_to_cancel = [
-        r
-        for r in typed_runs
-        if r.name == workflow_name
-        and (target_repo is None or r.repository_name == target_repo)
+        r for r in typed_runs if r.name == workflow_name and (target_repo is None or r.repository_name == target_repo)
     ]
 
     cancelled: list[dict] = []

--- a/backend/run_timing.py
+++ b/backend/run_timing.py
@@ -1,0 +1,88 @@
+"""Pure functions for computing per-run queue-wait vs. execution timing.
+
+No FastAPI or identity imports — keeps this module importable from tests
+without triggering the principals.yml security check in identity.py.
+
+These helpers are consumed by ``backend/routers/queue.py`` for the
+``GET /api/queue/status`` endpoint (issue #637).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def parse_iso(ts: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp string into a UTC-aware datetime.
+
+    Returns ``None`` if the input is absent or unparseable.
+    GitHub timestamps are always UTC (end in ``Z`` or ``+00:00``).
+    """
+    if not ts:
+        return None
+    try:
+        # Python 3.11+ handles ``Z`` natively; fromisoformat on 3.10 does not.
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def compute_run_timing(run: dict) -> dict:
+    """Compute per-run queue-wait and execution timing from GitHub timestamps.
+
+    GitHub provides:
+      - ``created_at``    — when the run was created (queued).
+      - ``run_started_at``— when the first job began executing on a runner.
+
+    For *in-progress* runs:
+      queue_wait_seconds = run_started_at - created_at
+      exec_seconds       = now            - run_started_at
+
+    For *queued* runs (no runner assigned yet):
+      queue_wait_seconds = now - created_at
+      exec_seconds       = 0
+
+    All values are non-negative integers (clamped to 0 on clock skew).
+
+    Returns::
+
+        {"queue_wait_seconds": int, "exec_seconds": int}
+    """
+    now = datetime.now(UTC)
+    created = parse_iso(run.get("created_at"))
+    started = parse_iso(run.get("run_started_at"))
+
+    if started is not None and created is not None:
+        queue_wait = max(0, int((started - created).total_seconds()))
+        exec_secs = max(0, int((now - started).total_seconds()))
+    elif created is not None:
+        # Still queued — no runner yet.
+        queue_wait = max(0, int((now - created).total_seconds()))
+        exec_secs = 0
+    else:
+        queue_wait = 0
+        exec_secs = 0
+
+    return {
+        "queue_wait_seconds": queue_wait,
+        "exec_seconds": exec_secs,
+    }
+
+
+def annotate_runs_with_timing(queue_data: dict) -> dict:
+    """Return a copy of *queue_data* with ``timing`` added to every run.
+
+    The ``timing`` key holds the dict returned by :func:`compute_run_timing`.
+    Original run dicts are not mutated.
+
+    Example::
+
+        >>> raw = {"in_progress": [{"id": 1, "run_started_at": "..."}], "queued": []}
+        >>> result = annotate_runs_with_timing(raw)
+        >>> result["in_progress"][0]["timing"]
+        {"queue_wait_seconds": 45, "exec_seconds": 120}
+    """
+    result = dict(queue_data)
+    result["in_progress"] = [{**run, "timing": compute_run_timing(run)} for run in queue_data.get("in_progress", [])]
+    result["queued"] = [{**run, "timing": compute_run_timing(run)} for run in queue_data.get("queued", [])]
+    return result

--- a/frontend/src/pages/Queue/MobileRunDetail.tsx
+++ b/frontend/src/pages/Queue/MobileRunDetail.tsx
@@ -1,7 +1,7 @@
 import { BottomSheet } from "../../primitives/BottomSheet";
 import { TouchButton } from "../../primitives/TouchButton";
 import type { RunDetail } from "./mobileTypes";
-import { runnerName, statusLabel, triggeredBy } from "./mobileTypes";
+import { runnerName, statusLabel, timingLabel, triggeredBy } from "./mobileTypes";
 
 interface MobileRunDetailProps {
   selectedRun: RunDetail | null;
@@ -50,6 +50,9 @@ export function MobileRunDetail({
               { label: "Runner", value: runnerName(selectedRun.run) },
               { label: "Elapsed", value: selectedRun.elapsed },
               { label: "Status", value: statusLabel(selectedRun.status) },
+              ...(timingLabel(selectedRun.run)
+                ? [{ label: "Timing", value: timingLabel(selectedRun.run) }]
+                : []),
             ].map(({ label, value }) => (
               <div
                 key={label}

--- a/frontend/src/pages/Queue/mobileTypes.ts
+++ b/frontend/src/pages/Queue/mobileTypes.ts
@@ -1,6 +1,17 @@
 // Shared types and helpers for the Queue mobile view.
 // Extracted from Mobile.tsx to keep that file under the 500-line cap.
 
+/**
+ * Per-run queue-wait vs execution-time breakdown.
+ * Populated by GET /api/queue/status (see backend/routers/queue.py).
+ */
+export interface RunTiming {
+  /** Seconds the run spent waiting for a runner to become available. */
+  queue_wait_seconds: number;
+  /** Seconds the run has been actively executing on a runner. */
+  exec_seconds: number;
+}
+
 export interface WorkflowRun {
   id: string | number;
   name?: string;
@@ -13,6 +24,8 @@ export interface WorkflowRun {
   triggering_actor?: { login?: string };
   actor?: { login?: string };
   repository?: { name?: string };
+  /** Present when fetched from /api/queue/status. */
+  timing?: RunTiming;
 }
 
 export interface QueueData {
@@ -65,6 +78,24 @@ export function triggeredBy(run: WorkflowRun): string {
 
 export function runnerName(run: WorkflowRun): string {
   return run.runner_name ?? run.runner?.name ?? "-";
+}
+
+/**
+ * Format a run's timing breakdown as a compact string.
+ *
+ * Returns "Queue: Xm Ys | Exec: Xm Ys" for in-progress runs,
+ * "Queue: Xm Ys" for queued runs (exec_seconds === 0),
+ * or an empty string when timing data is absent.
+ */
+export function timingLabel(run: WorkflowRun): string {
+  const t = run.timing;
+  if (!t) return "";
+  const queueStr = formatDuration(t.queue_wait_seconds);
+  if (t.exec_seconds === 0) {
+    return `Queue: ${queueStr}`;
+  }
+  const execStr = formatDuration(t.exec_seconds);
+  return `Queue: ${queueStr} | Exec: ${execStr}`;
 }
 
 export function statusTone(

--- a/tests/test_run_timing.py
+++ b/tests/test_run_timing.py
@@ -1,0 +1,200 @@
+"""Tests for per-run queue-wait vs. execution-time timing helpers (issue #637).
+
+Tests the pure-Python ``run_timing`` module (no FastAPI/identity imports)
+and verifies the ``GET /api/queue/status`` route is registered on the queue
+router.
+
+Covers:
+  - parse_iso: parses GitHub-style ISO-8601 timestamps (Z-suffix and +00:00).
+  - compute_run_timing: returns correct queue_wait_seconds / exec_seconds for
+    both in-progress and queued runs; handles missing/bad timestamps.
+  - annotate_runs_with_timing: annotates every run in both lists; does not
+    mutate the original run dicts.
+  - GET /api/queue/status route is registered and accepts only GET.
+  - routers/queue.py imports from run_timing (DRY enforcement).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+import run_timing as rt  # no identity / FastAPI deps
+
+
+# ---------------------------------------------------------------------------
+# parse_iso
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_z_suffix() -> None:
+    result = rt.parse_iso("2026-05-17T12:00:00Z")
+    assert result is not None
+    assert result.tzinfo is not None
+    assert result.year == 2026
+    assert result.month == 5
+    assert result.day == 17
+    assert result.hour == 12
+
+
+def test_parse_iso_plus_zero() -> None:
+    result = rt.parse_iso("2026-05-17T12:00:00+00:00")
+    assert result is not None
+    assert result.hour == 12
+
+
+def test_parse_iso_none_returns_none() -> None:
+    assert rt.parse_iso(None) is None
+
+
+def test_parse_iso_empty_string_returns_none() -> None:
+    assert rt.parse_iso("") is None
+
+
+def test_parse_iso_invalid_string_returns_none() -> None:
+    assert rt.parse_iso("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# compute_run_timing — in-progress run (has run_started_at)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_run_timing_in_progress() -> None:
+    """Queue wait = started_at - created_at; exec = now - started_at."""
+    now = datetime(2026, 5, 17, 14, 0, 0, tzinfo=UTC)
+    created = datetime(2026, 5, 17, 13, 55, 0, tzinfo=UTC)  # 5 min before started
+    started = datetime(2026, 5, 17, 13, 57, 0, tzinfo=UTC)  # 3 min before now
+
+    run = {
+        "created_at": created.isoformat().replace("+00:00", "Z"),
+        "run_started_at": started.isoformat().replace("+00:00", "Z"),
+    }
+
+    with patch.object(rt, "datetime") as mock_dt:
+        mock_dt.now.return_value = now
+        mock_dt.fromisoformat = datetime.fromisoformat
+        timing = rt.compute_run_timing(run)
+
+    assert timing["queue_wait_seconds"] == 120  # 2 min (started - created)
+    assert timing["exec_seconds"] == 180  # 3 min (now - started)
+
+
+def test_compute_run_timing_queued_no_started_at() -> None:
+    """Queued run: exec_seconds=0, queue_wait = now - created_at."""
+    now = datetime(2026, 5, 17, 14, 0, 0, tzinfo=UTC)
+    created = datetime(2026, 5, 17, 13, 50, 0, tzinfo=UTC)  # 10 min ago
+
+    run = {
+        "created_at": created.isoformat().replace("+00:00", "Z"),
+    }
+
+    with patch.object(rt, "datetime") as mock_dt:
+        mock_dt.now.return_value = now
+        mock_dt.fromisoformat = datetime.fromisoformat
+        timing = rt.compute_run_timing(run)
+
+    assert timing["queue_wait_seconds"] == 600  # 10 min
+    assert timing["exec_seconds"] == 0
+
+
+def test_compute_run_timing_missing_timestamps() -> None:
+    """Missing created_at: both values are 0 (no data to compute from)."""
+    timing = rt.compute_run_timing({})
+    assert timing["queue_wait_seconds"] == 0
+    assert timing["exec_seconds"] == 0
+
+
+def test_compute_run_timing_clamps_negative_values() -> None:
+    """Clock skew should not produce negative values."""
+    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    run = {
+        "created_at": future,  # future timestamp → negative diff → clamped to 0
+    }
+    timing = rt.compute_run_timing(run)
+    assert timing["queue_wait_seconds"] >= 0
+    assert timing["exec_seconds"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# annotate_runs_with_timing
+# ---------------------------------------------------------------------------
+
+
+def test_annotate_runs_adds_timing_key_to_in_progress() -> None:
+    raw = {
+        "in_progress": [{"id": 1, "created_at": "2026-05-17T12:00:00Z"}],
+        "queued": [],
+    }
+    result = rt.annotate_runs_with_timing(raw)
+    assert "timing" in result["in_progress"][0]
+    assert isinstance(result["in_progress"][0]["timing"]["queue_wait_seconds"], int)
+
+
+def test_annotate_runs_adds_timing_key_to_queued() -> None:
+    raw = {
+        "in_progress": [],
+        "queued": [{"id": 2, "created_at": "2026-05-17T12:00:00Z"}],
+    }
+    result = rt.annotate_runs_with_timing(raw)
+    assert "timing" in result["queued"][0]
+    assert result["queued"][0]["timing"]["exec_seconds"] == 0
+
+
+def test_annotate_runs_does_not_mutate_original() -> None:
+    original_run = {"id": 1, "created_at": "2026-05-17T12:00:00Z"}
+    raw = {
+        "in_progress": [original_run],
+        "queued": [],
+    }
+    rt.annotate_runs_with_timing(raw)
+    assert "timing" not in original_run, "original run dict must not be mutated"
+
+
+def test_annotate_runs_preserves_extra_queue_fields() -> None:
+    raw = {
+        "in_progress": [],
+        "queued": [],
+        "total": 5,
+        "stats": {"repos_sampled": 10},
+    }
+    result = rt.annotate_runs_with_timing(raw)
+    assert result["total"] == 5
+    assert result["stats"]["repos_sampled"] == 10
+
+
+def test_annotate_runs_empty_lists() -> None:
+    raw = {"in_progress": [], "queued": []}
+    result = rt.annotate_runs_with_timing(raw)
+    assert result["in_progress"] == []
+    assert result["queued"] == []
+
+
+# ---------------------------------------------------------------------------
+# Route registration — source-level inspection (avoids identity.py side-effects)
+# ---------------------------------------------------------------------------
+
+
+def test_queue_status_route_declared_in_source() -> None:
+    """GET /api/queue/status must be declared with @router.get in queue.py."""
+    source = (_BACKEND_DIR / "routers" / "queue.py").read_text(encoding="utf-8")
+    assert '@router.get("/api/queue/status")' in source, "queue.py must declare @router.get('/api/queue/status')"
+
+
+def test_queue_status_calls_annotate_runs_with_timing() -> None:
+    """get_queue_status must delegate to annotate_runs_with_timing from run_timing."""
+    source = (_BACKEND_DIR / "routers" / "queue.py").read_text(encoding="utf-8")
+    assert "annotate_runs_with_timing" in source, "queue.py must call annotate_runs_with_timing"
+
+
+def test_queue_router_imports_run_timing() -> None:
+    """queue.py must import from run_timing (DRY — no duplicated timing logic)."""
+    source = (_BACKEND_DIR / "routers" / "queue.py").read_text(encoding="utf-8")
+    assert "from run_timing import" in source or "import run_timing" in source, (
+        "queue.py must delegate timing to run_timing module"
+    )


### PR DESCRIPTION
## Summary

- Adds GET /api/queue/status endpoint returning queue data with per-run timing sub-object (queue_wait_seconds, exec_seconds)
- Adds backend/run_timing.py — pure Python module (no FastAPI/identity imports) with parse_iso, compute_run_timing, and annotate_runs_with_timing
- Updates frontend/src/pages/Queue/mobileTypes.ts with RunTiming interface, timing? field on WorkflowRun, and timingLabel() helper
- Updates frontend/src/pages/Queue/MobileRunDetail.tsx to show Timing row in detail sheet when present
- Adds 17 tests in tests/test_run_timing.py covering all timing logic and source-level route registration
- Documents the new endpoint in SPEC.md

## Test plan

- [x] All 17 new tests pass (python -m pytest tests/test_run_timing.py -v)
- [x] ruff check and ruff format pass on all changed Python files
- [x] Module coverage invariant passes
- [x] No TypeScript errors in changed files
- [x] Existing tests unaffected

Fixes #637

Generated with Claude Code (https://claude.com/claude-code)