### PR TITLE
fix(frontend): replace misleading HTTPS error in backend recovery modal

### DIFF
--- a/docs/tailscale-funnel.md
+++ b/docs/tailscale-funnel.md
@@ -77,6 +77,20 @@ Expected response:
 }
 ```
 
+## Same-origin /api/* passthrough
+
+Because `tailscale funnel 8321` forwards **all** paths under the public HTTPS
+host to the local backend on port 8321, the dashboard's `/api/*` calls (and
+the `/health` probe consumed by the in-app recovery modal) are served from the
+**same origin** as the frontend bundle. No browser mixed-content blocking and
+no separate reverse proxy is required: the FastAPI server hosts both the Vite
+static bundle and the JSON API under one port.
+
+If you front the dashboard with your own reverse proxy (nginx, Caddy) instead
+of Tailscale Funnel, ensure it proxies `/api/*` **and** `/health` to
+`127.0.0.1:8321`, or the in-app "Backend is down" recovery modal will fire
+even though the backend is healthy.
+
 ## Security Considerations
 
 | Control | Purpose |

--- a/frontend/src/legacy/RecoveryDialog.tsx
+++ b/frontend/src/legacy/RecoveryDialog.tsx
@@ -2,6 +2,12 @@ import React from "react";
 
 export interface RecoveryDialogProps {
   onClose: () => void;
+  /**
+   * Optional override for the health-check URL surfaced in diagnostic messages.
+   * Defaults to ``${window.location.origin}/health`` at render time, which is
+   * what the legacy App.tsx polls. Exposed for tests.
+   */
+  healthUrl?: string;
 }
 
 const focusableSelector = [
@@ -18,12 +24,22 @@ function isDesktopPlatform() {
   return navigator.platform.includes("Win32") || navigator.platform.includes("Mac");
 }
 
-export function RecoveryDialog({ onClose }: RecoveryDialogProps) {
+function defaultHealthUrl(): string {
+  if (typeof window === "undefined") return "/health";
+  try {
+    return `${window.location.origin}/health`;
+  } catch {
+    return "/health";
+  }
+}
+
+export function RecoveryDialog({ onClose, healthUrl }: RecoveryDialogProps) {
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const startButtonRef = React.useRef<HTMLButtonElement>(null);
   const refreshButtonRef = React.useRef<HTMLButtonElement>(null);
   const [protocolError, setProtocolError] = React.useState<string | null>(null);
   const canUseProtocolHandler = isDesktopPlatform();
+  const resolvedHealthUrl = healthUrl ?? defaultHealthUrl();
 
   React.useEffect(() => {
     (startButtonRef.current || refreshButtonRef.current)?.focus();
@@ -62,12 +78,32 @@ export function RecoveryDialog({ onClose }: RecoveryDialogProps) {
   };
 
   const handleStartNow = () => {
-    if (window.location.protocol === "https:") {
+    // Most browsers only honour custom URL protocol handlers when the page is
+    // served over HTTPS *and* the protocol has been registered on the host OS
+    // (see deploy/register-protocol.ps1). We still attempt the handler in any
+    // context so an operator who has it registered can use it, but we always
+    // surface an actionable diagnostic explaining what to try if nothing
+    // happens after the click — the previous "Make sure you're using HTTPS"
+    // message was misleading (issue: dashboard backend HTTPS mixed content).
+    try {
       window.location.href = "runner-dashboard://start";
-      return;
+    } catch {
+      // window.location assignment can throw in sandboxed iframes — ignore.
     }
 
-    setProtocolError("Protocol handler requires HTTPS context. Make sure you're using HTTPS.");
+    const origin = (() => {
+      try {
+        return window.location.origin;
+      } catch {
+        return "(unknown origin)";
+      }
+    })();
+    setProtocolError(
+      `If nothing happened: the runner-dashboard:// handler is not registered on this device, ` +
+        `or the page (${origin}) is not allowed to invoke it. ` +
+        `Run "systemctl --user restart runner-dashboard" on the dashboard host, then click Refresh. ` +
+        `Backend health URL: ${resolvedHealthUrl}`,
+    );
   };
 
   return (
@@ -114,20 +150,17 @@ export function RecoveryDialog({ onClose }: RecoveryDialogProps) {
           Backend Not Responding
         </h2>
         <div aria-live="assertive" id="recovery-dialog-description">
-          {canUseProtocolHandler ? (
-            <p style={{ margin: "0 0 16px 0", color: "var(--text-secondary)", fontSize: "14px" }}>
-              The dashboard backend is not responding. Click "Start Now" to restart the service, or run the terminal command below.
-            </p>
-          ) : (
-            <div>
-              <p style={{ margin: "0 0 12px 0", color: "var(--text-secondary)", fontSize: "14px" }}>
-                The dashboard backend is not responding. To restart the service, run this command in a terminal:
-              </p>
-              <pre style={{ background: "var(--bg-secondary)", padding: "12px", borderRadius: 4, margin: "0 0 16px 0", fontSize: "13px", overflow: "auto", color: "var(--text-primary)" }}>
-                {"systemctl --user restart runner-dashboard\n\nThen refresh this page."}
-              </pre>
-            </div>
-          )}
+          <p style={{ margin: "0 0 12px 0", color: "var(--text-secondary)", fontSize: "14px" }}>
+            {canUseProtocolHandler
+              ? 'The dashboard backend is not responding. Click "Start Now" to invoke the registered runner-dashboard:// handler, or run the terminal command below on the dashboard host.'
+              : "The dashboard backend is not responding. To restart the service, run this command on the dashboard host:"}
+          </p>
+          <pre style={{ background: "var(--bg-secondary)", padding: "12px", borderRadius: 4, margin: "0 0 16px 0", fontSize: "13px", overflow: "auto", color: "var(--text-primary)" }}>
+            {"systemctl --user restart runner-dashboard\n\nThen click Refresh."}
+          </pre>
+          <p style={{ margin: "0 0 16px 0", color: "var(--text-tertiary, var(--text-secondary))", fontSize: "12px" }}>
+            Health probe: <code>{resolvedHealthUrl}</code>
+          </p>
         </div>
         {protocolError ? (
           <p

--- a/frontend/src/legacy/__tests__/RecoveryDialog.test.tsx
+++ b/frontend/src/legacy/__tests__/RecoveryDialog.test.tsx
@@ -61,17 +61,54 @@ describe("RecoveryDialog", () => {
     expect(refresh).toHaveFocus();
   });
 
-  it("shows inline protocol handler guidance instead of using alert", () => {
+  it("shows actionable diagnostic guidance without misleading HTTPS verbiage when Start Now is clicked", () => {
     setPlatform("Win32");
     const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
 
-    render(<RecoveryDialog onClose={vi.fn()} />);
+    render(
+      <RecoveryDialog
+        onClose={vi.fn()}
+        healthUrl="https://example.ts.net/health"
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Start Now" }));
 
     expect(alertSpy).not.toHaveBeenCalled();
-    expect(screen.getByRole("alert")).toHaveTextContent("Protocol handler requires HTTPS context");
+    const alert = screen.getByRole("alert");
+    // The misleading "Make sure you're using HTTPS" guidance must be gone:
+    expect(alert.textContent ?? "").not.toMatch(/make sure you're using https/i);
+    expect(alert.textContent ?? "").not.toMatch(/protocol handler requires https context/i);
+    // The replacement is actionable: tells the user what to do and which URL
+    // is being probed.
+    expect(alert).toHaveTextContent(/systemctl --user restart runner-dashboard/);
+    expect(alert).toHaveTextContent("https://example.ts.net/health");
 
     alertSpy.mockRestore();
+  });
+
+  it("always shows the terminal restart command, including on desktop platforms", () => {
+    setPlatform("Win32");
+
+    render(<RecoveryDialog onClose={vi.fn()} />);
+
+    // The restart command must be visible up-front — clicking Start Now is
+    // best-effort and frequently does nothing (handler not registered).
+    expect(
+      screen.getByText(/systemctl --user restart runner-dashboard/),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the health-probe URL so operators can curl it from outside the page", () => {
+    setPlatform("Win32");
+
+    render(
+      <RecoveryDialog
+        onClose={vi.fn()}
+        healthUrl="https://example.ts.net/health"
+      />,
+    );
+
+    expect(screen.getByText("https://example.ts.net/health")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Root cause

When the dashboard's `/health` probe fails three times, the legacy
`RecoveryDialog` opens and offers a **Start Now** button that invokes a custom
`runner-dashboard://start` URL protocol handler. The previous code only
attempted the handler when `window.location.protocol === "https:"`, and
otherwise displayed:

> Protocol handler requires HTTPS context. Make sure you're using HTTPS.

This is the "https" error the user saw. It is misleading in every realistic
deployment:

1. **The dashboard is already same-origin under Tailscale Funnel.** `tailscale
   funnel 8321` (see `docs/tailscale-funnel.md` and
   `deploy/setup-tailscale.sh`) forwards `https://<host>.ts.net/*` to
   `http://127.0.0.1:8321/*`. Both the SPA bundle and `/api/*` are served by
   the same FastAPI process under the same HTTPS origin, so there is no
   browser mixed-content blocking and no separate reverse proxy is required.
2. **The real failure mode is the protocol handler, not HTTPS.** The
   `runner-dashboard://` scheme is registered by `deploy/register-protocol.ps1`
   on Windows hosts only, and most browsers refuse to invoke unregistered
   custom protocols silently. An operator on HTTPS who has never installed
   the handler clicks Start Now and nothing happens; an operator on
   `http://localhost:8321` clicks Start Now and gets the inverted HTTPS
   warning, with no actionable next step.

The frontend's API client (`frontend/src/lib/api.ts`) already uses relative
`/api/*` paths everywhere, and the legacy health-check loop
(`frontend/src/legacy/App.tsx`) polls relative `/health`. The
`/health` endpoint exists in `backend/health.py`. The topology is already
correct; the bug is purely the recovery dialog's UX.

## Topology before/after

Unchanged — `tailscale funnel 8321` is the front door. This PR documents that
arrangement in `docs/tailscale-funnel.md` and warns any operator rolling
their own reverse proxy that **both** `/api/*` and `/health` must be proxied
to `127.0.0.1:8321`, otherwise the recovery modal fires even when the
backend is healthy.

## Fix shipped (error-message-only fallback, not a topology change)

In `frontend/src/legacy/RecoveryDialog.tsx`:

- Always attempt the `runner-dashboard://start` handler when **Start Now** is
  clicked, in every context. If the handler is registered it works; if not,
  the click is a no-op rather than a misleading HTTPS warning.
- Replace the HTTPS error with an actionable diagnostic that surfaces the
  page origin, the `systemctl --user restart runner-dashboard` command, and
  the resolved `/health` URL being probed.
- Always render the restart command in the dialog body (previously only
  shown on non-desktop platforms), so the operator has a working escape
  hatch even when the protocol handler silently fails.
- Add a `healthUrl` prop so the surfaced URL can be unit-tested without
  mocking `window.location`.

## Test plan

- [x] `npx vitest run frontend/src/legacy/__tests__/RecoveryDialog.test.tsx` — 6 cases pass, including two new ones:
  - Asserts the alert text no longer matches `/make sure you're using https/i` or `/protocol handler requires https context/i`.
  - Asserts the surfaced health URL renders verbatim so an operator can copy/paste it into `curl`.
- [x] `npx vitest run` (RecoveryDialog suite) green locally on Windows.
- [ ] Operator smoke test on `d-sorg-local-ControlTower`: kill backend, confirm modal opens, confirm Start Now click no longer surfaces "HTTPS context" verbiage, confirm the `systemctl --user restart runner-dashboard` command and the `https://<host>.ts.net/health` URL appear in the dialog body.
- [ ] (Not changed in this PR but verified during investigation) `tailscale funnel status` shows `8321` forwarded; `curl https://<host>.ts.net/health` returns `{"status":"ready", ...}` when backend is up.

## Candid note on scope

This is the **error-message-improvement fallback** called out in the brief,
not a topology fix. The topology is already correct: `tailscale funnel 8321`
provides same-origin HTTPS for both the SPA and `/api/*`. The user's "https"
error came from inverted UX logic in `RecoveryDialog`, not from a mixed-content
block. If the operator on `d-sorg-local-ControlTower` is hitting the dashboard
through something other than the Funnel (e.g. the unrelated Next.js bundle on
:80, or :3002), that is a separate environmental issue that this PR does not
attempt to solve — the right next step there is to confirm which URL the
browser is loading and either point it at the Funnel host or add an nginx/Caddy
snippet to `deploy/` that proxies `/api/*` and `/health` to `127.0.0.1:8321`.
I would recommend that as a follow-up issue once the operator confirms which
front door they are actually using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)