### PR TITLE
chore(frontend): remove mock FLEET QUOTA widget from legacy header

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -40,7 +40,6 @@
   --glass-blur: 12px;
   
   /* Vibrant Gradients */
-  --grad-quota: linear-gradient(90deg, #00f2fe 0%, #4facfe 100%);
   --grad-fair: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   
   /* Spacing Scale */

--- a/frontend/src/legacy/App.tsx
+++ b/frontend/src/legacy/App.tsx
@@ -16085,45 +16085,15 @@ function App({ initialTab, onTabChange }: { initialTab?: string; onTabChange?: (
       h(
         "div",
         { className: "header-right" },
-        (function() {
-          // Mock quota data for visualization
-          var quotaUsed = 14;
-          var quotaTotal = 20;
-          var percent = (quotaUsed / quotaTotal) * 100;
-          return h(
-            "div",
-            {
-              className: "glass-card",
-              style: {
-                padding: "4px 12px",
-                display: "flex",
-                alignItems: "center",
-                gap: "10px",
-                marginRight: "12px",
-                fontSize: "11px",
-                height: "32px"
-              }
-            },
-            h("span", { style: { color: "var(--text-secondary)", fontWeight: "600" } }, "FLEET QUOTA"),
-            h(
-              "div",
-              {
-                className: "progress-bar",
-                style: { width: "80px", height: "6px", background: "rgba(255,255,255,0.1)" },
-                title: quotaUsed + "/" + quotaTotal + " Runners Active"
-              },
-              h("div", {
-                className: "progress-fill",
-                style: {
-                  width: percent + "%",
-                  background: "var(--grad-quota)",
-                  boxShadow: "0 0 10px rgba(0, 242, 254, 0.5)"
-                }
-              })
-            ),
-            h("span", { style: { color: "var(--text-primary)", fontWeight: "700" } }, quotaUsed + "/" + quotaTotal)
-          );
-        })(),
+        // The "FLEET QUOTA" widget that used to live here was a hardcoded
+        // mock (14/20). Removed because it (a) showed fake data with no
+        // backing API, (b) had no defined semantics — "quota" wasn't tied
+        // to runner schedule limits, busy-count, or anything real, and
+        // (c) was obscuring the principal/badge/settings controls in the
+        // toolstrip. If a real fleet-capacity indicator is wanted, it
+        // belongs in the new shell under frontend/src/shell with a clear
+        // data contract (e.g. busy_runners / scheduled_runners derived
+        // from /api/fleet/nodes), not as another mock here.
         principal ? h(
           "span",
           { className: "section-badge", style: { background: "rgba(88,166,255,0.15)", color: "var(--accent-blue)" } },


### PR DESCRIPTION
## What you saw

The "FLEET QUOTA  [bar]  14/20" widget in the dashboard top toolstrip is a hardcoded mock — comment in `frontend/src/legacy/App.tsx` literally says `// Mock quota data for visualization`. It has been showing the same fake `14/20` to everyone since it was added.

## Why remove rather than rewire

1. **No backing data.** `quotaUsed` and `quotaTotal` are hardcoded constants. There's no `/api/quota` or similar endpoint and no clear product definition of what "quota" should mean here (busy runners vs. scheduled limit? registered vs. license cap? per-host vs. fleet-wide?).
2. **Visual cost.** It's in the `header-right` toolstrip ahead of the "Acting as: …" principal badge and the settings controls — was obscuring those.
3. **Wrong location for a future fix.** The widget lives in `frontend/src/legacy/App.tsx`, which per CLAUDE.md is being migrated *away* from. Adding more logic to the legacy bundle would slow that migration.

If a real fleet-capacity indicator is wanted, the right home is `frontend/src/shell/` or `frontend/src/pages/Fleet/` with a clear contract — for example `busy_runners` / `scheduled_runners` derived from `/api/fleet/nodes` (which already returns `total_runners` and online state per host).

## Changes

- Removed the IIFE in `legacy/App.tsx` (40 lines)
- Removed the now-unused `--grad-quota` CSS custom property in `index.css`
- Repo-wide grep confirms no other consumers

## Test plan

- [x] `git diff --stat` confirms the only changes are the removal
- [x] `grep -rn 'grad-quota\|FLEET QUOTA\|quotaUsed' frontend/` returns no orphans
- [ ] CI green
- [ ] Local rebuild: `npm run build` should still produce a clean `dist/`
- [ ] After deploy: top toolstrip shows the principal badge and settings controls without the obscuring quota widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)