### PR TITLE
fix(server): mount /icons + serve /favicon.ico /sw.js /offline.html /robots.txt

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -2309,6 +2309,63 @@ _assets_dir = FRONTEND_DIR / "assets"
 if _assets_dir.is_dir():
     app.mount("/assets", StaticFiles(directory=str(_assets_dir)), name="assets")
 
+# Mount the PWA icon set for /icons/<name>.png. The dist build copies
+# frontend/public/icons/ to dist/icons/ via vite build (the public/ dir
+# semantics). Without this mount, /icons/icon-180.png requests fall through
+# to the SPA catch-all and return index.html, which means Windows taskbar
+# pinned shortcuts (and any browser that pre-fetches the apple-touch-icon)
+# get HTML instead of a PNG and silently fall back to a generic icon.
+_icons_dir = FRONTEND_DIR / "icons"
+if _icons_dir.is_dir():
+    app.mount("/icons", StaticFiles(directory=str(_icons_dir)), name="icons")
+
+
+@app.get("/favicon.ico")
+async def serve_favicon():
+    """Serve /favicon.ico for browsers and taskbar shortcuts.
+
+    Windows browsers always probe this URL when creating a pinned site
+    shortcut. With no real ICO in the bundle, fall back to the SVG icon
+    served with image/x-icon content type (the SVG renders fine in modern
+    browsers; only legacy IE would have a problem).
+    """
+    favicon = FRONTEND_DIR / "favicon.ico"
+    if favicon.exists():
+        return FileResponse(favicon, media_type="image/x-icon")
+    svg = FRONTEND_DIR / "icon.svg"
+    if svg.exists():
+        return FileResponse(svg, media_type="image/svg+xml")
+    raise HTTPException(status_code=404, detail="favicon not found")
+
+
+@app.get("/sw.js")
+async def serve_service_worker():
+    """Serve the PWA service worker. Must be at the origin root or PWA
+    install fails."""
+    sw = FRONTEND_DIR / "sw.js"
+    if not sw.exists():
+        raise HTTPException(status_code=404, detail="service worker not found")
+    return FileResponse(sw, media_type="application/javascript")
+
+
+@app.get("/offline.html")
+async def serve_offline():
+    """Serve the PWA offline fallback page."""
+    offline = FRONTEND_DIR / "offline.html"
+    if not offline.exists():
+        raise HTTPException(status_code=404, detail="offline page not found")
+    return FileResponse(offline, media_type="text/html")
+
+
+@app.get("/robots.txt")
+async def serve_robots():
+    """Serve robots.txt (currently disallows everything; this dashboard is
+    a private operator console)."""
+    robots = FRONTEND_DIR / "robots.txt"
+    if not robots.exists():
+        raise HTTPException(status_code=404, detail="robots.txt not found")
+    return FileResponse(robots, media_type="text/plain")
+
 
 @app.get("/")
 async def serve_index():

