### PR TITLE
test: bulletproof regression guards for today's 13-PR series

### DIFF
--- a/frontend/src/legacy/App.tsx
+++ b/frontend/src/legacy/App.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import * as fleetAlerts from "../lib/fleetAlerts"
 import { AgentDispatchPage } from "../pages/AgentDispatch"
 import { QueueTab } from "../pages/Queue"
 import { Badge } from "../primitives/Badge"
@@ -977,48 +978,21 @@ function FleetTab(p) {
     );
   }
   // ─── Fleet status hero panel (computed once per render) ─────────────────
-  // Rolls up the cross-cutting health signals into a single banner so an
-  // operator can see "is everything OK?" at a glance, before scrolling
-  // through the KPI grid. See feat/header-2row-overview-alerts.
-  var heroAlerts = [];
-  if (machineCount > 0 && machineOnline < machineCount) {
-    var offlineMachines = machineNodes
-      .filter(function (n) { return !n.online; })
-      .map(function (n) { return n.name; });
-    heroAlerts.push({
-      level: "critical",
-      title: (machineCount - machineOnline) + " machine(s) offline",
-      detail: offlineMachines.join(", ") || "see Machine Health below",
-    });
-  }
-  if (watchdog && watchdog.status && watchdog.status !== "healthy") {
-    heroAlerts.push({
-      level: watchdog.status === "legacy" ? "critical" : "warning",
-      title: "WSL Keepalive: " + watchdog.status,
-      detail: watchdog.summary || watchdog.detail || "WSL keepalive needs attention",
-    });
-  }
-  if (stats.success_rate !== undefined && stats.success_rate < 70 && completedRuns > 0) {
-    heroAlerts.push({
-      level: stats.success_rate < 40 ? "critical" : "warning",
-      title: "Success rate: " + stats.success_rate + "%",
-      detail: stats.runs_success + "/" + completedRuns + " recent runs passed",
-    });
-  }
-  if (runnerAudit && runnerAudit.violations && runnerAudit.violations.length > 0) {
-    heroAlerts.push({
-      level: "warning",
-      title: runnerAudit.violations.length + " job(s) on GitHub-hosted runners",
-      detail: "Billing alert — see Runner Audit tab",
-    });
-  }
-  var heroLevel =
-    heroAlerts.some(function (a) { return a.level === "critical"; })
-      ? "critical"
-      : heroAlerts.length > 0
-        ? "warning"
-        : "ok";
-  var heroLevelLabel = heroLevel === "ok" ? "Operational" : heroLevel === "warning" ? "Degraded" : "Critical";
+  // The rollup logic lives in frontend/src/lib/fleetAlerts.ts so it can be
+  // unit-tested without the legacy h()-tree. The hero panel below is the
+  // only consumer today; the new shell migration will reuse the same fn.
+  var heroResult = fleetAlerts.computeFleetAlerts({
+    machineCount: machineCount,
+    machineOnline: machineOnline,
+    machineNodes: machineNodes,
+    watchdog: watchdog,
+    stats: stats,
+    completedRuns: completedRuns,
+    runnerAudit: runnerAudit,
+  });
+  var heroAlerts = heroResult.alerts;
+  var heroLevel = heroResult.level;
+  var heroLevelLabel = fleetAlerts.fleetLevelLabel(heroLevel);
   var heroLevelColor = heroLevel === "ok"
     ? "var(--accent-green)"
     : heroLevel === "warning"

