### PR TITLE
fix(health): raise HEALTH_GH_API_S from 1s to 10s; pin 5s floor in tests

### DIFF
--- a/backend/dashboard_config/timeouts.py
+++ b/backend/dashboard_config/timeouts.py
@@ -36,7 +36,18 @@ class HttpTimeout:
     # GitHub API tail latency without holding workers too long.
     PROXY_TO_HUB_S: float = 15.0
     GH_API_DEFAULT_S: int = 15
-    HEALTH_GH_API_S: int = 1
+    # 10 s. The original 1 s value (added in #669) assumed the network
+    # round-trip is the bottleneck; on this fleet the bottleneck is
+    # `gh api` itself — forking the Go binary, loading its config, and
+    # signing the request takes 5-8 s consistently even when curl-direct
+    # is sub-second. A 1 s budget killed every health check, surfacing as
+    # `github_api=unreachable` on hosts where the network was fine
+    # (observed on d-sorg-local-ControlTower 2026-05-18 evening; the
+    # entire Overview tab rendered 0 % success rate because /api/stats
+    # depends on the same path and times out the same way). 10 s leaves
+    # enough headroom for tail-latency without holding the worker thread
+    # for the full 15 s default that long-running endpoints use.
+    HEALTH_GH_API_S: int = 10
 
     # Default budget for ``run_cmd`` subprocess invocations. Used at call
     # sites that pass ``timeout=20`` explicitly when a tighter budget is

--- a/tests/test_today_deploy_hardening.py
+++ b/tests/test_today_deploy_hardening.py
@@ -254,13 +254,37 @@ def test_update_deployed_builds_frontend_and_syncs_dist() -> None:
 # ─── PR #669: health-check fail-fast ─────────────────────────────────────────
 
 
-def test_health_uses_short_github_timeout() -> None:
-    """Health check must use HEALTH_GH_API_S (1s) so it doesn't hang on
-    slow / unreachable GitHub. Inheriting the default dispatch timeout
-    (15s+) made the dashboard appear hung on networks where Tailscale's
-    outbound was degraded (observed on DeskComputer)."""
+def test_health_uses_named_github_timeout() -> None:
+    """Health check must use a NAMED timeout constant (HEALTH_GH_API_S)
+    so an operator changing the budget doesn't have to grep multiple
+    call sites. The original 1 s value was too tight (gh api subprocess
+    startup takes 5-8 s on a typical host); the constant now lives at
+    10 s but the named-constant contract is what matters here."""
     src = _read(_BACKEND / "health.py")
     assert "HEALTH_GH_API_S" in src
+
+
+def test_health_gh_api_timeout_is_realistic() -> None:
+    """The original 1 s value killed every health check because `gh api`
+    forks a Go binary, loads its config, signs the request, and only
+    then makes the network call — that takes 5-8 s on a typical host
+    even when curl-direct against api.github.com takes 130 ms. Pin a
+    floor so a future operator can't re-tighten back to a value that
+    breaks the dashboard's GitHub view.
+
+    See d-sorg-local-ControlTower 2026-05-18: the 1 s budget made the
+    Overview tab render 0 % success rate because /api/stats depends on
+    the same `gh api` path and times out identically."""
+    src = _read(_BACKEND / "dashboard_config" / "timeouts.py")
+    import re
+
+    match = re.search(r"HEALTH_GH_API_S:\s*int\s*=\s*(\d+)", src)
+    assert match is not None, "HEALTH_GH_API_S declaration not found"
+    value = int(match.group(1))
+    assert value >= 5, (
+        f"HEALTH_GH_API_S={value}s is below the 5s floor; `gh api` subprocess "
+        f"startup alone takes 5-8s. Anything lower kills every health check."
+    )
 
 
 def test_metrics_imports_psutil_directly_not_through_server() -> None:


### PR DESCRIPTION
## What was broken

Dashboard Overview tab shows **Success Rate: 0%** even when ~36% of recent runs succeed. \`/api/health\` reports \`github_api=unreachable\`. \`/api/stats\` hangs forever.

## Root cause

PR [#669](https://github.com/D-sorganization/Runner_Dashboard/pull/669) set \`HEALTH_GH_API_S=1\` on the theory that the bottleneck for the GitHub health check was network latency. On this fleet the bottleneck is \`gh api\` subprocess startup, not the wire.

Measured on \`d-sorg-local-ControlTower\` 2026-05-18:

```
$ /usr/bin/time -f "elapsed=%e" gh api /orgs/D-sorganization/actions/runners --jq ".total_count"
34
elapsed=8.18
34
elapsed=6.29
34
elapsed=5.76
```

vs. direct curl against the same endpoint:

```
$ time curl -sS -H "Authorization: token $GH_TOKEN" \
    https://api.github.com/orgs/D-sorganization/actions/runners > /dev/null
real    0m0.136s
```

The wire is fast. \`gh api\` is slow because it forks a Go binary, loads its config, signs the request, then makes the call. **1 s killed every single health check** — observable as \`github_check_seconds: 1.01\` in the \`/api/health\` response (exactly at the timeout edge).

## Fix

- Raise \`HEALTH_GH_API_S\` to **10 s**. Leaves headroom for the p99 (~8 s) without holding the worker thread for the full \`GH_API_DEFAULT_S=15 s\` used by long-running endpoints.
- Add \`test_health_gh_api_timeout_is_realistic\` that pins a **5 s floor** so a future operator tempted to make it snappier can't accidentally re-break the dashboard's GitHub view.
- Rename the existing test from \`test_health_uses_short_github_timeout\` to \`test_health_uses_named_github_timeout\` — the contract that matters is "use a named constant", not "be short".

## Verification

- \`pytest tests/test_today_deploy_hardening.py tests/test_health.py -q -k "health or timeout or HEALTH"\` → 5 passed
- \`ruff check\` clean
- After merge + deploy on this host, \`/api/health\` will return \`github_api: connected\` and the Overview tab will render real success-rate data.

## Follow-up worth considering (out of scope)

Route \`/api/health\`'s GitHub check through the same httpx pool the rest of the backend uses (auth header from the stored \`GH_TOKEN\`). That drops health-check latency from ~6 s to ~150 ms and makes a 1-2 s budget genuinely viable. Big enough refactor to deserve its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)