### PR TITLE
feat(ui): two-row header + fleet-status hero panel + bounded KPI sub-line

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -175,6 +175,42 @@ code, pre, .code, kbd {
   top: 0;
   z-index: 100;
 }
+
+/* Two-row header variant — primary row has logo + tabs, secondary row has
+ * status badges + action buttons. Eliminates horizontal scrolling when there
+ * are 8+ tabs and 4+ status pills competing for one 56px row. */
+.app-header.app-header--rows {
+  flex-direction: column;
+  align-items: stretch;
+  height: auto;
+  padding: 0;
+}
+.app-header__row {
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  min-height: 48px;
+}
+.app-header__row--primary {
+  height: 56px;
+  border-bottom: 1px solid var(--border);
+}
+.app-header__row--secondary {
+  min-height: 44px;
+  background: rgba(255, 255, 255, 0.025);
+  font-size: 12px;
+}
+.app-header__row--secondary .header-right {
+  width: 100%;
+  margin-left: 0;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  row-gap: 6px;
+}
+@media (max-width: 720px) {
+  .app-header__row--primary { padding: 0 12px; }
+  .app-header__row--secondary { padding: 0 12px; }
+}
 .app-logo {
   display: flex;
   align-items: center;
@@ -196,7 +232,12 @@ code, pre, .code, kbd {
   height: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  flex: 1;
 }
+/* Hide scrollbar on the tab-bar — it's still scrollable but doesn't add a
+ * persistent grey strip below the header. */
+.tab-bar::-webkit-scrollbar { height: 0; }
+.tab-bar { scrollbar-width: none; }
 .tab-btn {
   background: none;
   border: none;
@@ -346,6 +387,143 @@ code, pre, .code, kbd {
   font-size: 11px;
   color: var(--text-muted);
   margin-top: 2px;
+  /* Bound the sub-line so a long error message (e.g. raw Windows scheduled
+   * task failure) can't blow out the card height. Full text is preserved
+   * in the title attribute for hover. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── Fleet status hero panel ──────────────────────────────────────────────
+ * Sits at the top of the Overview tab; rolls up cross-cutting signals
+ * (machines offline, keepalive degraded, low success rate, hosted-runner
+ * billing alerts) into a single banner so an operator can answer "is
+ * anything wrong?" without scanning the KPI grid.
+ */
+.fleet-hero {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  grid-template-areas:
+    "status kpis"
+    "alerts alerts";
+  gap: 16px 24px;
+  padding: 18px 22px;
+  margin-bottom: 18px;
+  border-radius: 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+.fleet-hero--ok      { border-left: 4px solid var(--accent-green); }
+.fleet-hero--warning { border-left: 4px solid var(--accent-yellow); }
+.fleet-hero--critical{ border-left: 4px solid var(--accent-red); }
+.fleet-hero__status {
+  grid-area: status;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.fleet-hero__dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.fleet-hero__status-text { display: flex; flex-direction: column; gap: 2px; }
+.fleet-hero__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.2px;
+}
+.fleet-hero__subtitle {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.fleet-hero__kpis {
+  grid-area: kpis;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+.fleet-hero__kpi {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+  color: inherit;
+  font: inherit;
+}
+.fleet-hero__kpi:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+.fleet-hero__kpi:active {
+  transform: scale(0.98);
+}
+.fleet-hero__kpi-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.fleet-hero__kpi-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.1;
+}
+.fleet-hero__kpi-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.fleet-hero__alerts {
+  grid-area: alerts;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 12px 14px 0;
+  list-style: none;
+  border-top: 1px solid var(--border);
+}
+.fleet-hero__alert {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.fleet-hero__alert::before {
+  content: "•";
+  font-size: 16px;
+  line-height: 1;
+}
+.fleet-hero__alert--critical { color: var(--accent-red); }
+.fleet-hero__alert--critical::before { color: var(--accent-red); }
+.fleet-hero__alert--warning  { color: var(--accent-yellow); }
+.fleet-hero__alert--warning::before  { color: var(--accent-yellow); }
+.fleet-hero__alert-title { font-weight: 600; color: var(--text-primary); }
+.fleet-hero__alert-detail { color: var(--text-muted); }
+@media (max-width: 720px) {
+  .fleet-hero {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "status"
+      "kpis"
+      "alerts";
+  }
 }
 .deployment-note {
   display: flex;

--- a/frontend/src/legacy/App.tsx
+++ b/frontend/src/legacy/App.tsx
@@ -517,7 +517,17 @@ function Stat(p) {
       { className: "stat-value", style: { color: p.color || "inherit" } },
       p.value,
     ),
-    p.sub ? h("div", { className: "stat-sub" }, p.sub) : null,
+    p.sub
+      ? h(
+          "div",
+          {
+            className: "stat-sub",
+            // Hover for the full text when the sub line has been truncated.
+            title: p.subTitle || (typeof p.sub === "string" ? p.sub : ""),
+          },
+          p.sub,
+        )
+      : null,
   );
 }
 
@@ -793,6 +803,11 @@ function FleetTab(p) {
   var machinesData = p.machinesData || {};
   var deployment = p.deployment || {};
   var onOpenDeployment = p.onOpenDeployment || function () {};
+  // Used by the fleet-status hero panel for KPI buttons and the
+  // hosted-runner billing alert. Defaulted so unit tests / standalone
+  // rendering of FleetTab don't need to pass them.
+  var setTab = p.setTab || function () {};
+  var runnerAudit = p.runnerAudit || { violations: [] };
   var driftState = React.useState(null);
   var driftInfo = driftState[0], setDriftInfo = driftState[1];
   React.useEffect(function () {
@@ -961,9 +976,127 @@ function FleetTab(p) {
       }),
     );
   }
+  // ─── Fleet status hero panel (computed once per render) ─────────────────
+  // Rolls up the cross-cutting health signals into a single banner so an
+  // operator can see "is everything OK?" at a glance, before scrolling
+  // through the KPI grid. See feat/header-2row-overview-alerts.
+  var heroAlerts = [];
+  if (machineCount > 0 && machineOnline < machineCount) {
+    var offlineMachines = machineNodes
+      .filter(function (n) { return !n.online; })
+      .map(function (n) { return n.name; });
+    heroAlerts.push({
+      level: "critical",
+      title: (machineCount - machineOnline) + " machine(s) offline",
+      detail: offlineMachines.join(", ") || "see Machine Health below",
+    });
+  }
+  if (watchdog && watchdog.status && watchdog.status !== "healthy") {
+    heroAlerts.push({
+      level: watchdog.status === "legacy" ? "critical" : "warning",
+      title: "WSL Keepalive: " + watchdog.status,
+      detail: watchdog.summary || watchdog.detail || "WSL keepalive needs attention",
+    });
+  }
+  if (stats.success_rate !== undefined && stats.success_rate < 70 && completedRuns > 0) {
+    heroAlerts.push({
+      level: stats.success_rate < 40 ? "critical" : "warning",
+      title: "Success rate: " + stats.success_rate + "%",
+      detail: stats.runs_success + "/" + completedRuns + " recent runs passed",
+    });
+  }
+  if (runnerAudit && runnerAudit.violations && runnerAudit.violations.length > 0) {
+    heroAlerts.push({
+      level: "warning",
+      title: runnerAudit.violations.length + " job(s) on GitHub-hosted runners",
+      detail: "Billing alert — see Runner Audit tab",
+    });
+  }
+  var heroLevel =
+    heroAlerts.some(function (a) { return a.level === "critical"; })
+      ? "critical"
+      : heroAlerts.length > 0
+        ? "warning"
+        : "ok";
+  var heroLevelLabel = heroLevel === "ok" ? "Operational" : heroLevel === "warning" ? "Degraded" : "Critical";
+  var heroLevelColor = heroLevel === "ok"
+    ? "var(--accent-green)"
+    : heroLevel === "warning"
+      ? "var(--accent-yellow)"
+      : "var(--accent-red)";
+
   return h(
     "div",
     null,
+    h(
+      "section",
+      {
+        className: "fleet-hero fleet-hero--" + heroLevel,
+        role: "region",
+        "aria-label": "Fleet status",
+      },
+      h(
+        "div",
+        { className: "fleet-hero__status" },
+        h("span", {
+          className: "fleet-hero__dot",
+          style: { background: heroLevelColor, boxShadow: "0 0 0 4px " + heroLevelColor.replace(")", " / 0.18)").replace("var(--", "var(--") },
+          "aria-hidden": true,
+        }),
+        h(
+          "div",
+          { className: "fleet-hero__status-text" },
+          h("div", { className: "fleet-hero__title" }, "Fleet ", heroLevelLabel),
+          h("div", { className: "fleet-hero__subtitle" },
+            heroAlerts.length === 0
+              ? "All systems nominal"
+              : heroAlerts.length + " active alert" + (heroAlerts.length === 1 ? "" : "s")),
+        ),
+      ),
+      h(
+        "div",
+        { className: "fleet-hero__kpis" },
+        h("button", { className: "fleet-hero__kpi", onClick: function () { setTab("machines"); }, type: "button" },
+          h("span", { className: "fleet-hero__kpi-label" }, "Machines"),
+          h("span", { className: "fleet-hero__kpi-value" }, machineOnline + " / " + machineCount),
+        ),
+        h("button", { className: "fleet-hero__kpi", onClick: function () { setTab("overview"); }, type: "button" },
+          h("span", { className: "fleet-hero__kpi-label" }, "Open PRs"),
+          h("span", { className: "fleet-hero__kpi-value" }, String(openPrs)),
+        ),
+        h("button", { className: "fleet-hero__kpi", onClick: function () { setTab("queue"); }, type: "button" },
+          h("span", { className: "fleet-hero__kpi-label" }, "Queue"),
+          h("span", { className: "fleet-hero__kpi-value" }, String(queued)),
+          queued > 0
+            ? h("span", { className: "fleet-hero__kpi-sub" }, running + " running")
+            : null,
+        ),
+        h("button", { className: "fleet-hero__kpi", onClick: function () { setTab("overview"); }, type: "button" },
+          h("span", { className: "fleet-hero__kpi-label" }, "Runners"),
+          h("span", { className: "fleet-hero__kpi-value" }, on + " / " + runners.length),
+          busy > 0
+            ? h("span", { className: "fleet-hero__kpi-sub" }, busy + " busy")
+            : null,
+        ),
+      ),
+      heroAlerts.length > 0
+        ? h(
+            "ul",
+            { className: "fleet-hero__alerts", "aria-label": "Active alerts" },
+            heroAlerts.map(function (a, i) {
+              return h(
+                "li",
+                {
+                  key: "alert-" + i,
+                  className: "fleet-hero__alert fleet-hero__alert--" + a.level,
+                },
+                h("span", { className: "fleet-hero__alert-title" }, a.title),
+                h("span", { className: "fleet-hero__alert-detail" }, a.detail),
+              );
+            }),
+          )
+        : null,
+    ),
     h(
       "div",
       { className: "stat-row" },
@@ -1020,10 +1153,16 @@ function FleetTab(p) {
               : watchdog.status === "degraded"
                 ? "var(--accent-yellow)"
                 : "inherit",
+        // Truncate the keepalive detail so a 200-character Windows
+        // scheduled-task error doesn't blow out the card height. Full
+        // detail stays available via tooltip + the alerts hero up top.
         sub:
-          watchdog.detail ||
-          watchdog.summary ||
-          "Read-only keepalive checks",
+          watchdog.summary
+            ? (watchdog.summary.length > 80
+                ? watchdog.summary.slice(0, 77) + "…"
+                : watchdog.summary)
+            : "Read-only keepalive checks",
+        subTitle: watchdog.detail || watchdog.summary || "",
       }),
       h(Stat, {
         label: "Storage",
@@ -15468,7 +15607,10 @@ function App({ initialTab, onTabChange }: { initialTab?: string; onTabChange?: (
     null,
     h(
       "header",
-      { className: "app-header" },
+      { className: "app-header app-header--rows" },
+      h(
+        "div",
+        { className: "app-header__row app-header__row--primary" },
       h(
         "div",
         { className: "app-logo" },
@@ -16082,6 +16224,10 @@ function App({ initialTab, onTabChange }: { initialTab?: string; onTabChange?: (
           "Settings",
         ),
       ),
+      ), // close app-header__row--primary
+      h(
+        "div",
+        { className: "app-header__row app-header__row--secondary" },
       h(
         "div",
         { className: "header-right" },
@@ -16185,6 +16331,7 @@ function App({ initialTab, onTabChange }: { initialTab?: string; onTabChange?: (
           I.refresh(12),
         ),
       ),
+      ), // close app-header__row--secondary
     ),
     (runnerAudit.violations && runnerAudit.violations.length > 0 && !auditBannerDismissed)
       ? h(
@@ -16254,6 +16401,8 @@ function App({ initialTab, onTabChange }: { initialTab?: string; onTabChange?: (
             loading: actionLoading,
             watchdog: watchdog,
             deployment: deployment,
+            setTab: setTab,             // for hero KPI buttons that navigate to other tabs
+            runnerAudit: runnerAudit,   // for hosted-runner billing alert in fleet hero
             onOpenDeployment: function () {
               setTab("deployment");
               fetchDeploymentState();


### PR DESCRIPTION
Three focused UX fixes addressing the reported issues:

> "Look how much scrolling is necessary on that top toolbar — very inefficient and difficult to read. Redesign the layout… more visually appealing."
> "The home page should clearly show how many open PR's there are, how many jobs are in the queue, and how many computers are online as well as a system health indicator."
> "WSL Keepalive needs attention" *(card was a 200-char Windows scheduled-task error)*

## 1. Two-row header

The 56px header was packing logo + 10 tabs + 6 status pills + 3 action buttons into one row, forcing horizontal scroll. New `.app-header.app-header--rows` variant splits into:

- **Row 1 (56px)** — logo + tab-bar
- **Row 2 (44px, tinted)** — status badges (Live time, Queue, Keepalive, Build) + action buttons (Chat, Quick Dispatch, ↻ refresh)

The tab-bar scrollbar is hidden (still scrollable on overflow) so it doesn't add a grey strip under the header.

## 2. Fleet status hero on the Overview tab

New `.fleet-hero` panel renders **before** the existing KPI grid:

- Big status dot + label: **"Fleet Operational" / "Degraded" / "Critical"**, with a coloured left-border (green/yellow/red)
- **4 click-through KPI tiles** — Machines online, Open PRs, Queue depth, Runners online. Click navigates to the matching tab.
- **Auto-rolled-up alert list** populated from cross-cutting signals:
  - Machines offline (named)
  - WSL keepalive not healthy
  - Success rate < 70%
  - Jobs detected on GitHub-hosted runners (billing alert)

Empty state: "All systems nominal" with a green dot, no alert list rendered.

## 3. Bounded KPI sub-line + WSL Keepalive compression

- The WSL Keepalive Stat card was dumping a 200+ character Windows scheduled-task error verbatim, blowing the card height out and dominating the visual hierarchy. Now truncated to 80 chars with ellipsis; full text on hover via `title`.
- All `.stat-sub` elements get a 2-line `line-clamp` so other long sub-lines can't repeat the regression.
- The hero is the primary surface for keepalive issues — the card becomes a status indicator rather than an error dump.

## Where the code lives

- `frontend/src/legacy/App.tsx` — header markup change (two row-wrappers), `FleetTab` gains 2 optional props (`setTab`, `runnerAudit`) with safe defaults, hero-panel render block, Stat `subTitle` prop.
- `frontend/src/index.css` — header-rows styles, fleet-hero styles, stat-sub line-clamp.

Both files note that the legacy bundle is being migrated and these are surgical UX fixes (no new tabs, no new state machines) — a future shell migration picks this up.

## Test plan

- [x] `npm run build` clean (47 KB CSS / 676 KB JS minified)
- [x] No new lint failures (legacy/ is already in the lint carve-out)
- [ ] CI green
- [ ] Local screenshot before/after on `d-sorg-local-ControlTower`

## Out of scope

A full migration of the Overview to `frontend/src/shell/` or `frontend/src/pages/Fleet/` with proper TS types + hooks. That's the right long-term home for the hero panel but pulling it out of legacy would be a separate, much larger PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)