### PR TITLE
fix(deploy): tolerate per-runner stop/start failures in cleanup loop

### DIFF
--- a/deploy/runner-cleanup.sh
+++ b/deploy/runner-cleanup.sh
@@ -161,7 +161,12 @@ cleanup_runner_diag() {
 }
 
 cleanup_runners() {
-    local unit runner_dir was_active
+    # Per-runner block: a stop/start failure on ONE runner must not abort the
+    # whole pass. Before this guard, `systemctl stop` returning exit 1 (which
+    # happens when stop races with a job pickup on that unit and systemctl
+    # reports "Job for ... canceled") tripped `set -e` and skipped runners 2..N.
+    # Result: on busy hosts the cleanup was a silent no-op every night.
+    local unit runner_dir was_active stop_rc start_rc
     while read -r unit; do
         [[ -n "$unit" ]] || continue
         runner_dir="$(service_workdir "$unit")"
@@ -174,14 +179,29 @@ cleanup_runners() {
             continue
         fi
         was_active=0
+        stop_rc=0
         if unit_active "$unit"; then
             was_active=1
-            run systemctl stop "$unit"
+            run systemctl stop "$unit" || stop_rc=$?
+            if (( stop_rc != 0 )); then
+                # If a job was assigned in the brief window between runner_busy()
+                # and systemctl stop, the stop is racy. Skip cleanup for this
+                # runner this pass; the next pass will catch it once idle.
+                log "skip $unit: systemctl stop failed (rc=$stop_rc), likely raced with job pickup; will retry next pass"
+                if ! unit_active "$unit"; then
+                    run systemctl start "$unit" || log "warn $unit: restart after failed stop also failed"
+                fi
+                continue
+            fi
         fi
         cleanup_runner_workdir "$runner_dir"
         cleanup_runner_diag "$runner_dir"
         if [[ "$was_active" == "1" ]]; then
-            run systemctl start "$unit"
+            start_rc=0
+            run systemctl start "$unit" || start_rc=$?
+            if (( start_rc != 0 )); then
+                log "error $unit: failed to restart after cleanup (rc=$start_rc); host may have a stuck unit"
+            fi
         fi
     done < <(list_runner_units)
 }


### PR DESCRIPTION
## Summary

The nightly `runner-cleanup.service` has been a silent no-op on hosts with active job traffic for months. Under `set -Eeuo pipefail`, when `systemctl stop` raced with a job pickup on the unit being stopped, systemctl exited 1 (`"Job for ... canceled"`) and aborted the entire cleanup pass on runner-1 — runners 2..N never got touched.

This is why PR #652's new cleanup paths (`_runner_file_commands`, `_diag/pages` rotation) never reached the runners that needed them: the loop died before getting there.

## Observed incident

d-sorg-local-ControlTower, 2026-05-18 04:26:24 PDT:

```
runner-cleanup[606147]: 2026-05-18T04:26:48-07:00 + systemctl stop actions.runner.D-sorganization.d-sorg-local-ControlTower-1.service
systemctl[606589]: Job for actions.runner.D-sorganization.d-sorg-local-ControlTower-1.service canceled.
systemd[1]: runner-cleanup.service: Main process exited, code=exited, status=1/FAILURE
```

A few hours later, 8 runners on the host had stale `_runner_file_commands` directories and 15 had stale `_diag/pages` logs.

## Change

`cleanup_runners()`: wrap `systemctl stop` and `systemctl start` with explicit return-code capture (`|| rc=$?`) so a single per-runner failure doesn't terminate the loop.

- **Stop failure** → log, attempt restart (if stop half-killed it), continue to next runner. Next pass will retry once the racing job exits.
- **Start failure after successful cleanup** → log loudly. This means a unit is genuinely stuck and needs operator attention.

The strict-mode stance at the top of the script is preserved; only the per-runner block now treats stop/start as expected-to-fail-sometimes.

## Why

Pairs with #651 / #652 — those added the *what* to clean, this ensures the cleanup *runs* on busy hosts. Without this patch, #652's payoff is gated on the cleanup never racing — which on any host with active autoscaling is a coin flip.

## Test plan

- [x] `bash -n deploy/runner-cleanup.sh` passes
- [x] Manual review of the per-runner block: stop-failure path now `continue`s instead of `exit`ing
- [x] Strict-mode preserved outside the per-runner block (top-of-script `set -Eeuo pipefail` unchanged)
- [ ] CI green
- [ ] Post-merge canary on `d-sorg-local-ControlTower`: trigger cleanup, observe runners 2..16 are now processed even if runner-1 stop fails

## Follow-ups (separate PRs)

- **PR #2** — `deploy/heal-host.sh`: explicit drain+heal+restart entrypoint for operators (one-shot heal after a corruption event).
- **PR #3** — job-pickup lockfile + `KillMode=mixed` on runner units: close the race window itself, not just tolerate it.
- **PR #4** — Prometheus metrics for cleanup success/failure, corruption residue, orphan workers. Would have caught this silent failure months ago.

Cross-ref: \`memory/runner_corruption_pattern.md\` — same signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)