### PR TITLE
fix(deploy): tolerate autoscaler race in runner-cleanup.sh (#653)

### DIFF
--- a/deploy/runner-cleanup.sh
+++ b/deploy/runner-cleanup.sh
@@ -160,6 +160,29 @@ cleanup_runner_diag() {
         done
 }
 
+# Stop a runner unit and wait for it to reach inactive. Tolerates the
+# autoscaler-race in #653: if a job lands between our busy-check and the
+# stop call, the unit self-exits and `systemctl stop` returns non-zero.
+# Aborting on that error left runners 2..N untouched, defeating #651/#652.
+# Returns 0 if the unit reaches inactive within STOP_TIMEOUT, 1 otherwise.
+STOP_TIMEOUT="${STOP_TIMEOUT:-30}"
+stop_runner_unit() {
+    local unit="$1"
+    local deadline=$(( SECONDS + STOP_TIMEOUT ))
+    if [[ "$DRY_RUN" == "1" ]]; then
+        log "[dry-run] systemctl stop --no-block $unit"
+        return 0
+    fi
+    log "+ systemctl stop --no-block $unit"
+    systemctl stop --no-block "$unit" || true
+    while (( SECONDS < deadline )); do
+        unit_active "$unit" || return 0
+        sleep 1
+    done
+    log "stop $unit: still active after ${STOP_TIMEOUT}s"
+    return 1
+}
+
 cleanup_runners() {
     local unit runner_dir was_active
     while read -r unit; do
@@ -176,7 +199,21 @@ cleanup_runners() {
         was_active=0
         if unit_active "$unit"; then
             was_active=1
-            run systemctl stop "$unit"
+            if ! stop_runner_unit "$unit"; then
+                log "skip $unit: did not reach inactive; leaving workdir untouched"
+                continue
+            fi
+        fi
+        # Re-check busy *after* stop: a job may have landed during the stop
+        # window and forked Runner.Worker, leaving an orphan even though the
+        # unit reports inactive. Cleaning under those conditions is exactly
+        # the corruption that #651/#652 set out to clean up.
+        if runner_busy "$runner_dir"; then
+            log "skip $unit: became busy during stop (orphan worker present)"
+            if [[ "$was_active" == "1" ]]; then
+                run systemctl start "$unit"
+            fi
+            continue
         fi
         cleanup_runner_workdir "$runner_dir"
         cleanup_runner_diag "$runner_dir"

--- a/tests/test_deploy_hardening.py
+++ b/tests/test_deploy_hardening.py
@@ -359,3 +359,61 @@ def test_rollback_sh_list_shows_integrity_status() -> None:
     content = _read(_DEPLOY / "rollback.sh")
     assert "_integrity_status" in content
     assert "--list" in content
+
+
+# ---------------------------------------------------------------------------
+# Issue #653: runner-cleanup must tolerate the autoscaler race.
+#
+# Before this fix the nightly cleanup ran under `set -Eeuo pipefail` and a
+# bare `systemctl stop "$unit"`. If a job landed between the busy-check and
+# the stop call the unit self-exited, systemctl returned exit 1, and the
+# whole loop aborted on the first runner — leaving runners 2..N untouched
+# and defeating the corruption cleanup added by #651/#652.
+# ---------------------------------------------------------------------------
+
+
+def test_runner_cleanup_tolerates_systemctl_stop_failure() -> None:
+    """cleanup_runners must not abort on `systemctl stop` failure.
+
+    Regression for #653: the script must use `stop_runner_unit` (which
+    wraps the call with `|| true` and polls `is-active`) instead of the
+    bare `run systemctl stop "$unit"` that aborts under set -e.
+    """
+    content = _read(_DEPLOY / "runner-cleanup.sh")
+    assert "stop_runner_unit" in content, (
+        "cleanup_runners must call stop_runner_unit, the tolerant wrapper"
+    )
+    assert "systemctl stop --no-block" in content, (
+        "stop_runner_unit must issue a non-blocking stop and poll for inactive"
+    )
+    # The legacy bare-stop call must be gone — its presence reintroduces the bug.
+    assert 'run systemctl stop "$unit"' not in content, (
+        "bare `run systemctl stop \"$unit\"` reintroduces the #653 strict-mode abort"
+    )
+
+
+def test_runner_cleanup_polls_for_inactive_with_timeout() -> None:
+    """stop_runner_unit must bound its wait via STOP_TIMEOUT."""
+    content = _read(_DEPLOY / "runner-cleanup.sh")
+    assert 'STOP_TIMEOUT="${STOP_TIMEOUT:-' in content, (
+        "STOP_TIMEOUT must be overridable and have a default"
+    )
+    assert "unit_active" in content
+
+
+def test_runner_cleanup_rechecks_busy_after_stop() -> None:
+    """cleanup_runners must re-check `runner_busy` after the stop completes.
+
+    A job that lands during the stop window can fork Runner.Worker even
+    though the unit ends up inactive; cleaning the workdir under those
+    conditions is exactly the corruption #651/#652 fixed.
+    """
+    content = _read(_DEPLOY / "runner-cleanup.sh")
+    # There must be at least two `runner_busy` checks: one before stop,
+    # one after. The post-stop check is the new guard.
+    assert content.count('runner_busy "$runner_dir"') >= 2, (
+        "cleanup_runners must re-check runner_busy after stop_runner_unit"
+    )
+    assert "orphan worker" in content, (
+        "post-stop busy-check should log the orphan-worker reason for skip"
+    )


### PR DESCRIPTION
## Summary

Closes #653.

`deploy/runner-cleanup.sh` ran under `set -Eeuo pipefail` with a bare `run systemctl stop \"\$unit\"`. When the autoscaler handed a runner a job between `runner_busy()` returning false and the stop call landing, the unit self-exited, systemctl's stop request collided with that exit and returned non-zero, and the whole loop aborted on runner-1. Runners 2..N were never visited — making the corruption cleanup added by #651/#652 a no-op on any host with an active autoscaler.

## Changes

- **`deploy/runner-cleanup.sh`**
  - New `stop_runner_unit` helper: `systemctl stop --no-block` wrapped in `|| true`, then poll `is-active` until inactive (bounded by `STOP_TIMEOUT`, default 30s).
  - `cleanup_runners` re-checks `runner_busy` *after* the stop completes. If a job landed during the stop window and forked `Runner.Worker`, we skip workdir cleanup for that runner and restart the unit — cleaning under those conditions is exactly the `_runner_file_commands` / `_diag/pages` corruption that #651/#652 fixed.
- **`tests/test_deploy_hardening.py`**
  - Three static regression tests pinning the new shape: tolerant stop, bounded poll, post-stop busy re-check. The bare `run systemctl stop \"\$unit\"` cannot regress back in.

## Out of scope

The `runsvc.sh` SIGKILL-without-wait behavior flagged in #653 is upstream `actions/runner` territory. Tracked as a follow-up.

## Test plan

- [x] `pytest tests/test_deploy_hardening.py` — new tests pass; only pre-existing failure is `test_dockerfile_pins_base_image_to_digest`, unrelated (Dockerfile bump in #654).
- [x] `bash -n deploy/runner-cleanup.sh` — clean.
- [ ] Manual: trigger `runner-cleanup.service` on `d-sorg-local-ControlTower` during an active autoscaler window and confirm the journal shows the script proceeding past the racing runner instead of aborting.

## Related

- #651
- #652
- Refs #653