### PR TITLE
fix(deploy): clean stale _runner_file_commands and _diag/pages

### DIFF
--- a/deploy/runner-cleanup.sh
+++ b/deploy/runner-cleanup.sh
@@ -132,6 +132,32 @@ cleanup_runner_workdir() {
                 delete_path "$path"
             done
     fi
+    # issue #651: clean stale _runner_file_commands left over from
+    # jobs that died mid-execution. The directory is normally
+    # created+deleted within a single job lifecycle; anything still
+    # here when the runner is idle is corruption that causes the
+    # next allocation to fail with "Missing file at path:
+    # .../_runner_file_commands/save_state_<uuid>".
+    if [[ -d "$work_dir/_temp/_runner_file_commands" ]]; then
+        delete_path "$work_dir/_temp/_runner_file_commands"
+    fi
+}
+
+cleanup_runner_diag() {
+    # issue #651: rotate the runner's _diag/pages/ output. The actions
+    # runner writes UUID-named log files there per page-event; if two
+    # runs collide on the same UUID the runner aborts with "The file
+    # '.../_diag/pages/<uuid>_<uuid>_1.log' already exists". Capping
+    # age + leaving the directory itself in place prevents both the
+    # collision and the next allocation's startup failure.
+    local runner_dir="$1"
+    local diag_dir="${runner_dir}/_diag/pages"
+    [[ -d "$diag_dir" ]] || return 0
+    find "$diag_dir" -maxdepth 1 -type f -name '*.log' \
+        -mtime +"$RUNNER_TEMP_DAYS" \
+        -print0 | while IFS= read -r -d '' path; do
+            delete_path "$path"
+        done
 }
 
 cleanup_runners() {
@@ -153,6 +179,7 @@ cleanup_runners() {
             run systemctl stop "$unit"
         fi
         cleanup_runner_workdir "$runner_dir"
+        cleanup_runner_diag "$runner_dir"
         if [[ "$was_active" == "1" ]]; then
             run systemctl start "$unit"
         fi


### PR DESCRIPTION
## Summary

Adds two targeted cleanup passes to `runner-cleanup.sh` so the corruption symptoms reported in [#651](https://github.com/D-sorganization/Runner_Dashboard/issues/651) self-heal on the next idle pass instead of permanently breaking job allocation on the affected runner.

- `cleanup_runner_workdir`: also delete `_work/_temp/_runner_file_commands` when found. Normal lifecycle creates+deletes it inside one job; presence at idle = mid-job crash residue.
- New `cleanup_runner_diag`: rotate `_diag/pages/*.log` older than `RUNNER_TEMP_DAYS` (default 1d). Stops the UUID-collision aborts.

Both passes run inside the existing `cleanup_runners` loop and inherit its `runner_busy` guard, so no race with live jobs.

## Why

Issue #651 documents `d-sorg-local-ControlTower-11` hitting two distinct corruption symptoms across 5 PRs in the 2026-05-17/18 cleanup sprint:
- `Missing file at path: .../_runner_file_commands/save_state_<uuid>`
- `_diag/pages/<uuid>.log already exists`

Currently the only recovery is manual `rm -rf`; this PR makes the existing maintenance cron self-heal both.

## Test plan

- [x] `bash -n deploy/runner-cleanup.sh` passes
- [x] `runner_busy` guard preserved by leaving the call site inside the existing loop
- [ ] CI green

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)