### PR TITLE
fix: harden DeskComputer dashboard deploy

### DIFF
--- a/backend/dashboard_config/timeouts.py
+++ b/backend/dashboard_config/timeouts.py
@@ -36,6 +36,7 @@ class HttpTimeout:
     # GitHub API tail latency without holding workers too long.
     PROXY_TO_HUB_S: float = 15.0
     GH_API_DEFAULT_S: int = 15
+    HEALTH_GH_API_S: int = 1
 
     # Default budget for ``run_cmd`` subprocess invocations. Used at call
     # sites that pass ``timeout=20`` explicitly when a tighter budget is

--- a/backend/health.py
+++ b/backend/health.py
@@ -27,6 +27,7 @@ import dashboard_config
 from cache_utils import cache_size
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from prometheus_metrics import record_dashboard_health
 from readiness import aggregate, get_default_probes
 
 router = APIRouter(tags=["health"])
@@ -95,6 +96,7 @@ async def readyz() -> JSONResponse:
 
 async def _health_impl() -> dict:
     """Core health logic, callable both from the HTTP endpoint and internally."""
+    start = time.perf_counter()
     # Lazy import to avoid circular dependency with server.py
     from server import (  # noqa: PLC0415
         BOOT_TIME,
@@ -106,25 +108,37 @@ async def _health_impl() -> dict:
         gh_api_admin,
     )
 
+    github_error_type = None
     try:
         # Reuse the runner cache so health checks don't add extra API calls.
         data = _cache_get("runners", 25.0)
         if data is None:
-            data = await gh_api_admin(f"/orgs/{ORG}/actions/runners")
+            data = await gh_api_admin(
+                f"/orgs/{ORG}/actions/runners",
+                timeout=dashboard_config.HttpTimeout.HEALTH_GH_API_S,
+            )
             _cache_set("runners", data)
         gh_ok = True
         runner_count = len(data.get("runners", []))
     except Exception as e:  # noqa: BLE001
         if isinstance(e, (KeyboardInterrupt, SystemExit)):
             raise
+        github_error_type = type(e).__name__
         gh_ok = False
         runner_count = 0
 
+    github_api = "connected" if gh_ok else "unreachable"
+    status = "healthy" if gh_ok else "degraded"
+    duration_s = time.perf_counter() - start
+    record_dashboard_health(status, github_api, duration_s)
+
     return {
-        "status": "healthy" if gh_ok else "degraded",
+        "status": status,
         "timestamp": _dt_mod.datetime.now(UTC).isoformat(),
         "hostname": HOSTNAME,
-        "github_api": "connected" if gh_ok else "unreachable",
+        "github_api": github_api,
+        "github_error_type": github_error_type,
+        "github_check_seconds": round(duration_s, 3),
         "runners_registered": runner_count,
         "dashboard_uptime_seconds": int(time.time() - BOOT_TIME),
         "deployment": _deployment_info(),

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -5,9 +5,19 @@ Extracted from server.py as part of issue #159 god-module-refactor-2026q2.
 
 from __future__ import annotations
 
+import datetime as _dt_mod
+import os
+import platform
+import shutil
+import time
+from pathlib import Path
+
+import psutil
 from fastapi import APIRouter, Request
 
 router = APIRouter(tags=["metrics"])
+UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
+datetime = _dt_mod.datetime
 
 
 @router.get("/api/system")
@@ -24,18 +34,7 @@ async def get_system_metrics():
         get_gpu_info,
         get_per_runner_resources,
     )
-    from server import (  # noqa: PLC0415
-        BOOT_TIME,
-        HOST_MEMORY_GB,
-        UTC,
-        Path,
-        datetime,
-        os,
-        platform,
-        psutil,
-        shutil,
-        time,
-    )
+    from server import BOOT_TIME, HOST_MEMORY_GB  # noqa: PLC0415
 
     cpu_freq = psutil.cpu_freq()
     mem = psutil.virtual_memory()

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -228,12 +228,12 @@ async def add_security_headers(request: Request, call_next: Any) -> Any:
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "SAMEORIGIN"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    # CSP: remove third-party CDN sources; use 'strict-dynamic' with nonce-based
-    # scripts only (issue #324).  'unsafe-inline' on style-src is retained for
-    # Vite-injected critical CSS until a nonce pipeline is available.
+    # CSP: keep script loading self-hosted. Vite emits static module scripts
+    # without nonces, so do not use strict-dynamic until the HTML path can
+    # attach a nonce to the generated entrypoint.
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
-        "script-src 'self' 'strict-dynamic'; "
+        "script-src 'self'; "
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data:; "
         "connect-src 'self'; "

