### PR TITLE
fix(autoscaler): add graceful-drain drop-in for actions.runner.* units (Fix 3, #640)

### DIFF
--- a/backend/runner_autoscaler.py
+++ b/backend/runner_autoscaler.py
@@ -411,6 +411,23 @@ def _runner_is_busy(unit: str) -> bool:
 
 
 def _stop_unit(unit: str) -> bool:
+    """Stop *unit* via ``sudo systemctl stop``.
+
+    Graceful-drain contract (issue #640 Fix 3):
+    This function sends ``systemctl stop`` which delivers SIGTERM to the unit's
+    main process. Whether the runner Worker children survive long enough to
+    finish their job depends on the ``KillMode`` and ``TimeoutStopSec`` settings
+    of the runner's service unit. The ``deploy/install-autoscaler.sh`` installer
+    writes a drop-in that sets ``KillMode=mixed`` and ``TimeoutStopSec=600`` on
+    all ``actions.runner.*`` units. Without that drop-in, systemd falls back to
+    its default ``TimeoutStopSec=90s`` and ``KillMode=control-group``, which
+    sends SIGKILL to the entire cgroup after 90 seconds — killing mid-job
+    Workers and corrupting the runner's work directory.
+
+    The autoscaler never calls ``systemctl kill --signal=SIGKILL`` directly;
+    the kill is always delegated to systemd's stop machinery, whose behaviour
+    the drop-in controls.
+    """
     if DRY_RUN:
         log.info("[dry-run] would stop %s", unit)
         return True

--- a/deploy/install-autoscaler.sh
+++ b/deploy/install-autoscaler.sh
@@ -6,6 +6,11 @@
 # - Installs runner-autoscaler.service as a systemd unit.
 # - Installs a sudoers drop-in granting the runner user the minimum rights to
 #   start/stop actions.runner.* units (and nothing else).
+# - Installs a systemd drop-in for ALL actions.runner.* units that raises
+#   TimeoutStopSec to 600s and sets KillMode=mixed so the autoscaler's
+#   `systemctl stop` sends SIGTERM (not SIGKILL) and gives running jobs
+#   up to 10 minutes to finish cleanly before the process is force-killed.
+#   (Fix 3 from issue #640.)
 # - Enables + starts the service.
 #
 # Run once per fleet machine:
@@ -19,6 +24,13 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DASHBOARD_DIR="${DASHBOARD_DIR:-$HOME/actions-runners/dashboard}"
 RUNNER_USER="${RUNNER_USER:-$(id -un)}"
 SCHEDULE_CONFIG="${RUNNER_SCHEDULE_CONFIG:-$HOME/.config/runner-dashboard/runner-schedule.json}"
+# Directory for the graceful-stop drop-in. All actions.runner.*.service units
+# matching this glob will be governed by the drop-in placed here.
+RUNNER_DROPIN_DIR="${RUNNER_DROPIN_DIR:-/etc/systemd/system/actions.runner@.service.d}"
+# How long to wait for a running job to finish before systemd sends SIGKILL.
+# 600s (10 min) is generous but avoids truncating legitimate long-running steps
+# (pip-install on slow hosts, integration test suites, etc.).
+RUNNER_STOP_TIMEOUT="${RUNNER_STOP_TIMEOUT:-600}"
 
 echo "==> Installing runner auto-scaler on $(hostname)"
 echo "    Deployed dashboard dir: $DASHBOARD_DIR"
@@ -47,7 +59,55 @@ EOF
     sudo visudo -cf "$SUDOERS_FILE" > /dev/null || { echo "sudoers validation failed"; exit 1; }
 fi
 
-# 4. Install + enable the systemd unit
+# 4. Graceful-stop drop-in for all actions.runner.* units (issue #640 Fix 3).
+#
+# Problem: `systemctl stop` defaults to TimeoutStopSec=90s then SIGKILL.
+# Runners executing pip-install (network-bound) or long test suites may still
+# be busy at 90s, so they get SIGKILL mid-job, leaving corrupted state and
+# stuck GitHub workflow runs (the "in_progress for 360 minutes" symptom).
+#
+# Fix: a drop-in under /etc/systemd/system/actions.runner@.service.d/ raises
+# TimeoutStopSec to RUNNER_STOP_TIMEOUT and sets KillMode=mixed so:
+#   - MainPID (Runner.Listener) gets SIGTERM immediately.
+#   - Worker processes are allowed to finish naturally up to TimeoutStopSec.
+#   - Only if the timeout fires does systemd send SIGKILL to stragglers.
+#
+# The GitHub Actions runner honours SIGTERM on its Listener by draining the
+# current job before exiting, so this cooperates with the runner's own
+# graceful-shutdown contract.
+#
+# Note: we target actions.runner@.service (the template unit) so the drop-in
+# applies to all instances (actions.runner@<runner-name>.service). If the
+# runner installer on this machine uses uninstanced names
+# (actions.runner.<org>.<name>.service), we also create a drop-in directory
+# for those by detecting existing unit names and writing per-unit drop-ins.
+echo "==> Installing graceful-stop drop-in for actions.runner.* units"
+DROPIN_CONTENT="[Service]
+# Raised from the default 90s so running jobs can finish before SIGKILL.
+# Matches the autoscaler's busy-detection window (issue #640 Fix 3).
+TimeoutStopSec=${RUNNER_STOP_TIMEOUT}
+# KillMode=mixed: send SIGTERM to the main process (Runner.Listener),
+# but allow Worker children to finish naturally within TimeoutStopSec.
+KillMode=mixed"
+
+# Install drop-in for the template unit (covers instanced units on some setups)
+sudo mkdir -p "$RUNNER_DROPIN_DIR"
+echo "$DROPIN_CONTENT" | sudo tee "${RUNNER_DROPIN_DIR}/graceful-stop.conf" > /dev/null
+echo "    Installed drop-in at ${RUNNER_DROPIN_DIR}/graceful-stop.conf"
+
+# Also apply to any non-template actions.runner.*.service units already on disk
+for unit_path in /etc/systemd/system/actions.runner.*.service; do
+    [[ -f "$unit_path" ]] || continue
+    unit_name="$(basename "$unit_path" .service)"
+    dropin_dir="/etc/systemd/system/${unit_name}.service.d"
+    if [[ ! -f "${dropin_dir}/graceful-stop.conf" ]]; then
+        sudo mkdir -p "$dropin_dir"
+        echo "$DROPIN_CONTENT" | sudo tee "${dropin_dir}/graceful-stop.conf" > /dev/null
+        echo "    Installed drop-in for ${unit_name}"
+    fi
+done
+
+# 5. Install + enable the systemd unit
 echo "==> Installing systemd unit"
 
 TEMPLATE_FILE="$SCRIPT_DIR/runner-autoscaler.service"

--- a/tests/test_runner_autoscaler.py
+++ b/tests/test_runner_autoscaler.py
@@ -633,3 +633,88 @@ class TestAutoscalerLockPathFallback:
                 fd2.close()
         finally:
             fd1.close()
+
+
+# ---------------------------------------------------------------------------
+# Graceful-drain drop-in contract — issue #640 Fix 3
+#
+# _stop_unit() delegates SIGTERM/SIGKILL timing entirely to systemd's stop
+# machinery. Correct behaviour requires that the actions.runner.* units are
+# configured with KillMode=mixed and TimeoutStopSec >= 600s. The installer
+# (deploy/install-autoscaler.sh) is responsible for writing this drop-in;
+# the tests below pin the expected drop-in content so regressions in the
+# installer are caught by CI rather than silently landing on the host.
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDrainDropin:
+    """install-autoscaler.sh must emit a correct graceful-stop drop-in."""
+
+    INSTALL_SCRIPT = Path(__file__).resolve().parent.parent / "deploy" / "install-autoscaler.sh"
+
+    def _read_script(self) -> str:
+        return self.INSTALL_SCRIPT.read_text(encoding="utf-8")
+
+    def test_install_script_exists(self) -> None:
+        assert self.INSTALL_SCRIPT.is_file(), "deploy/install-autoscaler.sh is missing"
+
+    def test_dropin_sets_timeout_stop_sec(self) -> None:
+        """TimeoutStopSec must be present and set to ≥ 600s in the drop-in block."""
+        content = self._read_script()
+        # The drop-in block must reference TimeoutStopSec with a value derived
+        # from RUNNER_STOP_TIMEOUT (default 600).
+        assert "TimeoutStopSec" in content, (
+            "install-autoscaler.sh must set TimeoutStopSec in the graceful-stop drop-in"
+        )
+        assert "600" in content, (
+            "Default RUNNER_STOP_TIMEOUT must be 600 (seconds) in install-autoscaler.sh"
+        )
+
+    def test_dropin_sets_kill_mode_mixed(self) -> None:
+        """KillMode=mixed must be present — it lets Worker children finish naturally."""
+        content = self._read_script()
+        assert "KillMode=mixed" in content, (
+            "install-autoscaler.sh must set KillMode=mixed so Worker children "
+            "survive their parent's SIGTERM and can complete the running job"
+        )
+
+    def test_dropin_applied_to_runner_units(self) -> None:
+        """The drop-in must target actions.runner units, not the autoscaler itself."""
+        content = self._read_script()
+        assert "actions.runner" in content, (
+            "install-autoscaler.sh must write the drop-in for actions.runner.* units"
+        )
+
+    def test_stop_unit_uses_systemctl_stop(self) -> None:
+        """_stop_unit must use 'systemctl stop', delegating kill timing to the drop-in.
+
+        If _stop_unit hard-codes --signal=SIGKILL or uses systemctl kill,
+        the drop-in's TimeoutStopSec/KillMode settings are bypassed, defeating
+        the graceful-drain contract.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        # Extract only the code lines (skip the docstring) to avoid false
+        # positives from documentation that mentions SIGKILL as an anti-pattern.
+        tree = ast.parse(textwrap.dedent(inspect.getsource(ra._stop_unit)))
+        func_def = tree.body[0]
+        assert isinstance(func_def, ast.FunctionDef)
+        # Reconstruct source without the leading docstring node.
+        non_doc_nodes = func_def.body
+        if non_doc_nodes and isinstance(non_doc_nodes[0], ast.Expr) and isinstance(
+            non_doc_nodes[0].value, ast.Constant
+        ):
+            non_doc_nodes = non_doc_nodes[1:]
+        code_src = ast.unparse(ast.Module(body=non_doc_nodes, type_ignores=[]))  # type: ignore[attr-defined]
+
+        assert "systemctl" in code_src, "_stop_unit must call systemctl"
+        assert "stop" in code_src, "_stop_unit must use systemctl stop"
+        assert "SIGKILL" not in code_src, (
+            "_stop_unit must not hard-code SIGKILL in its executable code; "
+            "let systemd's TimeoutStopSec handle it"
+        )
+        assert "systemctl kill" not in code_src, (
+            "_stop_unit must not use systemctl kill; that bypasses the graceful-drain drop-in"
+        )


### PR DESCRIPTION
## Summary

This PR completes **Fix 3** from issue #640 ("Autoscaler kills busy runners mid-job").

**Fixes 1 & 2** (MainPID=0 fallback + LOAD_PER_CORE raised to 2.5) were shipped in PR #647. The remaining acceptance criterion was:

> Fix 3 — defense in depth: stop using SIGKILL for scale-down. Set `KillMode=mixed` + a long `TimeoutStopSec=600` in the service unit so workers can finish.

## Problem

`systemctl stop actions.runner.*.service` relies on the service unit's `TimeoutStopSec` and `KillMode`. Without explicit configuration:
- `TimeoutStopSec` defaults to **90s** — not enough for a pip-install step on a slow host
- `KillMode` defaults to **control-group** — sends SIGKILL to the entire cgroup after the timeout, killing `Runner.Worker` children mid-step

Result: corrupted `_work/` directories, stuck `in_progress` workflow runs for up to 360 minutes, and the exact "orphaned Unit process remains running after unit stopped" symptom documented in issue #653.

## Changes

### `deploy/install-autoscaler.sh`

New step 4 installs a systemd drop-in under `/etc/systemd/system/actions.runner@.service.d/graceful-stop.conf` (and individual per-unit drop-ins for non-instanced runner names) that sets:

```ini
[Service]
TimeoutStopSec=600   # 10 min window before SIGKILL
KillMode=mixed       # SIGTERM to MainPID; let Worker children finish naturally
```

Configurable via `RUNNER_STOP_TIMEOUT` env var. The GitHub Actions runner honours SIGTERM on its Listener by draining the current job, so this cooperates with the runner's own graceful-shutdown contract.

### `backend/runner_autoscaler.py`

Docstring on `_stop_unit()` documents the graceful-drain contract so future maintainers understand why the function must not add `--signal=SIGKILL`.

### `tests/test_runner_autoscaler.py`

New `TestGracefulDrainDropin` class (5 tests):
- install script exists
- `TimeoutStopSec` present with default 600
- `KillMode=mixed` present
- drop-in targets `actions.runner.*` units
- `_stop_unit` uses `systemctl stop` (not `systemctl kill` / hard-coded SIGKILL)

## Verification

- [x] `pytest tests/test_runner_autoscaler.py` — 53 passed, 2 skipped (POSIX-only fcntl tests, expected on Windows)
- [x] `ruff check backend/runner_autoscaler.py tests/test_runner_autoscaler.py` — clean
- [x] New `TestGracefulDrainDropin` tests all pass locally
- [x] No change to `_runner_is_busy()` or `_stop_unit()` logic — deploy-only fix

## Acceptance criteria status (issue #640)

- [x] `_runner_is_busy()` returns True for MainPID=0 (Fix 1, PR #647)
- [x] `AUTOSCALER_LOAD_PER_CORE` default raised to 2.5 (Fix 2, PR #647)
- [x] Unit tests cover the three is-busy paths (PR #647 + existing tests)
- [x] Service file uses graceful drain (`TimeoutStopSec=600`, `KillMode=mixed`) **← this PR**
- [ ] Soak test (1h with all runners busy, zero STOPPED log lines) — ops verification post-merge

Fixes #640