--- a/tests/test_static_serving.py
+++ b/tests/test_static_serving.py
@@ -1,0 +1,59 @@
+"""Tests for the dashboard's static-asset routes.
+
+Background: `update-deployed.sh` now runs `vite build` and syncs `dist/` to
+the deployed install (PR #669). But the FastAPI server only mounted
+`/assets` — every other static URL referenced from `index.html`
+(`/icons/icon-180.png`, `/favicon.ico`, `/manifest.webmanifest`, etc.) fell
+through to the SPA catch-all and returned `index.html` as `text/html`.
+
+Symptom: Windows taskbar pinned shortcuts had no favicon because the
+browser fetched `/favicon.ico` and got 1.8 KB of HTML instead of an icon.
+
+This module pins the contract that each of these URLs serves real binary
+content with the right Content-Type when the matching file exists in
+`dist/`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# These tests are pure structural greps over backend/server.py — they
+# never import server, so they're safe on every platform (including
+# Windows-mounted filesystems where security.py's POSIX-mode check would
+# otherwise trip).
+_SERVER_SRC = (Path(__file__).resolve().parent.parent / "backend" / "server.py").read_text(
+    encoding="utf-8"
+)
+
+
+def test_server_mounts_icons_dir() -> None:
+    """/icons/<name>.png must be mounted as StaticFiles so PNGs are served
+    with the correct Content-Type instead of being shadowed by the SPA
+    catch-all."""
+    src = _SERVER_SRC
+    assert '"/icons"' in src
+    assert "StaticFiles(directory=str(_icons_dir))" in src
+
+
+def test_server_has_favicon_route() -> None:
+    """Windows pinned-shortcut creation probes /favicon.ico. Must not 404
+    or return HTML."""
+    src = _SERVER_SRC
+    assert '@app.get("/favicon.ico")' in src
+
+
+def test_server_has_service_worker_route() -> None:
+    """PWA install requires /sw.js at the origin root."""
+    src = _SERVER_SRC
+    assert '@app.get("/sw.js")' in src
+
+
+def test_server_has_offline_route() -> None:
+    src = _SERVER_SRC
+    assert '@app.get("/offline.html")' in src
+
+
+def test_server_has_robots_route() -> None:
+    src = _SERVER_SRC
+    assert '@app.get("/robots.txt")' in src


### PR DESCRIPTION
Follow-up to [#669](https://github.com/D-sorganization/Runner_Dashboard/pull/669). #669 fixed the missing `vite build` step so `dist/` finally contains the PWA icon set, favicon, service worker, and offline page. But `server.py` only mounted `/assets`, so every other static URL referenced from `index.html` (`/icons/icon-180.png`, `/favicon.ico`, `/sw.js`, etc.) fell through to the SPA catch-all and returned `index.html` as `text/html`.

**Symptom:** Windows taskbar pinned shortcuts had no favicon — the browser fetched `/favicon.ico` and got 1.8 KB of HTML instead of an icon, so it fell back to a generic browser icon.

## Changes

- **`/icons` mount** — `app.mount("/icons", StaticFiles(directory=str(_icons_dir)))` analogous to the existing `/assets` mount. Serves `icon-{180,192,256,384,512}.png` with `image/png` Content-Type.
- **`/favicon.ico`** — explicit route. Returns the real `.ico` if present; otherwise falls back to `icon.svg` with `image/x-icon` Content-Type so existing modern browsers render it. (Authoring a real `.ico` is a separate, optional follow-up.)
- **`/sw.js`** — PWA service worker. Must be at origin-root for browsers to honour the registration scope.
- **`/offline.html`** — PWA offline-fallback page.
- **`/robots.txt`** — operator console; the file already exists in `frontend/public/` and `dist/`.

## Tests

`tests/test_static_serving.py` — 5 structural greps over `backend/server.py`. They confirm each route is declared. Pure-text checks (no module import), so they run on every platform including the Windows-mounted-FS test env.

## Verification

Pre-fix:
```
$ curl -s -o /dev/null -w '%{http_code} %{content_type} %{size_download}B\n' http://localhost:8321/favicon.ico
200 text/html; charset=utf-8 1840B
```

Post-fix (after merging this + deploying):
```
$ curl -s -o /dev/null -w '%{http_code} %{content_type} %{size_download}B\n' http://localhost:8321/favicon.ico
200 image/svg+xml ~700B          # SVG fallback
$ curl -s -o /dev/null -w '%{http_code} %{content_type} %{size_download}B\n' http://localhost:8321/icons/icon-180.png
200 image/png ~3KB
```

## Why these are separate routes vs. a single mount

I considered mounting the whole `dist/` as a single `StaticFiles(html=True)` at `/`, but that would intercept every URL — including ones the API serves at the same root. Explicit routes for the small handful of static files at origin-root, plus the `/icons` directory mount, leaves the API path-space untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)