--- a/backend/prometheus_metrics.py
+++ b/backend/prometheus_metrics.py
@@ -11,6 +11,8 @@ the ``prometheus_client`` library.  Metrics collected:
 - ``dashboard_runner_leases_expired_total``   – Expired runner leases counter
 - ``dashboard_cache_hits_total``              – Cache hits by cache name
 - ``dashboard_cache_misses_total``            – Cache misses by cache name
+- ``dashboard_health_checks_total``           – Dashboard health outcomes
+- ``dashboard_health_check_duration_seconds`` – Dashboard health-check latency
 """
 
 from __future__ import annotations
@@ -85,6 +87,19 @@ if _PROMETHEUS_AVAILABLE:
         "Total cache misses",
         ["cache"],
     )
+
+    # Health endpoint
+    DASHBOARD_HEALTH_CHECKS_TOTAL = Counter(
+        "dashboard_health_checks_total",
+        "Total dashboard health checks by dashboard and GitHub API status",
+        ["status", "github_api"],
+    )
+    DASHBOARD_HEALTH_DURATION = Histogram(
+        "dashboard_health_check_duration_seconds",
+        "Dashboard health-check latency in seconds",
+        ["status", "github_api"],
+        buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+    )
 else:  # pragma: no cover
     # Stub objects so imports don't fail when prometheus_client is absent
     class _Stub:  # type: ignore[override]
@@ -114,6 +129,8 @@ else:  # pragma: no cover
     RUNNER_LEASES_EXPIRED_TOTAL = _stub  # type: ignore[assignment]
     CACHE_HITS_TOTAL = _stub  # type: ignore[assignment]
     CACHE_MISSES_TOTAL = _stub  # type: ignore[assignment]
+    DASHBOARD_HEALTH_CHECKS_TOTAL = _stub  # type: ignore[assignment]
+    DASHBOARD_HEALTH_DURATION = _stub  # type: ignore[assignment]
 
 
 # ─── Helpers for external callers ─────────────────────────────────────────────
@@ -133,6 +150,12 @@ def record_cache_hit(cache_name: str) -> None:
 def record_cache_miss(cache_name: str) -> None:
     """Record a cache miss for the named cache."""
     CACHE_MISSES_TOTAL.labels(cache=cache_name).inc()
+
+
+def record_dashboard_health(status: str, github_api: str, duration_s: float) -> None:
+    """Record a completed dashboard health check."""
+    DASHBOARD_HEALTH_CHECKS_TOTAL.labels(status=status, github_api=github_api).inc()
+    DASHBOARD_HEALTH_DURATION.labels(status=status, github_api=github_api).observe(duration_s)
 
 
 def update_lease_gauge(active_count: int) -> None:

--- a/backend/server.py
+++ b/backend/server.py
@@ -703,14 +703,14 @@ async def run_cmd(
         return -1, "", "Command timed out"
 
 
-async def gh_api(endpoint: str) -> dict:
+async def gh_api(endpoint: str, timeout: int = HttpTimeout.GH_DISPATCH_S) -> dict:
     """Call the GitHub API via gh CLI.
 
     Uses GH_TOKEN env var when set (required for admin:org endpoints such as
     /orgs/{org}/actions/runners).  GH_TOKEN must be a classic PAT with
     scopes: repo, admin:org.  See docs/operations/fleet-machine-setup.md.
     """
-    code, stdout, stderr = await run_cmd(["gh", "api", endpoint])
+    code, stdout, stderr = await run_cmd(["gh", "api", endpoint], timeout=timeout)
     if code != 0:
         raise HTTPException(status_code=502, detail=f"GitHub API error: {stderr}")
     return json.loads(stdout)

--- a/deploy/update-deployed.sh
+++ b/deploy/update-deployed.sh
@@ -96,7 +96,12 @@ else
 
     info "Copying frontend..."
     if ! dry_run "sync_dir $REPO/runner-dashboard/frontend $DEPLOY_DIR/frontend"; then
+        if [[ ! -d "$REPO/node_modules" ]]; then
+            (cd "$REPO" && npm install --no-audit --no-fund --package-lock=false)
+        fi
+        (cd "$REPO" && npm run build)
         sync_dir "$REPO/frontend" "$DEPLOY_DIR/frontend"
+        sync_dir "$REPO/dist" "$DEPLOY_DIR/dist"
         ok  "frontend deployed"
     fi
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -21,6 +21,9 @@ i18n
       order: ['localStorage', 'navigator'],
       caches: ['localStorage'],
     },
+    react: {
+      useSuspense: false,
+    },
   });
 
 export default i18n;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -220,18 +220,20 @@ function AppWithMobileShell({ initialTab }: { initialTab?: string }) {
 // isPushSettingsRoute(window.location.pathname) ? <PushSettings /> : <AppWithMobileShell />
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RootErrorBoundary>
-      <ThemeProvider>
-        <BreakpointProvider>
-          <Toaster>
-            {isPushSettingsRoute(window.location.pathname) ? (
-              <PushSettings />
-            ) : (
-              <AppWithMobileShell initialTab={initialTabFromPathname(window.location.pathname)} />
-            )}
-          </Toaster>
-        </BreakpointProvider>
-      </ThemeProvider>
-    </RootErrorBoundary>
+    <React.Suspense fallback={<div role="status" className="app-loading">Loading dashboard...</div>}>
+      <RootErrorBoundary>
+        <ThemeProvider>
+          <BreakpointProvider>
+            <Toaster>
+              {isPushSettingsRoute(window.location.pathname) ? (
+                <PushSettings />
+              ) : (
+                <AppWithMobileShell initialTab={initialTabFromPathname(window.location.pathname)} />
+              )}
+            </Toaster>
+          </BreakpointProvider>
+        </ThemeProvider>
+      </RootErrorBoundary>
+    </React.Suspense>
   </React.StrictMode>,
 )

--- a/tests/test_deploy_hardening.py
+++ b/tests/test_deploy_hardening.py
@@ -52,6 +52,13 @@ def test_update_deployed_requires_successful_backup() -> None:
     assert 'fail "Backup returned empty path; aborting update"' in content
 
 
+def test_update_deployed_builds_and_syncs_frontend_dist() -> None:
+    content = _read(_DEPLOY / "update-deployed.sh")
+    assert "npm install --no-audit --no-fund --package-lock=false" in content
+    assert "npm run build" in content
+    assert 'sync_dir "$REPO/dist" "$DEPLOY_DIR/dist"' in content
+
+
 def test_refresh_token_requires_more_than_prefix() -> None:
     content = _read(_DEPLOY / "refresh-token.sh")
     assert "[A-Za-z0-9_]{30,}" in content

--- a/tests/test_frontend_integrity.py
+++ b/tests/test_frontend_integrity.py
@@ -472,6 +472,18 @@ def test_push_settings_route_tracer_bullet_is_present() -> None:
         assert marker in main_tsx
 
 
+def test_main_tsx_has_root_suspense_fallback() -> None:
+    main_tsx = (_FRONTEND_DIR / "src" / "main.tsx").read_text(encoding="utf-8")
+    assert "<React.Suspense" in main_tsx
+    assert 'role="status"' in main_tsx
+    assert "Loading dashboard..." in main_tsx
+
+
+def test_i18n_disables_suspense_for_sync_resources() -> None:
+    i18n_ts = (_FRONTEND_DIR / "src" / "i18n.ts").read_text(encoding="utf-8")
+    assert "useSuspense: false" in i18n_ts
+
+
 # ---------------------------------------------------------------------------
 # Single source of truth enforcement (issue #3)
 # ---------------------------------------------------------------------------

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -6,8 +6,19 @@ We can test the router object without spawning the full server.
 
 from __future__ import annotations
 
-import health as h
+import sys
+import time
+import types
+from pathlib import Path
+
+import pytest
 from fastapi import APIRouter
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+import health as h  # noqa: E402
 
 
 def test_router_is_apiRouter() -> None:
@@ -18,3 +29,45 @@ def test_router_has_health_routes() -> None:
     paths = [r.path for r in h.router.routes]  # type: ignore[attr-defined]
     # At minimum a /health or /api/health route must exist
     assert any("health" in p for p in paths), f"No health route found in {paths}"
+
+
+@pytest.mark.asyncio
+async def test_api_health_uses_short_github_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Health polling must not inherit the long dispatch timeout."""
+    import dashboard_config  # noqa: PLC0415
+
+    seen: dict[str, int] = {}
+    metrics: list[tuple[str, str, float]] = []
+
+    async def fake_gh_api_admin(endpoint: str, timeout: int = 30) -> dict:
+        seen["endpoint"] = endpoint
+        seen["timeout"] = timeout
+        raise RuntimeError("network unavailable")
+
+    fake_server = types.SimpleNamespace(
+        BOOT_TIME=time.time(),
+        HOSTNAME="test-host",
+        ORG="D-sorganization",
+        _cache_get=lambda *_args, **_kwargs: None,
+        _cache_set=lambda *_args, **_kwargs: None,
+        _deployment_info=lambda: {"version": "test"},
+        gh_api_admin=fake_gh_api_admin,
+    )
+    monkeypatch.setitem(sys.modules, "server", fake_server)
+    monkeypatch.setattr(
+        h,
+        "record_dashboard_health",
+        lambda status, github_api, duration_s: metrics.append((status, github_api, duration_s)),
+    )
+
+    body = await h._health_impl()  # noqa: SLF001
+
+    assert body["status"] == "degraded"
+    assert body["github_api"] == "unreachable"
+    assert body["github_error_type"] == "RuntimeError"
+    assert body["github_check_seconds"] >= 0
+    assert seen["endpoint"] == "/orgs/D-sorganization/actions/runners"
+    assert seen["timeout"] == dashboard_config.HttpTimeout.HEALTH_GH_API_S
+    assert metrics
+    assert metrics[0][0:2] == ("degraded", "unreachable")
+    assert metrics[0][2] >= 0

