### PR TITLE
chore(observability): Prometheus telemetry for cleanup, corruption, orphans

### DIFF
--- a/deploy/install-runner-maintenance.sh
+++ b/deploy/install-runner-maintenance.sh
@@ -7,6 +7,7 @@ RUNNER_ROOT="${RUNNER_ROOT:-$HOME/actions-runners}"
 RUNNER_USER="${RUNNER_USER:-$USER}"
 SCHEDULE_CONFIG="${RUNNER_SCHEDULE_CONFIG:-$HOME/.config/runner-dashboard/runner-schedule.json}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-$(command -v systemctl)}"
+TEXTFILE_COLLECTOR_DIR="${TEXTFILE_COLLECTOR_DIR:-/var/lib/node_exporter/textfile_collector}"
 
 echo "Installing runner maintenance services for ${RUNNER_USER}"
 
@@ -17,7 +18,8 @@ fi
 
 sudo install -m 0755 "${SCRIPT_DIR}/runner-cleanup.sh" /usr/local/bin/runner-cleanup
 sudo install -m 0755 "${SCRIPT_DIR}/runner-scheduler.py" /usr/local/bin/runner-scheduler
-sudo install -d -m 0755 /var/log/runner-cleanup /var/lib/runner-scheduler
+sudo install -m 0755 "${SCRIPT_DIR}/runner-corruption-scan.sh" /usr/local/bin/runner-corruption-scan
+sudo install -d -m 0755 /var/log/runner-cleanup /var/lib/runner-scheduler "${TEXTFILE_COLLECTOR_DIR}"
 
 SCHEDULER_SUDOERS="/etc/sudoers.d/runner-dashboard-scheduler"
 sudo tee "${SCHEDULER_SUDOERS}" > /dev/null <<SUDOERS
@@ -87,8 +89,49 @@ Persistent=true
 WantedBy=timers.target
 TIMER
 
+sudo tee /etc/systemd/system/runner-corruption-scan.service > /dev/null <<SERVICE
+[Unit]
+Description=Scan GitHub runner directories for corruption residue and emit Prometheus metrics
+Documentation=https://github.com/D-sorganization/Runner_Dashboard/blob/main/docs/observability.md
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=root
+Environment=RUNNER_ROOT=${RUNNER_ROOT}
+Environment=PROM_FILE=${TEXTFILE_COLLECTOR_DIR}/runner_corruption.prom
+Environment=DIAG_PAGES_MIN_AGE_DAYS=1
+ExecStart=/usr/local/bin/runner-corruption-scan
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+SERVICE
+
+sudo tee /etc/systemd/system/runner-corruption-scan.timer > /dev/null <<'TIMER'
+[Unit]
+Description=Run runner corruption residue scan every five minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMER
+
+# Ensure runner-cleanup writes its textfile metric to the same collector
+# directory used by node_exporter. The cleanup script defaults to
+# /var/lib/node_exporter/textfile_collector but honours TEXTFILE_COLLECTOR_DIR.
+sudo mkdir -p /etc/systemd/system/runner-cleanup.service.d
+sudo tee /etc/systemd/system/runner-cleanup.service.d/textfile.conf > /dev/null <<CONF
+[Service]
+Environment=TEXTFILE_COLLECTOR_DIR=${TEXTFILE_COLLECTOR_DIR}
+CONF
+
 sudo systemctl daemon-reload
-sudo systemctl enable --now runner-cleanup.timer runner-scheduler.timer
+sudo systemctl enable --now runner-cleanup.timer runner-scheduler.timer runner-corruption-scan.timer
 
 echo "Installed:"
-systemctl list-timers runner-cleanup.timer runner-scheduler.timer --all
+systemctl list-timers runner-cleanup.timer runner-scheduler.timer runner-corruption-scan.timer --all

--- a/deploy/observability/vector.toml
+++ b/deploy/observability/vector.toml
@@ -33,6 +33,21 @@
   # Also capture kernel-level OOM kills that may affect the service.
   include_matches = { "_SYSTEMD_UNIT" = ["runner-dashboard.service", "runner-autoscaler.service"] }
 
+# Issue #651 — orphan Runner.Worker detection.
+# systemd emits "Unit process <PID> (Runner.Worker) remains running after
+# unit stopped" when KillMode=process on the actions.runner.*.service
+# units leaves a Worker behind. These orphans corrupt the next allocation
+# (stale _runner_file_commands, _diag/pages collisions). This source
+# tails the systemd journal globally so we can see the kernel/systemd-
+# generated messages that the per-unit `journald` source above filters
+# out by design.
+[sources.journald_systemd]
+  type = "journald"
+  include_units = ["init.scope", "systemd"]
+  # Also include the actions runner units themselves so worker exit
+  # messages aren't lost.
+  include_matches = { "SYSLOG_IDENTIFIER" = ["systemd"] }
+
 [sources.docker_logs]
   type = "docker_logs"
   # In Docker Compose mode, collect from the dashboard container by label.