--- a/frontend/src/lib/__tests__/fleetAlerts.test.ts
+++ b/frontend/src/lib/__tests__/fleetAlerts.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for computeFleetAlerts — the hero-panel rollup logic
+ * extracted from legacy/App.tsx so it can be tested without the
+ * `h()` tree.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  computeFleetAlerts,
+  fleetLevelLabel,
+  type FleetState,
+} from "../fleetAlerts";
+
+const baseState: FleetState = {
+  machineCount: 4,
+  machineOnline: 4,
+  machineNodes: [
+    { name: "ControlTower", online: true },
+    { name: "DeskComputer", online: true },
+    { name: "OGLaptop", online: true },
+    { name: "Brick", online: true },
+  ],
+  watchdog: { status: "healthy" },
+  stats: { success_rate: 95, runs_success: 95 },
+  completedRuns: 100,
+  runnerAudit: { violations: [] },
+};
+
+describe("computeFleetAlerts — happy path", () => {
+  it("returns level=ok with no alerts when everything is healthy", () => {
+    const result = computeFleetAlerts(baseState);
+    expect(result.level).toBe("ok");
+    expect(result.alerts).toEqual([]);
+  });
+
+  it("treats a registry with zero machines as ok (no false alert)", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      machineCount: 0,
+      machineOnline: 0,
+      machineNodes: [],
+    });
+    expect(result.level).toBe("ok");
+    expect(result.alerts).toEqual([]);
+  });
+});
+
+describe("computeFleetAlerts — Rule 1: machines offline", () => {
+  it("flags critical when one machine is offline", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      machineOnline: 3,
+      machineNodes: [
+        { name: "ControlTower", online: true },
+        { name: "DeskComputer", online: true },
+        { name: "OGLaptop", online: true },
+        { name: "Brick", online: false },
+      ],
+    });
+    expect(result.level).toBe("critical");
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]).toMatchObject({
+      level: "critical",
+      title: "1 machine(s) offline",
+      detail: "Brick",
+    });
+  });
+
+  it("lists multiple offline machine names in the detail", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      machineOnline: 2,
+      machineNodes: [
+        { name: "ControlTower", online: true },
+        { name: "DeskComputer", online: true },
+        { name: "OGLaptop", online: false },
+        { name: "Brick", online: false },
+      ],
+    });
+    expect(result.alerts[0].title).toBe("2 machine(s) offline");
+    expect(result.alerts[0].detail).toBe("OGLaptop, Brick");
+  });
+
+  it("falls back to a generic detail when no machine names are available", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      machineOnline: 3,
+      machineNodes: [],
+    });
+    expect(result.alerts[0].detail).toBe("see Machine Health below");
+  });
+});
+
+describe("computeFleetAlerts — Rule 2: WSL keepalive", () => {
+  it("flags warning when watchdog is degraded", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      watchdog: { status: "degraded", summary: "scheduled task misconfigured" },
+    });
+    expect(result.level).toBe("warning");
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]).toMatchObject({
+      level: "warning",
+      title: "WSL Keepalive: degraded",
+      detail: "scheduled task misconfigured",
+    });
+  });
+
+  it("flags CRITICAL (not warning) when watchdog is legacy", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      watchdog: { status: "legacy" },
+    });
+    expect(result.level).toBe("critical");
+    expect(result.alerts[0].level).toBe("critical");
+    expect(result.alerts[0].title).toBe("WSL Keepalive: legacy");
+  });
+
+  it("uses detail when summary is absent", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      watchdog: { status: "degraded", detail: "fallback detail string" },
+    });
+    expect(result.alerts[0].detail).toBe("fallback detail string");
+  });
+
+  it("falls back to a generic message when neither summary nor detail is set", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      watchdog: { status: "degraded" },
+    });
+    expect(result.alerts[0].detail).toBe("WSL keepalive needs attention");
+  });
+
+  it("does not flag when watchdog.status is healthy", () => {
+    const result = computeFleetAlerts(baseState);
+    expect(result.alerts.find((a) => a.title.startsWith("WSL Keepalive"))).toBeUndefined();
+  });
+});
+
+describe("computeFleetAlerts — Rule 3: success rate", () => {
+  it("flags warning when success_rate is between 40 and 70", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      stats: { success_rate: 55, runs_success: 55 },
+    });
+    expect(result.level).toBe("warning");
+    expect(result.alerts[0]).toMatchObject({
+      level: "warning",
+      title: "Success rate: 55%",
+    });
+  });
+
+  it("flags critical when success_rate is below 40", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      stats: { success_rate: 30, runs_success: 30 },
+    });
+    expect(result.level).toBe("critical");
+    expect(result.alerts[0].level).toBe("critical");
+  });
+
+  it("does NOT flag when completedRuns is zero (no signal yet)", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      stats: { success_rate: 0 },
+      completedRuns: 0,
+    });
+    expect(result.alerts.find((a) => a.title.startsWith("Success rate"))).toBeUndefined();
+  });
+
+  it("does NOT flag when success_rate is exactly 70 (threshold is strict)", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      stats: { success_rate: 70, runs_success: 70 },
+    });
+    expect(result.alerts.find((a) => a.title.startsWith("Success rate"))).toBeUndefined();
+  });
+});
+
+describe("computeFleetAlerts — Rule 4: hosted-runner billing", () => {
+  it("flags warning when there are violations", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      runnerAudit: { violations: [{}, {}, {}] },
+    });
+    expect(result.level).toBe("warning");
+    expect(result.alerts[0]).toMatchObject({
+      level: "warning",
+      title: "3 job(s) on GitHub-hosted runners",
+      detail: "Billing alert — see Runner Audit tab",
+    });
+  });
+
+  it("does NOT flag when violations is an empty array", () => {
+    const result = computeFleetAlerts(baseState);
+    expect(result.alerts.find((a) => a.title.includes("GitHub-hosted"))).toBeUndefined();
+  });
+});
+
+describe("computeFleetAlerts — severity rollup", () => {
+  it("critical dominates warning when both are present", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      machineOnline: 3, // critical
+      machineNodes: [
+        { name: "ControlTower", online: true },
+        { name: "DeskComputer", online: true },
+        { name: "OGLaptop", online: true },
+        { name: "Brick", online: false },
+      ],
+      runnerAudit: { violations: [{}] }, // warning
+    });
+    expect(result.level).toBe("critical");
+    expect(result.alerts).toHaveLength(2);
+  });
+
+  it("emits alerts in stable rule order (machines → watchdog → success → hosted)", () => {
+    const result = computeFleetAlerts({
+      ...baseState,
+      machineOnline: 3,
+      machineNodes: [
+        { name: "A", online: true },
+        { name: "A", online: true },
+        { name: "A", online: true },
+        { name: "B", online: false },
+      ],
+      watchdog: { status: "degraded" },
+      stats: { success_rate: 50, runs_success: 50 },
+      runnerAudit: { violations: [{}] },
+    });
+    expect(result.alerts.map((a) => a.title)).toEqual([
+      "1 machine(s) offline",
+      "WSL Keepalive: degraded",
+      "Success rate: 50%",
+      "1 job(s) on GitHub-hosted runners",
+    ]);
+  });
+
+  it("is a pure function — same input always yields same output", () => {
+    const a = computeFleetAlerts(baseState);
+    const b = computeFleetAlerts(baseState);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("fleetLevelLabel", () => {
+  it("maps ok → Operational", () => {
+    expect(fleetLevelLabel("ok")).toBe("Operational");
+  });
+
+  it("maps warning → Degraded", () => {
+    expect(fleetLevelLabel("warning")).toBe("Degraded");
+  });
+
+  it("maps critical → Critical", () => {
+    expect(fleetLevelLabel("critical")).toBe("Critical");
+  });
+});

--- a/frontend/src/lib/fleetAlerts.ts
+++ b/frontend/src/lib/fleetAlerts.ts
@@ -1,0 +1,141 @@
+/**
+ * Fleet-alert rollup logic for the Overview hero panel.
+ *
+ * Extracted from `frontend/src/legacy/App.tsx` so it can be unit-tested
+ * without spinning up the whole legacy `h()`-tree. Pure function — no
+ * React imports, no `h()`, no DOM. Consumed by the legacy FleetTab today;
+ * the new shell migration can consume the same function unchanged.
+ *
+ * Severity contract:
+ *   - "ok"       → no alerts; UI shows the green dot + "All systems nominal"
+ *   - "warning"  → at least one warning-level alert; UI shows yellow dot
+ *   - "critical" → at least one critical-level alert; UI shows red dot
+ *
+ * Rule ordering does NOT affect severity — the overall level is the max
+ * severity across rules. Rule order DOES affect display order in the
+ * alerts list (visually: most-actionable first).
+ */
+
+export type AlertLevel = "warning" | "critical";
+export type FleetLevel = "ok" | AlertLevel;
+
+export interface FleetAlert {
+  level: AlertLevel;
+  title: string;
+  detail: string;
+}
+
+export interface FleetState {
+  machineCount: number;
+  machineOnline: number;
+  /** Machine objects from /api/fleet/nodes. Only `name` and `online` are read. */
+  machineNodes?: ReadonlyArray<{ name?: string; online?: boolean }>;
+  /** Watchdog state from /api/watchdog. `status` is the load-bearing field. */
+  watchdog?: { status?: string; summary?: string; detail?: string };
+  /** Run statistics. success_rate is a percentage (0-100). */
+  stats?: { success_rate?: number; runs_success?: number };
+  /** Total completed runs in the recent window. Used as a denominator. */
+  completedRuns?: number;
+  /** Runner audit violations (GitHub-hosted runners). */
+  runnerAudit?: { violations?: ReadonlyArray<unknown> };
+}
+
+export interface FleetAlertsResult {
+  level: FleetLevel;
+  alerts: FleetAlert[];
+}
+
+/**
+ * Roll up cross-cutting fleet signals into a single status + list of
+ * alerts. Pure function: same input → same output.
+ *
+ * Thresholds chosen to match operator perception:
+ *   - any machine offline → critical (a host being down blocks job pickup)
+ *   - watchdog "legacy"   → critical (security regression — old VBS path)
+ *   - watchdog "degraded" → warning  (configured but not running)
+ *   - success_rate < 40   → critical
+ *   - success_rate < 70   → warning
+ *   - hosted-runner violations → warning (billing impact, not outage)
+ */
+export function computeFleetAlerts(state: FleetState): FleetAlertsResult {
+  const alerts: FleetAlert[] = [];
+
+  // Rule 1: machine offline count
+  const machineCount = state.machineCount ?? 0;
+  const machineOnline = state.machineOnline ?? 0;
+  if (machineCount > 0 && machineOnline < machineCount) {
+    const offlineNames = (state.machineNodes ?? [])
+      .filter((n) => n && !n.online)
+      .map((n) => n.name ?? "")
+      .filter(Boolean);
+    alerts.push({
+      level: "critical",
+      title: `${machineCount - machineOnline} machine(s) offline`,
+      detail: offlineNames.join(", ") || "see Machine Health below",
+    });
+  }
+
+  // Rule 2: WSL keepalive watchdog
+  const watchdogStatus = state.watchdog?.status;
+  if (watchdogStatus && watchdogStatus !== "healthy") {
+    alerts.push({
+      level: watchdogStatus === "legacy" ? "critical" : "warning",
+      title: `WSL Keepalive: ${watchdogStatus}`,
+      detail:
+        state.watchdog?.summary ||
+        state.watchdog?.detail ||
+        "WSL keepalive needs attention",
+    });
+  }
+
+  // Rule 3: success rate
+  const successRate = state.stats?.success_rate;
+  const completedRuns = state.completedRuns ?? 0;
+  if (
+    typeof successRate === "number" &&
+    successRate < 70 &&
+    completedRuns > 0
+  ) {
+    alerts.push({
+      level: successRate < 40 ? "critical" : "warning",
+      title: `Success rate: ${successRate}%`,
+      detail: `${state.stats?.runs_success ?? 0}/${completedRuns} recent runs passed`,
+    });
+  }
+
+  // Rule 4: hosted-runner billing violations
+  const violations = state.runnerAudit?.violations ?? [];
+  if (violations.length > 0) {
+    alerts.push({
+      level: "warning",
+      title: `${violations.length} job(s) on GitHub-hosted runners`,
+      detail: "Billing alert — see Runner Audit tab",
+    });
+  }
+
+  // Severity rollup: critical dominates warning
+  let level: FleetLevel = "ok";
+  if (alerts.some((a) => a.level === "critical")) {
+    level = "critical";
+  } else if (alerts.length > 0) {
+    level = "warning";
+  }
+
+  return { level, alerts };
+}
+
+/**
+ * Human-readable label for the FleetLevel. Kept separate from
+ * computeFleetAlerts so the function stays pure and the label can be
+ * localized independently in the future.
+ */
+export function fleetLevelLabel(level: FleetLevel): string {
+  switch (level) {
+    case "ok":
+      return "Operational";
+    case "warning":
+      return "Degraded";
+    case "critical":
+      return "Critical";
+  }
+}

--- a/tests/test_today_deploy_hardening.py
+++ b/tests/test_today_deploy_hardening.py
@@ -1,0 +1,299 @@
+"""Structural regression guards for the 2026-05-18 deploy-hardening series.
+
+These tests pin the load-bearing properties of the deploy scripts that
+shipped in PRs #660, #661, #663, #664, #666, #667, #668, #669, #670.
+Each test names the exact string / pattern that, if removed, would
+silently reintroduce one of the bugs we just fixed.
+
+Style note: structural greps over the script source — no script execution.
+This keeps the tests portable (Linux CI, Windows dev) and fast.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_DEPLOY = _REPO / "deploy"
+_BACKEND = _REPO / "backend"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# ─── PR #660: cleanup strict-mode regression ─────────────────────────────────
+
+
+def test_cleanup_tolerates_per_runner_stop_failure() -> None:
+    """runner-cleanup.sh must capture systemctl stop's exit code so a
+    failed stop on runner-1 does NOT abort the loop on runners 2..N.
+
+    The previous code ran `run systemctl stop "$unit"` bare under
+    `set -Eeuo pipefail` — exit 1 from systemctl on a racy "Job for ...
+    canceled" terminated the entire pass and silently skipped every
+    subsequent runner. Pin the capture pattern so the regression can't
+    re-land.
+    """
+    src = _read(_DEPLOY / "runner-cleanup.sh")
+    assert "stop_rc=$?" in src, "missing stop-rc capture introduced in #660"
+    # And the per-runner block must `continue` rather than exit
+    assert "will retry next pass" in src, "missing continue-on-stop-fail message"
+
+
+# ─── PR #661: heal-host.sh operator break-glass ──────────────────────────────
+
+
+def test_heal_host_has_three_phases() -> None:
+    """heal-host.sh must drain → cleanup → restart in that order.
+
+    Skipping cleanup or reordering would defeat the whole purpose
+    (cleanup needs units stopped to GC their `_work/_temp` residue).
+    """
+    src = _read(_DEPLOY / "heal-host.sh")
+    drain = src.find("=== drain ===")
+    cleanup = src.find("=== cleanup ===")
+    restart = src.find("=== restart ===")
+    assert drain >= 0 and cleanup >= 0 and restart >= 0, "missing phase markers"
+    assert drain < cleanup < restart, "phases must run in order: drain → cleanup → restart"
+
+
+def test_heal_host_force_kills_orphan_workers() -> None:
+    """The post-drain sweep must SIGKILL leftover Runner.Worker
+    processes. Without this, KillMode=process leaves orphans that block
+    the cleanup pass."""
+    src = _read(_DEPLOY / "heal-host.sh")
+    assert "pkill -KILL -f 'Runner\\.Worker spawnclient'" in src, (
+        "missing post-drain orphan-Worker kill"
+    )
+
+
+# ─── PR #664 + #666: runner unit drop-ins (race + orphan fix) ───────────────
+
+
+def test_migrate_runner_units_sets_kill_mode_mixed() -> None:
+    """The drop-in must change KillMode from `process` (default) to
+    `mixed` so the cgroup-wide signal cascade reaches Worker children.
+    Without this, `KillMode=process` leaves Workers orphaned on stop.
+    """
+    src = _read(_DEPLOY / "migrate-runner-units.sh")
+    assert "KillMode=mixed" in src, "drop-in must set KillMode=mixed"
+
+
+def test_migrate_runner_units_passes_unit_name_via_specifier() -> None:
+    """The ExecStop= drop-in must pass %n (full unit name) to
+    force-drain.sh as $1. systemd does NOT export $SYSTEMD_UNIT to
+    ExecStop= portably; without %n, force-drain.sh can't resolve the
+    correct WorkingDirectory and silently no-ops.
+    """
+    src = _read(_DEPLOY / "migrate-runner-units.sh")
+    assert "ExecStop=-${HOOK_DIR}/force-drain.sh %n" in src, (
+        "ExecStop= must pass %n to force-drain"
+    )
+
+
+def test_migrate_runner_units_default_hook_dir_matches_installer() -> None:
+    """The drop-in's default HOOK_DIR must match where
+    install-runner-maintenance.sh puts the hooks (/usr/local/bin/runner-hooks).
+    The old default (/opt/runner-dashboard/deploy/runner-hooks) didn't
+    exist on any host in the fleet.
+    """
+    src = _read(_DEPLOY / "migrate-runner-units.sh")
+    assert 'HOOK_DIR="${HOOK_DIR:-/usr/local/bin/runner-hooks}"' in src
+
+
+def test_force_drain_reads_unit_name_from_arg1() -> None:
+    """force-drain.sh must read the unit name from $1 (passed via %n)
+    first, with $SYSTEMD_UNIT as a fallback. Pre-fix it only read
+    $SYSTEMD_UNIT, which systemd doesn't reliably set."""
+    src = _read(_DEPLOY / "runner-hooks" / "force-drain.sh")
+    assert 'UNIT="${1:-${SYSTEMD_UNIT:-}}"' in src
+
+
+def test_force_drain_resolves_workdir_via_agentname() -> None:
+    """force-drain.sh's filesystem fallback must look up the runner's
+    .runner config and match on agentName, because runner-dir names
+    (runner-N) don't match the system runner names (d-sorg-local-Desktop-N).
+    """
+    src = _read(_DEPLOY / "runner-hooks" / "force-drain.sh")
+    assert "agentName" in src, "fallback must consult .runner agentName"
+
+
+def test_force_drain_never_blocks_systemd_stop() -> None:
+    """The script must exit 0 even when nothing was found — otherwise an
+    ExecStop= helper that returns non-zero would prevent systemd from
+    marking the unit inactive."""
+    src = _read(_DEPLOY / "runner-hooks" / "force-drain.sh")
+    assert "exit 0" in src
+
+
+def test_job_started_hook_writes_metadata_lockfile() -> None:
+    """The JOB_STARTED hook must write a lockfile under
+    $RUNNER_BUSY_LOCK_DIR with the runner's pid + workflow context so
+    autoscaler/cleanup can use it as a busy signal."""
+    src = _read(_DEPLOY / "runner-hooks" / "job-started.sh")
+    for key in ["pid=", "runner=", "job=", "workflow=", "run_id="]:
+        assert key in src, f"job-started lockfile must include {key}"
+
+
+def test_job_completed_hook_removes_the_lockfile() -> None:
+    src = _read(_DEPLOY / "runner-hooks" / "job-completed.sh")
+    assert "rm -f " in src and "$LOCK_FILE" in src
+
+
+# ─── PR #667: deploy-host.sh single-command entrypoint ───────────────────────
+
+
+def test_deploy_host_sets_uv_link_mode_copy() -> None:
+    """When the source repo lives on /mnt/c (Windows-mounted), uv's
+    default hardlink install fails with cross-filesystem ENOENT. The
+    script must default UV_LINK_MODE=copy upfront."""
+    src = _read(_DEPLOY / "deploy-host.sh")
+    assert 'UV_LINK_MODE="${UV_LINK_MODE:-copy}"' in src
+
+
+def test_deploy_host_invokes_deploy_check() -> None:
+    """The whole point of deploy-check.sh is to fail loudly when a
+    deploy succeeds but the dashboard is silently misconfigured. The
+    one-command flow must run it at the end."""
+    src = _read(_DEPLOY / "deploy-host.sh")
+    assert "deploy-check.sh" in src
+
+
+def test_deploy_host_dry_run_skips_sudo_writes() -> None:
+    """--dry-run must NOT invoke install-runner-maintenance.sh (which
+    has sudo writes). The script must explicitly skip it."""
+    src = _read(_DEPLOY / "deploy-host.sh")
+    assert "dry-run: skipping install-runner-maintenance.sh" in src
+
+
+# ─── PR #668: machine registry path + FLEET_NODES auto-derive ────────────────
+
+
+def test_machine_registry_allows_module_dir() -> None:
+    """load_machine_registry must include `Path(__file__).parent` in
+    its explicit allowed_roots, so the YAML shipping next to the .py
+    can be loaded on deployed installs (which aren't git checkouts)."""
+    src = _read(_BACKEND / "machine_registry.py")
+    assert "Path(__file__).resolve().parent" in src
+    assert "allowed_roots=explicit_roots" in src
+
+
+def test_server_auto_derives_fleet_nodes_from_registry() -> None:
+    """When FLEET_NODES env is empty, server.py must derive it from the
+    registry. Without this, peer federation never happens unless the
+    operator hand-maintains the env var (which nobody did)."""
+    src = _read(_BACKEND / "server.py")
+    assert "AUTODERIVE_FLEET_NODES" in src
+    assert "FLEET_NODES_SOURCE" in src
+    assert 'log.info("FLEET_NODES auto-derived from registry' in src
+
+
+def test_diagnostics_endpoint_exists() -> None:
+    """The /api/diagnostics endpoint must be declared and always return
+    200 (never raise) so it's a reliable deploy-health surface."""
+    src = _read(_BACKEND / "server.py")
+    assert '@app.get("/api/diagnostics")' in src
+    assert "def _diagnostics_payload" in src
+
+
+def test_deploy_check_parses_diagnostics_via_tempfile() -> None:
+    """The earlier inline `printf | python3 -c` pattern fought bash
+    heredoc semantics. The fix uses a tempfile so the JSON parse is
+    robust against any future curl response payload."""
+    src = _read(_DEPLOY / "deploy-check.sh")
+    assert "mktemp /tmp/diag" in src or 'mktemp /tmp/diag.XXXXXX.json' in src
+
+
+def test_deploy_check_warns_on_autoscaler_driven_scaledown() -> None:
+    """When the autoscaler is healthy and has legitimately scaled idle
+    units down, deploy-check must report WARN not FAIL. Otherwise every
+    deploy under load would falsely fail."""
+    src = _read(_DEPLOY / "deploy-check.sh")
+    assert "autoscaler-driven scale-down likely" in src
+
+
+# ─── PR #668 follow-up: world-writable YAML normalization ────────────────────
+
+
+def test_update_deployed_chmods_yaml_for_security_validator() -> None:
+    """Files copied from /mnt/c come over with mode 0777 because NTFS
+    can't represent POSIX bits. security.py rejects world-writable
+    config; the deploy must normalize *.yml/*.yaml/*.json to 0644."""
+    src = _read(_DEPLOY / "update-deployed.sh")
+    assert "chmod 0644" in src
+    assert "'*.yml'" in src and "'*.yaml'" in src and "'*.json'" in src
+
+
+# ─── PR #668 follow-up: Tailscale CGNAT + .ts.net allowance ──────────────────
+
+
+def test_validate_fleet_node_url_allows_cgnat_and_ts_net() -> None:
+    """Tailscale assigns 100.64.0.0/10 CGNAT addresses; ipaddress's
+    is_private excludes that range. Without explicit handling, every
+    Tailscale-routed peer gets rejected and federation never works.
+    Same for *.ts.net MagicDNS hostnames."""
+    src = _read(_BACKEND / "security.py")
+    assert "100.64.0.0/10" in src
+    assert ".ts.net" in src
+
+
+# ─── PR #669: deploy-host frontend build step ────────────────────────────────
+
+
+def test_update_deployed_builds_frontend_and_syncs_dist() -> None:
+    """server.py serves from <dashboard>/dist/. Without `npm run build`
+    + sync of dist/, the favicon, icons, manifest, and the entire SPA
+    bundle 404 (because dist/ is empty on a fresh install)."""
+    src = _read(_DEPLOY / "update-deployed.sh")
+    assert "npm install --no-audit --no-fund --package-lock=false" in src
+    assert "npm run build" in src
+    assert 'sync_dir "$REPO/dist" "$DEPLOY_DIR/dist"' in src
+
+
+# ─── PR #669: health-check fail-fast ─────────────────────────────────────────
+
+
+def test_health_uses_short_github_timeout() -> None:
+    """Health check must use HEALTH_GH_API_S (1s) so it doesn't hang on
+    slow / unreachable GitHub. Inheriting the default dispatch timeout
+    (15s+) made the dashboard appear hung on networks where Tailscale's
+    outbound was degraded (observed on DeskComputer)."""
+    src = _read(_BACKEND / "health.py")
+    assert "HEALTH_GH_API_S" in src
+
+
+def test_metrics_imports_psutil_directly_not_through_server() -> None:
+    """metrics.py was importing psutil + stdlib FROM server.py. Any
+    change to server.py's top-level imports broke /api/system with
+    `ImportError: cannot import name 'psutil' from 'server'`."""
+    src = _read(_BACKEND / "metrics.py")
+    assert "import psutil" in src
+    # The bad pattern was "from server import (... psutil, ...)" — make
+    # sure psutil never appears in such a multi-line import block.
+    assert "psutil," not in src
+
+
+# ─── PR #670: static-serve routes for /favicon, /icons, /sw.js, etc. ─────────
+
+
+def test_server_mounts_icons_dir() -> None:
+    """/icons/<name>.png must be mounted as StaticFiles so PNGs are
+    served with image/png Content-Type instead of being shadowed by the
+    SPA catch-all (which would return index.html as text/html)."""
+    src = _read(_BACKEND / "server.py")
+    assert '"/icons"' in src and "StaticFiles(directory=str(_icons_dir))" in src
+
+
+def test_server_has_static_root_routes() -> None:
+    """Windows taskbar shortcuts probe /favicon.ico; PWA install
+    requires /sw.js at origin-root; /offline.html and /robots.txt are
+    pre-existing static assets that were also shadowed."""
+    src = _read(_BACKEND / "server.py")
+    for path in [
+        '@app.get("/favicon.ico")',
+        '@app.get("/sw.js")',
+        '@app.get("/offline.html")',
+        '@app.get("/robots.txt")',
+    ]:
+        assert path in src, f"missing route: {path}"

--- a/tests/test_today_ui_redesign.py
+++ b/tests/test_today_ui_redesign.py
@@ -1,0 +1,186 @@
+"""Structural regression guards for the 2026-05-18 UI redesign series.
+
+Pins the markup + CSS contracts introduced in PRs #672 (mock-quota
+removal) and #673 (two-row header + fleet-hero panel + stat-sub clamp).
+
+Static greps over the source files — no module imports, no JSX runtime.
+Pure-text checks so they run on every platform.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_FRONTEND_SRC = _REPO / "frontend" / "src"
+_APP_TSX = _FRONTEND_SRC / "legacy" / "App.tsx"
+_INDEX_CSS = _FRONTEND_SRC / "index.css"
+_LIB_FLEET_ALERTS = _FRONTEND_SRC / "lib" / "fleetAlerts.ts"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# ─── PR #672 regression guard: FLEET QUOTA stays removed ─────────────────────
+
+
+def test_fleet_quota_widget_not_reintroduced() -> None:
+    """The mock 'FLEET QUOTA 14/20' widget had no backing API and was
+    obscuring the principal/settings controls. Removed in #672 —
+    explicit guard so it can't be quietly re-added.
+
+    The file is allowed to contain a comment EXPLAINING the removal; the
+    assertion strips `//`-prefixed lines before grepping so the comment
+    doesn't trigger a false positive.
+    """
+    src = _read(_APP_TSX)
+    # Mock-data variables — these only exist if the widget is rendering
+    assert "var quotaUsed" not in src, "mock quotaUsed variable reintroduced"
+    assert "quotaTotal" not in src, "mock quotaTotal variable reintroduced"
+    # Strip line comments before checking for the rendered widget label
+    non_comment = "\n".join(
+        line for line in src.splitlines() if not line.lstrip().startswith("//")
+    )
+    assert '"FLEET QUOTA"' not in non_comment, (
+        "the FLEET QUOTA widget string was reintroduced inside a render call"
+    )
+
+
+def test_grad_quota_css_token_not_reintroduced() -> None:
+    """The --grad-quota CSS custom property powered the mock widget's
+    progress bar. With the widget gone, the token is unused — guard
+    against zombie re-introduction."""
+    src = _read(_INDEX_CSS)
+    assert "--grad-quota" not in src
+
+
+# ─── PR #673: two-row header ────────────────────────────────────────────────
+
+
+def test_app_header_uses_two_row_variant() -> None:
+    """The header was packing logo + 10 tabs + 6 status pills + 3
+    actions into a 56px row, forcing horizontal scroll. The .app-header
+    must opt into the .app-header--rows variant which lays out children
+    in two stacked rows."""
+    src = _read(_APP_TSX)
+    assert '"app-header app-header--rows"' in src
+
+
+def test_app_header_has_primary_and_secondary_rows() -> None:
+    """The two-row split must use the documented class names so the CSS
+    can target them. Renaming either side would break the layout."""
+    src = _read(_APP_TSX)
+    assert "app-header__row--primary" in src
+    assert "app-header__row--secondary" in src
+
+
+def test_index_css_defines_two_row_header_styles() -> None:
+    """The CSS variant must define both rows with the correct sizing:
+    primary 56px, secondary 44px+, secondary tinted."""
+    src = _read(_INDEX_CSS)
+    assert ".app-header.app-header--rows" in src
+    assert ".app-header__row--primary" in src
+    assert ".app-header__row--secondary" in src
+
+
+def test_index_css_hides_tab_bar_scrollbar() -> None:
+    """The tab-bar is still scrollable on overflow but the persistent
+    grey scrollbar underneath the header was visual clutter. Hidden via
+    -webkit-scrollbar height:0 + scrollbar-width:none."""
+    src = _read(_INDEX_CSS)
+    assert ".tab-bar::-webkit-scrollbar" in src
+    assert "scrollbar-width: none" in src
+
+
+# ─── PR #673: fleet-hero panel on Overview ───────────────────────────────────
+
+
+def test_overview_renders_fleet_hero_section() -> None:
+    """The Overview tab must render the fleet-hero section above the
+    KPI grid. This is the user-facing 'system health' surface they
+    asked for."""
+    src = _read(_APP_TSX)
+    assert '"fleet-hero fleet-hero--"' in src or '"fleet-hero"' in src
+    assert "fleet-hero__status" in src
+    assert "fleet-hero__kpis" in src
+    assert "fleet-hero__alerts" in src
+
+
+def test_fleet_hero_kpi_buttons_navigate_to_tabs() -> None:
+    """The hero KPI tiles must be click-through buttons that navigate
+    to the matching tab (machines, queue, overview). Just rendering
+    static numbers misses the 'jump to detail' affordance."""
+    src = _read(_APP_TSX)
+    # The four KPI buttons each have an onClick: function () { setTab(...); }
+    assert 'setTab("machines"); }' in src
+    assert 'setTab("queue"); }' in src
+
+
+def test_fleet_hero_uses_extracted_alerts_module() -> None:
+    """The rollup logic must call the extracted, unit-tested
+    fleetAlerts module rather than reintroducing inline rules in the
+    legacy h()-tree. That's the whole point of the extraction."""
+    src = _read(_APP_TSX)
+    assert 'from "../lib/fleetAlerts"' in src
+    assert "fleetAlerts.computeFleetAlerts" in src
+    assert "fleetAlerts.fleetLevelLabel" in src
+
+
+def test_fleet_alerts_module_exists_and_exports_contract() -> None:
+    """The extracted module's public contract: computeFleetAlerts,
+    fleetLevelLabel, FleetAlert, FleetState, FleetLevel."""
+    src = _read(_LIB_FLEET_ALERTS)
+    for export in [
+        "export function computeFleetAlerts",
+        "export function fleetLevelLabel",
+        "export interface FleetAlert",
+        "export interface FleetState",
+        "export type FleetLevel",
+    ]:
+        assert export in src, f"missing export: {export}"
+
+
+def test_index_css_defines_fleet_hero_severity_borders() -> None:
+    """The hero panel's left border colour reflects the worst severity
+    (green/yellow/red). Pin the three CSS classes so a severity
+    semantic change doesn't quietly drop a level."""
+    src = _read(_INDEX_CSS)
+    assert ".fleet-hero--ok" in src
+    assert ".fleet-hero--warning" in src
+    assert ".fleet-hero--critical" in src
+
+
+# ─── PR #673: bounded stat-sub line-clamp ───────────────────────────────────
+
+
+def test_stat_sub_has_line_clamp() -> None:
+    """A 200+ char Windows scheduled-task error in the keepalive
+    sub-line was blowing out the card height. CSS line-clamp(2) keeps
+    every Stat card uniform; full text remains accessible via title."""
+    src = _read(_INDEX_CSS)
+    assert ".stat-sub" in src
+    assert "-webkit-line-clamp: 2" in src or "line-clamp: 2" in src
+
+
+def test_stat_component_supports_subtitle_for_truncation_hover() -> None:
+    """When the visible sub line has been truncated, the full text must
+    still be reachable via the title attribute. The Stat component
+    accepts a subTitle prop for exactly this case."""
+    src = _read(_APP_TSX)
+    assert "p.subTitle" in src
+    assert 'title: p.subTitle' in src
+
+
+def test_keepalive_card_passes_subtitle_with_full_message() -> None:
+    """The WSL Keepalive card must pass the FULL watchdog message via
+    subTitle so the truncated visible text can be expanded on hover."""
+    src = _read(_APP_TSX)
+    # Find the WSL Keepalive Stat block and check subTitle is supplied
+    # within ~30 lines of "label: \"WSL Keepalive\""
+    idx = src.find('label: "WSL Keepalive"')
+    assert idx >= 0, "WSL Keepalive Stat not found"
+    block = src[idx : idx + 1500]
+    assert "subTitle: watchdog.detail" in block, (
+        "WSL Keepalive must pass full watchdog.detail/summary as subTitle"
+    )


### PR DESCRIPTION
Today's series (#660–#673) merged 13 production changes; CI coverage was uneven across them. This PR adds a focused regression-test layer pinning the load-bearing properties of every change so the next refactor can't silently undo them.

## What's new

### A. Extract + properly test the fleet-alert rollup logic

The Overview "fleet hero" alert rules from #673 were buried inside a `legacy/App.tsx` `h()` tree — impossible to test without spinning up the whole SPA.

- **`frontend/src/lib/fleetAlerts.ts`** — `computeFleetAlerts(state)` returns `{ level, alerts[] }`. Pure function, zero React imports. Same input → same output.
- **`frontend/src/lib/__tests__/fleetAlerts.test.ts`** — **22 vitest cases** covering happy path, zero-machines edge, all 4 rules (machines offline, WSL keepalive degraded/legacy, success rate thresholds, hosted-runner violations), severity rollup, rule ordering, purity, and label mapping.

This is the highest-impact gap from today — the hero panel was the user-facing UI surface and had **zero** automated tests.

### B. Deploy-series structural guards

**`tests/test_today_deploy_hardening.py`** — **26 pytest cases** pinning the exact strings that, if removed, would silently regress one of today's fixes:

| PR | Guard |
|----|-------|
| #660 | `stop_rc=$?` capture must stay in `runner-cleanup.sh` |
| #661 | `heal-host.sh` 3-phase order (drain → cleanup → restart) + `pkill -KILL` post-drain |
| #664/#666 | `KillMode=mixed`, `ExecStop=...%n`, hook lockfile metadata |
| #666 | `force-drain.sh` reads `$1` first, `.runner agentName` fallback, always `exit 0` |
| #667 | `deploy-host.sh` sets `UV_LINK_MODE=copy`, invokes deploy-check, dry-run skips sudo |
| #668 | Registry explicit `allowed_roots`, FLEET_NODES auto-derive, `/api/diagnostics`, CGNAT 100.64/10 + `.ts.net`, deploy-check tempfile JSON parse |
| #669 | `npm install` + `npm run build` + `sync_dir dist/`, 1s health timeout, `metrics.py` imports psutil directly |
| #670 | `/icons` mount + `/favicon.ico` + `/sw.js` + `/offline.html` + `/robots.txt` routes |

### C. UI-redesign structural guards

**`tests/test_today_ui_redesign.py`** — **14 pytest cases** pinning markup + CSS contracts:

- #672 mock quota removal: no `quotaUsed`/`quotaTotal`, no rendered `"FLEET QUOTA"` string, no `--grad-quota` CSS token. Strips line-comments before grepping so the doc-comment about removal doesn't trip the guard.
- #673 two-row header: `app-header--rows` class, primary/secondary row classes, hidden tab-bar scrollbar
- #673 fleet hero: classes, KPI buttons `setTab` to machines/queue, severity border colours (ok/warning/critical)
- #673 alerts module wiring: legacy/App.tsx must import from `../lib/fleetAlerts` and call `computeFleetAlerts` + `fleetLevelLabel`
- #673 stat-sub clamp: `line-clamp: 2` CSS, Stat component supports `subTitle`, WSL Keepalive card passes full watchdog text as `subTitle`

## Results

**62 new tests, all green:**
- 22 vitest (fleetAlerts.ts)
- 26 pytest (deploy-hardening structural guards)
- 14 pytest (UI-redesign structural guards)

`npm run build` clean (47 KB CSS / 676 KB JS — identical bundle size to pre-extraction; the helper module compiles into the same output).

## Test plan

- [x] `npx vitest run frontend/src/lib/__tests__/fleetAlerts.test.ts` → 22 pass
- [x] `pytest tests/test_today_deploy_hardening.py tests/test_today_ui_redesign.py -q` → 40 pass
- [x] `npm run build` clean
- [ ] CI green

## Out of scope

- Pre-existing `test_security.py` failures on Windows-mounted FS (POSIX-mode check) are not touched. They were failing before this PR and continue to. CI runs on Linux where they pass.
- The `test_dockerfile_pins_base_image_to_digest` pre-existing failure is also untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)