--- a/tests/test_metrics_module.py
+++ b/tests/test_metrics_module.py
@@ -38,3 +38,10 @@ def test_server_registers_metrics_router() -> None:
     server_src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
     assert "import metrics as _metrics_router" in server_src
     assert "include_router(_metrics_router.router)" in server_src
+
+
+def test_metrics_imports_psutil_directly() -> None:
+    """metrics.py must not depend on server.py re-exporting psutil."""
+    metrics_src = (_BACKEND_DIR / "metrics.py").read_text(encoding="utf-8")
+    assert "import psutil" in metrics_src
+    assert "psutil," not in metrics_src

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -110,6 +110,15 @@ def test_security_headers_csp_has_default_src() -> None:
     assert "default-src" in csp
 
 
+def test_security_headers_csp_allows_static_vite_entrypoint() -> None:
+    app = _make_app_with_security_headers()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/anything")
+    csp = resp.headers.get("Content-Security-Policy", "")
+    assert "script-src 'self';" in csp
+    assert "strict-dynamic" not in csp
+
+
 def test_security_headers_present_on_post() -> None:
     """Security headers must be injected on POST responses too."""
     app = _make_app_with_security_headers()

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -59,12 +59,19 @@ def test_record_cache_hit_miss_do_not_raise() -> None:
     record_cache_miss("main")
 
 