@@ -66,6 +81,33 @@
     del(.PRIORITY)
     del(.severity)
   '''
+
+# Issue #651 — Detect orphan Runner.Worker processes via the systemd
+# log line: "Unit process N (Runner.Worker) remains running after unit
+# stopped". This is the signature of KillMode=process letting a child
+# survive its parent. See docs/observability.md.
+[transforms.orphan_worker_filter]
+  type = "filter"
+  inputs = ["journald_systemd"]
+  condition = '''
+    msg = string!(.message ?? "")
+    contains(msg, "(Runner.Worker)") && contains(msg, "remains running after unit stopped")
+  '''
+
+[transforms.orphan_worker_to_metric]
+  type = "log_to_metric"
+  inputs = ["orphan_worker_filter"]
+
+  [[transforms.orphan_worker_to_metric.metrics]]
+    type = "counter"
+    field = "message"
+    name = "runner_orphan_worker_total"
+    namespace = "runner"
+    increment_by_value = false
+
+    [transforms.orphan_worker_to_metric.metrics.tags]
+      host   = "{{ host }}"
+      runner = "{{ _SYSTEMD_UNIT }}"
 
 [transforms.add_retention_label]
   type = "remap"
@@ -114,6 +156,51 @@
   type = "console"
   inputs = ["add_retention_label"]
   encoding.codec = "json"
+
+# ---------------------------------------------------------------------------
+# Issue #651 — Prometheus exporter for orphan-Worker counter.
+#
+# This is the canonical scrape path for `runner_orphan_worker_total`. The
+# Prometheus server (or the fleet's central scraper) must be configured to
+# pull from <vector-host>:9598/metrics. See docs/observability.md.
+#
+# TODO(observability): The fleet does not yet ship a centralised Prometheus
+# server config in this repo; verify the scrape target is registered with
+# the operator's Prometheus instance before relying on this metric for
+# alerting. If your deployment runs Vector behind a firewall, expose this
+# port via Tailscale rather than the public network.
+# ---------------------------------------------------------------------------
+[sinks.prometheus_runner_metrics]
+  type = "prometheus_exporter"
+  inputs = ["orphan_worker_to_metric"]
+  address = "${VECTOR_PROM_ADDR:-0.0.0.0:9598}"
+  default_namespace = "runner"
+
+# Forward the raw orphan-worker log lines to Loki as well so operators can
+# correlate the counter spike with the exact journald message. Use a
+# dedicated stream label so alerts can match on `{event="orphan_worker"}`.
+[transforms.orphan_worker_for_loki]
+  type = "remap"
+  inputs = ["orphan_worker_filter"]
+  source = '''
+    .event       = "orphan_worker"
+    .level       = "warn"
+    .fleet_node  = get_env_var!("FLEET_NODE_NAME")
+    .service     = "runner-dashboard"
+    .retention   = "30d"
+  '''
+
+[sinks.loki_orphan_worker]
+  type = "loki"
+  inputs = ["orphan_worker_for_loki"]
+  endpoint = "${LOKI_URL:-http://localhost:3100}"
+  encoding.codec = "json"
+
+  [sinks.loki_orphan_worker.labels]
+    job       = "runner-dashboard"
+    node      = "{{ fleet_node }}"
+    event     = "{{ event }}"
+    retention = "{{ retention }}"
 
 # --------------------------------------------------------------------------
 # Journald drop-in for retention limits

--- a/deploy/runner-cleanup.sh
+++ b/deploy/runner-cleanup.sh
@@ -17,6 +17,16 @@ COMPACT_VHD="${COMPACT_VHD:-0}"
 COMPACT_VHD_ONLY="${COMPACT_VHD_ONLY:-0}"
 COMPACT_VHD_DISTRO="${COMPACT_VHD_DISTRO:-Ubuntu-22.04}"
 LOCK_FILE="/run/runner-cleanup.lock"
+TEXTFILE_COLLECTOR_DIR="${TEXTFILE_COLLECTOR_DIR:-/var/lib/node_exporter/textfile_collector}"
+CLEANUP_METRICS_FILE="${CLEANUP_METRICS_FILE:-${TEXTFILE_COLLECTOR_DIR}/runner_cleanup.prom}"
+
+# Tracked by write_metrics(): incremented every time cleanup_runners() fails
+# to stop a runner unit. Surfaced as runner_cleanup_stop_failures_total.
+CLEANUP_STOP_FAILURES=0
+# Tracked by write_metrics(): "ok" for a clean run, "skipped" when another
+# instance held the lock, "failed" when main() returns non-zero or the EXIT
+# trap fires before main completes.
+CLEANUP_RESULT="failed"
 
 # Parse flags. Keep env-var style as the primary interface; flags are a
 # convenience wrapper so callers can say `runner-cleanup.sh --compact-vhd`.
@@ -72,6 +82,45 @@ delete_path() {
     local path="$1"
     log "delete $path"
     [[ "$DRY_RUN" == "1" ]] || rm -rf -- "$path"
+}
+
+write_metrics() {
+    # Emit a Prometheus textfile-collector snapshot of the last cleanup pass.
+    # Invoked from an EXIT trap so partial / failed runs still publish a
+    # signal. Failures here are non-fatal: the trap must never mask the
+    # underlying exit status of main().
+    local host metrics_dir tmp_file
+    host="${FLEET_NODE_NAME:-$(hostname -s 2>/dev/null || hostname)}"
+    metrics_dir="$(dirname -- "$CLEANUP_METRICS_FILE")"
+    if ! mkdir -p -- "$metrics_dir" 2>/dev/null; then
+        log "metrics: cannot create $metrics_dir; skipping textfile emit"
+        return 0
+    fi
+    tmp_file="${CLEANUP_METRICS_FILE}.tmp"
+    {
+        printf '# HELP runner_cleanup_runs_total Total runner cleanup passes by result.\n'
+        printf '# TYPE runner_cleanup_runs_total counter\n'
+        for result in ok skipped failed; do
+            local value=0
+            [[ "$result" == "$CLEANUP_RESULT" ]] && value=1
+            printf 'runner_cleanup_runs_total{host="%s",result="%s"} %d\n' \
+                "$host" "$result" "$value"
+        done
+        printf '# HELP runner_cleanup_stop_failures_total Runner unit stop failures observed in the last cleanup pass.\n'
+        printf '# TYPE runner_cleanup_stop_failures_total counter\n'
+        printf 'runner_cleanup_stop_failures_total{host="%s"} %d\n' \
+            "$host" "$CLEANUP_STOP_FAILURES"
+        printf '# HELP runner_cleanup_last_run_timestamp_seconds Unix timestamp of the last cleanup pass.\n'
+        printf '# TYPE runner_cleanup_last_run_timestamp_seconds gauge\n'
+        printf 'runner_cleanup_last_run_timestamp_seconds{host="%s"} %d\n' \
+            "$host" "$(date +%s)"
+    } >"$tmp_file" 2>/dev/null || {
+        log "metrics: failed writing $tmp_file"
+        rm -f -- "$tmp_file" 2>/dev/null || true
+        return 0
+    }
+    mv -f -- "$tmp_file" "$CLEANUP_METRICS_FILE" 2>/dev/null \
+        || log "metrics: failed publishing $CLEANUP_METRICS_FILE"
 }
 
 bytes_human() {
@@ -215,6 +264,8 @@ cleanup_runners() {
             was_active=1
             run systemctl stop "$unit" || stop_rc=$?
             if (( stop_rc != 0 )); then
+                # Increment the metric for #663's textfile-collector path.
+                CLEANUP_STOP_FAILURES=$((CLEANUP_STOP_FAILURES + 1))
                 # If a job was assigned in the brief window between runner_busy()
                 # and systemctl stop, the stop is racy. Skip cleanup for this
                 # runner this pass; the next pass will catch it once idle.
@@ -286,6 +337,7 @@ main() {
     exec 9>"$LOCK_FILE"
     if ! flock -n 9; then
         log "another cleanup is already running; exiting"
+        CLEANUP_RESULT="skipped"
         return 0
     fi
     local before after used
@@ -311,6 +363,13 @@ main() {
     if [[ "$COMPACT_VHD" == "1" ]]; then
         compact_wsl_vhd
     fi
+    CLEANUP_RESULT="ok"
 }
+
+# Emit a textfile-collector metric on every exit path. The trap fires
+# regardless of whether main() returned cleanly, hit set -e, or was
+# interrupted, so silent regressions (issue #651) can no longer accumulate
+# undetected — Prometheus will see runner_cleanup_runs_total{result="failed"}.
+trap 'write_metrics' EXIT
 
 main "$@"

--- a/deploy/runner-corruption-scan.service
+++ b/deploy/runner-corruption-scan.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Scan GitHub runner directories for corruption residue and emit Prometheus metrics
+Documentation=https://github.com/D-sorganization/Runner_Dashboard/blob/main/docs/observability.md
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=root
+# RUNNER_ROOT is overridden by install-runner-maintenance.sh to match the
+# operator-configured runner install location.
+Environment=RUNNER_ROOT=/home/runner/actions-runners
+Environment=PROM_FILE=/var/lib/node_exporter/textfile_collector/runner_corruption.prom
+Environment=DIAG_PAGES_MIN_AGE_DAYS=1
+ExecStart=/usr/local/bin/runner-corruption-scan
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/deploy/runner-corruption-scan.sh
+++ b/deploy/runner-corruption-scan.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# runner-corruption-scan.sh
+#
+# Scan every actions-runner directory under $RUNNER_ROOT for residue from
+# mid-job kills (see issue #651) and emit a Prometheus textfile-collector
+# snapshot to $PROM_FILE.
+#
+# Two corruption signatures are counted per runner:
+#
+#   * file_commands — files left under
+#     <runner>/_work/_temp/_runner_file_commands/.  These are cleaned at the
+#     end of every job; anything present while the runner is idle is
+#     residue that will cause the next allocation to fail with
+#     "Missing file at path: .../_runner_file_commands/save_state_<uuid>".
+#
+#   * diag_pages   — *.log files under <runner>/_diag/pages/ older than
+#     $DIAG_PAGES_MIN_AGE_DAYS.  Two runs colliding on a UUID will abort
+#     the runner with "the file '.../<uuid>_<uuid>_1.log' already exists".
+#
+# Output format (gauge):
+#
+#   # HELP runner_corruption_residue_count Stale corruption-residue file count by kind.
+#   # TYPE runner_corruption_residue_count gauge
+#   runner_corruption_residue_count{host="HOST",runner="runner-01",kind="file_commands"} 3
+#   runner_corruption_residue_count{host="HOST",runner="runner-01",kind="diag_pages"} 1
+#
+# Designed to be invoked from a 5-minute systemd timer
+# (runner-corruption-scan.timer) and scraped by node_exporter's
+# textfile collector. See docs/observability.md.
+
+set -Eeuo pipefail
+
+RUNNER_ROOT="${RUNNER_ROOT:-$HOME/actions-runners}"
+PROM_FILE="${PROM_FILE:-/var/lib/node_exporter/textfile_collector/runner_corruption.prom}"
+DIAG_PAGES_MIN_AGE_DAYS="${DIAG_PAGES_MIN_AGE_DAYS:-1}"
+FLEET_NODE_NAME="${FLEET_NODE_NAME:-$(hostname -s 2>/dev/null || hostname)}"
+
+tmp_file="${PROM_FILE}.tmp"
+trap 'rm -f -- "$tmp_file"' EXIT
+
+mkdir -p -- "$(dirname -- "$PROM_FILE")"
+
+{
+    printf '# HELP runner_corruption_residue_count Stale corruption-residue file count by kind.\n'
+    printf '# TYPE runner_corruption_residue_count gauge\n'
+} >"$tmp_file"
+
+count_file_commands() {
+    local runner_dir="$1"
+    local rfc="${runner_dir}/_work/_temp/_runner_file_commands"
+    if [[ -d "$rfc" ]]; then
+        # Count any regular file under the residue dir (recursive, in case
+        # the runner ever nests). We do not filter by age — by contract the
+        # directory should be empty between jobs.
+        find "$rfc" -type f 2>/dev/null | wc -l | tr -d ' '
+    else
+        printf '0'
+    fi
+}
+
+count_diag_pages() {
+    local runner_dir="$1"
+    local diag="${runner_dir}/_diag/pages"
+    if [[ -d "$diag" ]]; then
+        find "$diag" -maxdepth 1 -type f -name '*.log' \
+            -mtime +"$((DIAG_PAGES_MIN_AGE_DAYS - 1))" 2>/dev/null \
+            | wc -l | tr -d ' '
+    else
+        printf '0'
+    fi
+}
+
+if [[ -d "$RUNNER_ROOT" ]]; then
+    # shellcheck disable=SC2044  # paths under RUNNER_ROOT are operator-controlled
+    while IFS= read -r runner_dir; do
+        [[ -n "$runner_dir" ]] || continue
+        runner_name="$(basename -- "$runner_dir")"
+        fc_count="$(count_file_commands "$runner_dir")"
+        dp_count="$(count_diag_pages "$runner_dir")"
+        printf 'runner_corruption_residue_count{host="%s",runner="%s",kind="file_commands"} %s\n' \
+            "$FLEET_NODE_NAME" "$runner_name" "$fc_count" >>"$tmp_file"
+        printf 'runner_corruption_residue_count{host="%s",runner="%s",kind="diag_pages"} %s\n' \
+            "$FLEET_NODE_NAME" "$runner_name" "$dp_count" >>"$tmp_file"
+    done < <(find "$RUNNER_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'runner-*' 2>/dev/null | sort)
+fi
+
+# Atomic publish so node_exporter never sees a half-written file.
+mv -f -- "$tmp_file" "$PROM_FILE"
+trap - EXIT

--- a/deploy/runner-corruption-scan.timer
+++ b/deploy/runner-corruption-scan.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run runner corruption residue scan every five minutes
+Documentation=https://github.com/D-sorganization/Runner_Dashboard/blob/main/docs/observability.md
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,161 @@
+# Runner observability metrics
+
+Issue [#651](https://github.com/D-sorganization/Runner_Dashboard/issues/651)
+exposed a class of failure where the nightly `runner-cleanup.service` had
+been silently failing for months on busy hosts because of a strict-mode bug
+([fix in #660](https://github.com/D-sorganization/Runner_Dashboard/pull/660)).
+The only visible signal was that CI kept failing on PR after PR; nothing
+told us cleanup itself had stopped running.
+
+This document describes the three Prometheus metrics added so that silent
+regression can't happen again. Each metric has a single, well-defined scrape
+path — there is no ambiguity about which subsystem owns the data.
+
+## 1. `runner_cleanup_runs_total`
+
+| Field          | Value                                                           |
+| -------------- | --------------------------------------------------------------- |
+| Type           | Counter                                                         |
+| Labels         | `host`, `result` ∈ `{ok, skipped, failed}`                      |
+| Emitter        | `deploy/runner-cleanup.sh` (`write_metrics()` in an EXIT trap)  |
+| Scrape path    | node_exporter textfile collector                                |
+| State file     | `${TEXTFILE_COLLECTOR_DIR}/runner_cleanup.prom`                 |
+| Default dir    | `/var/lib/node_exporter/textfile_collector`                     |
+| Cadence        | Once per cleanup pass (daily timer, plus manual invocations)    |
+
+Co-emitted from the same trap:
+
+- `runner_cleanup_stop_failures_total{host}` — counter, number of runner
+  units that could not be stopped during the most recent pass. A non-zero
+  reading means cleanup ran but elided one or more runners.
+- `runner_cleanup_last_run_timestamp_seconds{host}` — gauge, unix time of
+  the most recent pass. Stale-by-time alerting is more reliable than
+  stale-by-counter, since a perpetually-skipped run still increments
+  `result="skipped"`.
+
+### Alerting
+
+```yaml
+- alert: RunnerCleanupStale
+  expr: time() - runner_cleanup_last_run_timestamp_seconds > 60 * 60 * 36
+  for: 15m
+  annotations:
+    summary: "runner-cleanup hasn't completed on {{ $labels.host }} for >36h"
+
+- alert: RunnerCleanupFailing
+  expr: increase(runner_cleanup_runs_total{result="failed"}[2h]) > 0
+  for: 5m
+```
+
+### How this would have caught #651
+
+The strict-mode regression caused `runner-cleanup.sh` to exit early under
+`set -Eeuo pipefail` whenever a single runner's directory was unreadable.
+The EXIT trap fires regardless of return value, so the textfile would have
+emitted `result="failed"` continuously. The `RunnerCleanupFailing` alert
+would have paged on the first 2-hour window.
+
+## 2. `runner_corruption_residue_count`
+
+| Field          | Value                                                                  |
+| -------------- | ---------------------------------------------------------------------- |
+| Type           | Gauge                                                                  |
+| Labels         | `host`, `runner`, `kind` ∈ `{file_commands, diag_pages}`               |
+| Emitter        | `deploy/runner-corruption-scan.sh`                                     |
+| Scrape path    | node_exporter textfile collector                                       |
+| State file     | `${PROM_FILE}` (default `/var/lib/node_exporter/textfile_collector/runner_corruption.prom`) |
+| Schedule       | `runner-corruption-scan.timer` — `OnUnitActiveSec=5min`                |
+
+The scan walks every `runner-*` directory under `$RUNNER_ROOT` and counts:
+
+- **`kind="file_commands"`** — every file under
+  `<runner>/_work/_temp/_runner_file_commands/`. By contract this directory
+  is empty between jobs; any file is residue from a mid-job kill and will
+  break the next allocation with
+  `Missing file at path: .../_runner_file_commands/save_state_<uuid>`.
+
+- **`kind="diag_pages"`** — `.log` files directly under
+  `<runner>/_diag/pages/` older than `DIAG_PAGES_MIN_AGE_DAYS` (default 1).
+  When two runs collide on a UUID the runner aborts with
+  `the file '.../<uuid>_<uuid>_1.log' already exists`.
+
+### Alerting
+
+```yaml
+- alert: RunnerCorruptionResidue
+  expr: sum by (host, runner) (runner_corruption_residue_count) > 0
+  for: 10m
+```
+
+The 10-minute `for:` is long enough to span a busy job that legitimately
+populates `_runner_file_commands` mid-execution.
+
+### How this would have caught #651
+
+The corruption residue is the *physical* failure mode that surfaces when
+cleanup stops running. Even if `runner_cleanup_runs_total` hadn't existed,
+this metric would have shown stale residue accumulating per-runner. Alerts
+would have fired on the first runner to hold ≥1 residue file for >10 min.
+
+## 3. `runner_orphan_worker_total`
+
+| Field          | Value                                                          |
+| -------------- | -------------------------------------------------------------- |
+| Type           | Counter                                                        |
+| Labels         | `host`, `runner` (systemd unit name)                          |
+| Emitter        | Vector journald → `log_to_metric` transform                    |
+| Scrape path    | Vector Prometheus exporter sink                                |
+| Endpoint       | `${VECTOR_PROM_ADDR:-0.0.0.0:9598}/metrics`                    |
+| Loki audit     | Loki stream `{event="orphan_worker"}` (raw journald line)      |
+
+Pattern matched in journald:
+
+```
+Unit process <PID> (Runner.Worker) remains running after unit stopped
+```
+
+This message is emitted by systemd when an `actions.runner.*.service` unit
+with `KillMode=process` stops without taking its `Runner.Worker` child with
+it. The orphan continues writing to `_runner_file_commands/` and
+`_diag/pages/`, producing the residue counted by metric #2.
+
+### Open coupling
+
+The `KillMode=` policy on the per-runner systemd units is owned by the
+autoscaler PR (#3 in this series) — see the parent task. This metric is
+*observation only* and intentionally avoids touching unit files.
+
+> **TODO (operator):** confirm your Prometheus scraper is configured to
+> pull `<vector-host>:9598/metrics`. The fleet does not yet ship a
+> centralised Prometheus config in this repo; if Vector is behind a
+> Tailscale tailnet, expose the scrape port via Tailscale, not the public
+> internet.
+
+### Alerting
+
+```yaml
+- alert: RunnerOrphanWorker
+  expr: increase(runner_orphan_worker_total[15m]) > 0
+  for: 5m
+  annotations:
+    summary: "Orphan Runner.Worker detected on {{ $labels.host }} ({{ $labels.runner }})"
+```
+
+## Installation summary
+
+`deploy/install-runner-maintenance.sh` installs the cleanup script, the
+corruption-scan script, and three systemd timers:
+
+| Timer                            | Cadence                  | Emits                                       |
+| -------------------------------- | ------------------------ | ------------------------------------------- |
+| `runner-cleanup.timer`           | Daily, 04:20 + jitter    | `runner_cleanup_runs_total` family          |
+| `runner-corruption-scan.timer`   | `OnUnitActiveSec=5min`   | `runner_corruption_residue_count`           |
+| `runner-scheduler.timer`         | Every 5 min              | (pre-existing — not changed by this PR)     |
+
+Vector (`deploy/observability/vector.toml`) handles the orphan-Worker
+metric; install Vector separately on each fleet node.
+
+The textfile-collector directory is operator-configurable via the
+`TEXTFILE_COLLECTOR_DIR` env var; the default
+(`/var/lib/node_exporter/textfile_collector`) matches the upstream
+node_exporter default.

--- a/tests/deploy/test_runner_corruption_scan.py
+++ b/tests/deploy/test_runner_corruption_scan.py
@@ -1,0 +1,204 @@
+"""Tests for deploy/runner-corruption-scan.sh.
+
+The scan script walks ``$RUNNER_ROOT`` looking for two known corruption
+signatures (see issue #651):
+
+* Stale files under ``runner-*/_work/_temp/_runner_file_commands/`` — these
+  should be cleaned at the end of every job; anything still present when the
+  runner is idle is residue from a mid-job kill and will cause the next
+  allocation to fail.
+* ``runner-*/_diag/pages/*.log`` files older than one day — when the actions
+  runner collides on a UUID, startup aborts with ``file already exists``.
+
+The script emits Prometheus textfile-collector format to a destination file:
+
+    runner_corruption_residue_count{host="...",runner="runner-01",kind="file_commands"} 3
+    runner_corruption_residue_count{host="...",runner="runner-01",kind="diag_pages"} 1
+
+These tests build synthetic runner trees in a tmp dir and assert the emitted
+metrics file matches the expected counts.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "deploy" / "runner-corruption-scan.sh"
+
+
+def _find_bash() -> str | None:
+    """Locate a POSIX bash that can resolve host filesystem paths.
+
+    On Windows, ``shutil.which("bash")`` typically returns ``C:\\Windows\\
+    System32\\bash.exe`` (WSL), which sees a separate Linux filesystem and
+    cannot resolve repo paths. Prefer Git Bash when it is installed.
+    """
+    candidates = [
+        os.environ.get("BASH"),
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+        r"C:\Program Files\Git\bin\bash.exe",
+        "/usr/bin/bash",
+        "/bin/bash",
+        shutil.which("bash"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            # Skip the WSL bash shim — it cannot see Windows paths.
+            if candidate.lower().endswith(r"system32\bash.exe"):
+                continue
+            return candidate
+    return None
+
+
+BASH = _find_bash()
+
+pytestmark = pytest.mark.skipif(
+    BASH is None,
+    reason="POSIX bash (Git Bash on Windows) is required to exercise the scan script",
+)
+
+
+def _as_bash_path(p: Path) -> str:
+    """Translate a host path into one bash on this platform can resolve.
+
+    On Windows / Git Bash, forward slashes are the safe form; the Git Bash
+    shell otherwise interprets backslashes as escapes when arguments are
+    passed through Python's subprocess.
+    """
+    return str(p).replace("\\", "/")
+
+
+def _run_scan(runner_root: Path, prom_path: Path, host: str = "test-host") -> str:
+    """Invoke the scan script and return the file's contents."""
+    env = os.environ.copy()
+    env["RUNNER_ROOT"] = _as_bash_path(runner_root)
+    env["PROM_FILE"] = _as_bash_path(prom_path)
+    env["FLEET_NODE_NAME"] = host
+    env["DIAG_PAGES_MIN_AGE_DAYS"] = "1"
+    result = subprocess.run(
+        [BASH or "bash", _as_bash_path(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"scan script failed: rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return prom_path.read_text()
+
+
+def _metric_value(content: str, runner: str, kind: str) -> int:
+    """Extract the metric value for a given runner+kind tuple."""
+    pattern = (
+        r"runner_corruption_residue_count\{[^}]*"
+        rf'runner="{re.escape(runner)}"[^}}]*kind="{re.escape(kind)}"[^}}]*\}}'
+        r"\s+(\d+)"
+    )
+    match = re.search(pattern, content)
+    if match is None:
+        # try kind-first ordering too
+        pattern2 = (
+            r"runner_corruption_residue_count\{[^}]*"
+            rf'kind="{re.escape(kind)}"[^}}]*runner="{re.escape(runner)}"[^}}]*\}}'
+            r"\s+(\d+)"
+        )
+        match = re.search(pattern2, content)
+    assert match is not None, f"no metric line for runner={runner} kind={kind} in:\n{content}"
+    return int(match.group(1))
+
+
+def test_script_exists_and_is_syntactically_valid() -> None:
+    assert SCRIPT.exists(), f"scan script missing: {SCRIPT}"
+    result = subprocess.run(
+        [BASH or "bash", "-n", _as_bash_path(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_empty_runner_root_emits_zero_metrics(tmp_path: Path) -> None:
+    runner_root = tmp_path / "runners"
+    runner_root.mkdir()
+    prom = tmp_path / "out.prom"
+    content = _run_scan(runner_root, prom)
+    # Header + TYPE lines must be present even with zero runners.
+    assert "# TYPE runner_corruption_residue_count gauge" in content
+
+
+def test_counts_file_commands_residue(tmp_path: Path) -> None:
+    runner_root = tmp_path / "runners"
+    rfc = runner_root / "runner-01" / "_work" / "_temp" / "_runner_file_commands"
+    rfc.mkdir(parents=True)
+    (rfc / "save_state_abc").write_text("x")
+    (rfc / "save_state_def").write_text("y")
+    (rfc / "set_output_ghi").write_text("z")
+    # An untracked file outside the residue dir must NOT be counted.
+    (runner_root / "runner-01" / "_work" / "_temp" / "ignore.txt").write_text("nope")
+
+    prom = tmp_path / "out.prom"
+    content = _run_scan(runner_root, prom)
+    assert _metric_value(content, "runner-01", "file_commands") == 3
+    assert _metric_value(content, "runner-01", "diag_pages") == 0
+
+
+def test_counts_diag_pages_older_than_one_day(tmp_path: Path) -> None:
+    runner_root = tmp_path / "runners"
+    diag = runner_root / "runner-02" / "_diag" / "pages"
+    diag.mkdir(parents=True)
+    old1 = diag / "stale1.log"
+    old2 = diag / "stale2.log"
+    fresh = diag / "fresh.log"
+    other = diag / "ignore.txt"
+    for f in (old1, old2, fresh, other):
+        f.write_text("log")
+    two_days_ago = time.time() - (2 * 86400)
+    os.utime(old1, (two_days_ago, two_days_ago))
+    os.utime(old2, (two_days_ago, two_days_ago))
+
+    prom = tmp_path / "out.prom"
+    content = _run_scan(runner_root, prom)
+    assert _metric_value(content, "runner-02", "diag_pages") == 2
+    assert _metric_value(content, "runner-02", "file_commands") == 0
+
+
+def test_multiple_runners_are_reported_independently(tmp_path: Path) -> None:
+    runner_root = tmp_path / "runners"
+    for name, n_fc in (("runner-a", 1), ("runner-b", 4)):
+        rfc = runner_root / name / "_work" / "_temp" / "_runner_file_commands"
+        rfc.mkdir(parents=True)
+        for i in range(n_fc):
+            (rfc / f"f{i}").write_text("x")
+    # Non-runner directories must be ignored.
+    (runner_root / "notes.txt").write_text("ignore")
+    (runner_root / "other-dir").mkdir()
+
+    prom = tmp_path / "out.prom"
+    content = _run_scan(runner_root, prom)
+    assert _metric_value(content, "runner-a", "file_commands") == 1
+    assert _metric_value(content, "runner-b", "file_commands") == 4
+
+
+def test_emits_atomic_write(tmp_path: Path) -> None:
+    """The script must write via a temp file then rename for atomicity.
+
+    Prometheus' textfile collector reads the file mid-scrape; a partial write
+    would expose half-formed metrics. We assert that after the run there is
+    exactly one .prom file and no stray .prom.tmp left over.
+    """
+    runner_root = tmp_path / "runners"
+    runner_root.mkdir()
+    prom = tmp_path / "out.prom"
+    _run_scan(runner_root, prom)
+    leftovers = list(tmp_path.glob("*.prom.tmp"))
+    assert leftovers == [], f"temp files were not cleaned up: {leftovers}"


### PR DESCRIPTION
## Summary

Adds three Prometheus metrics so that silent regressions of the runner cleanup pipeline (issue #651, strict-mode fix in #660) can no longer accumulate undetected.

| Metric | Type | Scrape path | Emitted by |
| --- | --- | --- | --- |
| `runner_cleanup_runs_total{host,result}` | counter | node_exporter textfile collector — `\${TEXTFILE_COLLECTOR_DIR}/runner_cleanup.prom` | `deploy/runner-cleanup.sh` via `write_metrics()` in an EXIT trap |
| `runner_corruption_residue_count{host,runner,kind}` | gauge | node_exporter textfile collector — `\${PROM_FILE}` | new `deploy/runner-corruption-scan.sh` on a 5-min systemd timer |
| `runner_orphan_worker_total{host,runner}` | counter | Vector `prometheus_exporter` sink at `:9598/metrics` (Loki audit stream `event=orphan_worker`) | Vector `journald` → `log_to_metric` transform |

Co-emitted with metric #1: `runner_cleanup_stop_failures_total` and `runner_cleanup_last_run_timestamp_seconds` (stale-by-time alerting is more reliable than stale-by-counter).

## How this would have caught #651

The strict-mode regression caused `runner-cleanup.sh` to exit early under `set -Eeuo pipefail`. Because `write_metrics()` is installed as an EXIT trap, every aborted run still publishes `result=\"failed\"` and a fresh `last_run_timestamp_seconds`. A `RunnerCleanupFailing` alert (`increase(runner_cleanup_runs_total{result=\"failed\"}[2h]) > 0`) would have paged on the first 2-hour window after the regression landed.

Even without metric #1, metric #2 would have lit up: the corruption residue is the *physical* failure mode that surfaces when cleanup stops running, and the 5-minute scanner would have shown stale `_runner_file_commands/` files accumulating on every affected runner.

## Files changed

- `deploy/runner-cleanup.sh` — `write_metrics()` + EXIT trap, stop-failure counter, result tracking (`ok`/`skipped`/`failed`).
- `deploy/runner-corruption-scan.sh` — new ~60-line scanner, atomic publish via `.tmp` + `mv -f`.
- `deploy/runner-corruption-scan.service` + `.timer` — `OnUnitActiveSec=5min`.
- `deploy/install-runner-maintenance.sh` — installs the new script + unit + timer, creates the textfile-collector dir, drops a systemd drop-in so `runner-cleanup.service` writes to the same dir.
- `deploy/observability/vector.toml` — adds a journald source for systemd, a filter for the orphan-Worker log line, `log_to_metric` transform, `prometheus_exporter` sink, and a Loki audit stream.
- `tests/deploy/test_runner_corruption_scan.py` — pytest with tmpdir fixtures; six tests covering empty trees, file-commands counting, age-thresholded diag-pages counting, multi-runner independence, and atomic-write invariants.
- `docs/observability.md` — metric reference, scrape paths, alerting rules, install summary, #651 retrospective.

## Test plan

- [x] `bash -n` on all three shell scripts.
- [x] `pytest tests/deploy/test_runner_corruption_scan.py -q` — 6 passed.
- [x] `ruff check` and `ruff format --check` on the new test file.
- [ ] Manual: install on a fleet host, confirm node_exporter exposes both textfile metrics within one scrape interval.
- [ ] Manual: trigger an orphan Worker (KillMode=process + kill the runner unit) and confirm `runner_orphan_worker_total` increments at the Vector exporter endpoint.

## Open questions

- The fleet does not yet ship a centralised Prometheus scrape config in this repo. The Vector `prometheus_exporter` sink listens on `\${VECTOR_PROM_ADDR:-0.0.0.0:9598}/metrics`; operators must add a scrape job pointing at it. See the TODO block in `deploy/observability/vector.toml` and the corresponding section in `docs/observability.md`.
- Whether to also wire these into `backend/prometheus_metrics.py` as a secondary `/metrics` path is deferred — the textfile collector is the canonical source and the dashboard endpoint would have to read the same files anyway.

## Out of scope

- Autoscaler / `KillMode=` changes on runner unit files belong to the parallel PR #3 in this series.
- No refactor of the existing cleanup logic — the `write_metrics()` function appends only.

Closes #651 (observability half — the strict-mode fix lands in #660).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>