+def test_record_dashboard_health_do_not_raise() -> None:
+    from prometheus_metrics import record_dashboard_health  # noqa: PLC0415
+
+    record_dashboard_health("degraded", "unreachable", 3.1)
+
+
 def test_helper_functions_exported() -> None:
     import prometheus_metrics  # noqa: PLC0415
 
     assert callable(prometheus_metrics.record_gh_api_call)
     assert callable(prometheus_metrics.record_cache_hit)
     assert callable(prometheus_metrics.record_cache_miss)
+    assert callable(prometheus_metrics.record_dashboard_health)
     assert callable(prometheus_metrics.update_lease_gauge)
     assert callable(prometheus_metrics.record_lease_expired)
 


### PR DESCRIPTION
## Summary

Six tightly-related fixes that surfaced on DeskComputer's first deploy of the new `deploy-host.sh` flow. All are valid and address real bugs — several align with what was diagnosed independently on ControlTower during the diagnostics work for #668.

### 1. `/api/health` no longer hangs on slow GitHub  (`backend/health.py`, `backend/dashboard_config/timeouts.py`, `backend/server.py`)

The health check called `gh_api_admin(...)` with no timeout, so it inherited `run_cmd`'s default. When GitHub was slow/unreachable (which on DeskComputer it consistently was due to a WSL outbound networking issue), the health endpoint hung instead of failing fast.

- New `HttpTimeout.HEALTH_GH_API_S = 1` (one second).
- `health.py` passes that to `gh_api_admin`.
- `gh_api(endpoint, timeout=…)` in `server.py` gains an optional `timeout` so call sites can override.
- Response body now reports `github_error_type` and `github_check_seconds` so operators can see what's wrong.
- Two new Prometheus metrics: `dashboard_health_checks_total{status, github_api}` and `dashboard_health_check_duration_seconds`.

### 2. `metrics.py` imports stdlib + `psutil` directly  (`backend/metrics.py`)

`metrics.py` was importing `psutil`, `os`, `platform`, `shutil`, `time`, `datetime`, `UTC`, `Path` **from `server.py`** — i.e. relying on `server.py` to re-export the entire stdlib. Any change to `server.py`'s top-level imports broke `/api/system` with `ImportError: cannot import name 'psutil' from 'server'`. Observed in ControlTower's journal during the diagnostics work too.

Fix: import them directly in `metrics.py`. Only `BOOT_TIME` and `HOST_MEMORY_GB` (genuine server state) still come from `server`.

Test added: `test_metrics_imports_psutil_directly` pins the contract.

### 3. `update-deployed.sh` actually builds the frontend  (`deploy/update-deployed.sh`)

This is **the missing build step** that caused the favicon (and every other frontend asset) to 404 on the deployed dashboard. `update-deployed.sh` was syncing `frontend/` source as-is, but `server.py` serves from `<dashboard>/dist/`, which only exists after `vite build`. Result: `/`, `/icons/*`, `/favicon.ico`, `/manifest.webmanifest` all returned 404 or the API fallback HTML.

Fix:
- `npm install --no-audit --no-fund --package-lock=false` if `node_modules` missing.
- `npm run build`.
- `sync_dir "$REPO/dist" "$DEPLOY_DIR/dist"`.

Test: `test_update_deployed_builds_and_syncs_frontend_dist`.

### 4. Root `<React.Suspense>` fallback  (`frontend/src/main.tsx`)

Without a Suspense boundary at the root, any `React.lazy` or Suspense-using component crashes with "no Suspense boundary" and the page goes black. Adds a fallback `<div role="status">Loading dashboard...</div>`.

### 5. Disable i18n Suspense for sync resources  (`frontend/src/i18n.ts`)

`react-i18next` defaults to Suspense-driven loading. When translations are local/sync, this triggers spurious re-renders. Set `react.useSuspense: false`.

### 6. Restore static-script CSP  (`backend/middleware.py`)

`script-src 'self' 'strict-dynamic'` requires nonces on each `<script>` tag. Vite-built static HTML doesn't emit nonces, so every script was blocked → black screen. The TODO is a proper nonce pipeline, but for now `script-src 'self'` is correct (same-origin only).

Test: `test_security_headers_csp_allows_static_vite_entrypoint`.

## Validation

- `ruff check` clean on all touched files.
- `pytest tests/test_health.py tests/test_metrics_module.py tests/test_prometheus_metrics.py tests/test_deploy_hardening.py tests/test_middleware.py tests/test_frontend_integrity.py` — all PR-related tests pass. Two failures are pre-existing (Dockerfile sha256 pinning + push-settings tracer marker out of date) and unrelated to this PR.
- `npm run build` succeeds after `rm -rf node_modules` on Windows-mounted repo (recommended note: WSL2 hosts with `/mnt/c` repos should wipe `node_modules` before first deploy to avoid cross-platform native-binding contamination).
- Live deploy on `d-sorg-local-ControlTower` (post-merge of #668) → see deploy log in the next comment.

## Mergeable with current main

PR was created against `243ff45` (the current `main` after #668), so no rebase needed. Diff: 15 files, +178/-36.

## DeskComputer note

WSL public outbound TCP to `api.github.com` / `1.1.1.1` is still timing out from DeskComputer while Windows-side HTTP succeeds. With this PR's 1s timeout, the dashboard now degrades gracefully on that host. The underlying WSL network path is a separate host-level fix that doesn't block this PR.