### PR TITLE
fix(frontend): add useTimeAgo hook and TimeAgo primitive (#725)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `backend/pyproject.toml` and `backend/uv.lock` for reproducible backend dependency resolution.
 - Root-level `uv.lock` for reproducible project dependency resolution.
+- `useTimeAgo` hook (`frontend/src/hooks/useTimeAgo.ts`) and `<TimeAgo>` primitive
+  (`frontend/src/primitives/TimeAgo.tsx`) for relative timestamp rendering
+  (`"just now"`, `"2m ago"`, `"3h ago"`, `"yesterday"`, absolute dates beyond
+  48h). Future timestamps render `"soon"`; invalid input degrades to the raw
+  value. Wired into `Reports/Mobile.tsx` Modified field as first call-site.
+  Closes #725.
 
 ### Changed
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,12 +1,19 @@
 ﻿# SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.26
+**Spec Version:** 2.5.27
 **Application Version:** 4.1.0 (see `VERSION`)
-**Last Updated:** 2026-05-22T17:45:00Z
+**Last Updated:** 2026-05-22T23:40:00Z
 **Status:** Active
 
 ### Recent Spec Updates
 
+- **2026-05-22 (2.5.27):** Added relative-timestamp primitive (#725):
+  `frontend/src/hooks/useTimeAgo.ts` (`useTimeAgo`, `formatTimeAgo`) and
+  `frontend/src/primitives/TimeAgo.tsx` (`<TimeAgo iso={...} />`). Renders
+  semantic `<time>` with the raw ISO in `dateTime` + tooltip; future
+  timestamps render `"soon"`, invalid input degrades to the raw value with
+  a `console.warn`. Wired into `Reports/Mobile.tsx` "Modified" field as the
+  first call-site; remaining pages migrate in follow-ups.
 - **2026-05-22 (2.5.26):** Added `DASHBOARD_HOST` env var
   (`dashboard_config.HOST`) for uvicorn bind interface; default preserves
   historical `0.0.0.0` behaviour. Added `deploy/wsl-mirrored-port-helper.sh`

--- a/frontend/src/hooks/__tests__/useTimeAgo.test.ts
+++ b/frontend/src/hooks/__tests__/useTimeAgo.test.ts
@@ -79,11 +79,11 @@ describe('useTimeAgo (hook)', () => {
     const iso = new Date(NOW - 30_000).toISOString();
     const { result } = renderHook(() => useTimeAgo(iso));
     expect(result.current).toBe('just now');
-    // Advance system clock by 90s — the hook's internal interval should fire
-    // and produce the updated relative string.
+    // Advance the fake-timer queue — vitest's advanceTimersByTime moves the
+    // mocked Date.now() forward in lockstep, so the 30s interval fires with
+    // a fresh "now". Total elapsed: 30s initial + 90s advance = 2m.
     act(() => {
-      vi.setSystemTime(NOW + 90_000);
-      vi.advanceTimersByTime(60_000);
+      vi.advanceTimersByTime(90_000);
     });
     expect(result.current).toBe('2m ago');
   });

--- a/frontend/src/hooks/__tests__/useTimeAgo.test.ts
+++ b/frontend/src/hooks/__tests__/useTimeAgo.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for useTimeAgo hook — relative timestamp utility.
+ *
+ * Covers issue #725 (D6).
+ *
+ * Engineering principles:
+ * - TDD: this file was authored before the implementation.
+ * - DbC: precondition (parseable input) and postcondition (non-empty,
+ *   human-readable output) are asserted via parameterised cases.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTimeAgo, formatTimeAgo } from '../useTimeAgo';
+
+const NOW = new Date('2026-05-22T12:00:00Z').getTime();
+
+describe('formatTimeAgo (pure)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['0 seconds ago renders "just now"', 0, 'just now'],
+    ['30 seconds ago renders "just now"', 30_000, 'just now'],
+    ['90 seconds ago renders "1m ago"', 90_000, '1m ago'],
+    ['2 hours ago renders "2h ago"', 2 * 60 * 60 * 1000, '2h ago'],
+    ['26 hours ago renders "yesterday"', 26 * 60 * 60 * 1000, 'yesterday'],
+    ['8 days ago renders an absolute date (e.g. May 14)', 8 * 24 * 60 * 60 * 1000, /^[A-Z][a-z]{2} \d{1,2}$/],
+    ['400 days ago renders an absolute date with year', 400 * 24 * 60 * 60 * 1000, /\d{4}/],
+  ])('%s', (_label, deltaMs, expected) => {
+    const past = new Date(NOW - deltaMs).toISOString();
+    const out = formatTimeAgo(past);
+    if (expected instanceof RegExp) {
+      expect(out).toMatch(expected);
+    } else {
+      expect(out).toBe(expected);
+    }
+    // DbC postcondition: non-empty string.
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('future timestamps render "soon"', () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(formatTimeAgo(future)).toBe('soon');
+  });
+
+  it('invalid input returns the raw string and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(formatTimeAgo('not-a-date')).toBe('not-a-date');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('accepts a Date object as input', () => {
+    expect(formatTimeAgo(new Date(NOW - 5 * 60 * 1000))).toBe('5m ago');
+  });
+});
+
+describe('useTimeAgo (hook)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the same string formatTimeAgo would produce', () => {
+    const iso = new Date(NOW - 60_000).toISOString();
+    const { result } = renderHook(() => useTimeAgo(iso));
+    expect(result.current).toBe('1m ago');
+  });
+
+  it('re-renders on its own clock when live=true (default)', () => {
+    const iso = new Date(NOW - 30_000).toISOString();
+    const { result } = renderHook(() => useTimeAgo(iso));
+    expect(result.current).toBe('just now');
+    // Advance system clock by 90s — the hook's internal interval should fire
+    // and produce the updated relative string.
+    act(() => {
+      vi.setSystemTime(NOW + 90_000);
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe('2m ago');
+  });
+
+  it('does not start a timer when live=false', () => {
+    const iso = new Date(NOW - 30_000).toISOString();
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+    renderHook(() => useTimeAgo(iso, { live: false }));
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    setIntervalSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useTimeAgo.ts
+++ b/frontend/src/hooks/useTimeAgo.ts
@@ -1,0 +1,136 @@
+/**
+ * useTimeAgo — relative timestamp formatting hook.
+ *
+ * Addresses Runner_Dashboard#725 (D6). Every visible timestamp in the
+ * dashboard should render through this utility so operators see
+ * `"2m ago"` rather than `2026-05-22T14:31:45.123456Z`.
+ *
+ * Engineering principles:
+ * - DbC: precondition asserts input is parseable as a Date in dev mode;
+ *   postcondition guarantees a non-empty, human-readable string.
+ * - LoD: pure `formatTimeAgo` takes a flat scalar — no reaching through
+ *   nested objects across module boundaries.
+ * - Reusable: hook delegates to the pure formatter; the primitive
+ *   `<TimeAgo />` consumes the hook so logic lives in exactly one place.
+ *
+ * Locale handling: uses `Intl.RelativeTimeFormat` and `Intl.DateTimeFormat`
+ * with the runtime locale (`document.documentElement.lang || navigator.language`)
+ * so we honour the i18n configuration without coupling to react-i18next.
+ */
+import { useEffect, useState } from 'react';
+
+const SECOND = 1_000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+const JUST_NOW_THRESHOLD = 60 * SECOND;
+const YESTERDAY_LOWER = 24 * HOUR;
+const YESTERDAY_UPPER = 48 * HOUR;
+
+export interface UseTimeAgoOptions {
+  /**
+   * Re-render the hook over time so the displayed value stays fresh.
+   * Defaults to `true`. Set to `false` for static contexts (e.g. exports).
+   */
+  live?: boolean;
+}
+
+function resolveLocale(): string {
+  if (typeof document !== 'undefined' && document.documentElement?.lang) {
+    return document.documentElement.lang;
+  }
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    return navigator.language;
+  }
+  return 'en';
+}
+
+function toDate(input: string | Date): Date | null {
+  if (input instanceof Date) {
+    return Number.isFinite(input.getTime()) ? input : null;
+  }
+  if (typeof input !== 'string' || input.length === 0) {
+    return null;
+  }
+  const d = new Date(input);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+function absoluteDate(date: Date, now: Date, locale: string): string {
+  const sameYear = date.getUTCFullYear() === now.getUTCFullYear();
+  const fmt = new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: sameYear ? undefined : 'numeric',
+  });
+  return fmt.format(date);
+}
+
+/**
+ * Pure formatter — exported for unit tests and one-off rendering (e.g.
+ * inside table cells where running a hook per row is undesirable).
+ *
+ * Postcondition: returns a non-empty string. For unparseable input the raw
+ * string is returned (with a `console.warn`) so the UI never blanks out.
+ */
+export function formatTimeAgo(input: string | Date, now: Date = new Date()): string {
+  const date = toDate(input);
+  if (!date) {
+    // DbC graceful-degradation: warn but never throw in production rendering.
+    // eslint-disable-next-line no-console
+    console.warn('[useTimeAgo] invalid input:', input);
+    return typeof input === 'string' ? input : String(input);
+  }
+
+  const deltaMs = now.getTime() - date.getTime();
+
+  // Future timestamps: render "soon" rather than nonsensical "-2m ago".
+  if (deltaMs < 0) {
+    return 'soon';
+  }
+
+  if (deltaMs < JUST_NOW_THRESHOLD) {
+    return 'just now';
+  }
+  if (deltaMs < HOUR) {
+    const minutes = Math.floor(deltaMs / MINUTE);
+    return `${minutes}m ago`;
+  }
+  if (deltaMs < YESTERDAY_LOWER) {
+    const hours = Math.floor(deltaMs / HOUR);
+    return `${hours}h ago`;
+  }
+  if (deltaMs < YESTERDAY_UPPER) {
+    return 'yesterday';
+  }
+  // Older than ~2 days — fall back to an absolute, locale-formatted date.
+  return absoluteDate(date, now, resolveLocale());
+}
+
+/**
+ * React hook that returns the formatted relative-time string and refreshes
+ * it on a coarse interval (30s for <1h timestamps, 5min for <24h, no
+ * refresh for older absolute dates).
+ */
+export function useTimeAgo(
+  input: string | Date,
+  opts: UseTimeAgoOptions = {},
+): string {
+  const { live = true } = opts;
+  const [, force] = useState(0);
+  const value = formatTimeAgo(input);
+
+  useEffect(() => {
+    if (!live) return;
+    const date = toDate(input);
+    if (!date) return;
+    const deltaMs = Date.now() - date.getTime();
+    // Older than 24h — the value is an absolute date that won't change.
+    if (deltaMs > YESTERDAY_UPPER) return;
+    const intervalMs = deltaMs < HOUR ? 30 * SECOND : 5 * MINUTE;
+    const id = window.setInterval(() => force((n) => n + 1), intervalMs);
+    return () => window.clearInterval(id);
+  }, [input, live, value]);
+
+  return value;
+}

--- a/frontend/src/pages/Reports/Mobile.tsx
+++ b/frontend/src/pages/Reports/Mobile.tsx
@@ -13,6 +13,7 @@ import { SkeletonCard, SkeletonLine } from "../../primitives/Skeleton";
 import { PullToRefresh } from "../../primitives/PullToRefresh";
 import { BottomSheet } from "../../primitives/BottomSheet";
 import { SegmentedControl } from "../../primitives/SegmentedControl";
+import { TimeAgo } from "../../primitives/TimeAgo";
 import { useHaptic } from "../../hooks/useHaptic";
 
 interface ReportFile {
@@ -158,7 +159,7 @@ function ReportDetailSheet({ report, onClose }: ReportDetailSheetProps) {
         </div>
         <div style={{ color: "var(--text-secondary)", fontSize: "13px" }}>
           <strong>Modified:</strong>{" "}
-          {new Date(report.modified).toLocaleString()}
+          <TimeAgo iso={report.modified} />
         </div>
 
         <div style={{ display: "flex", flexDirection: "column", gap: "8px", paddingTop: "8px" }}>

--- a/frontend/src/primitives/TimeAgo.tsx
+++ b/frontend/src/primitives/TimeAgo.tsx
@@ -1,0 +1,45 @@
+/**
+ * <TimeAgo /> — accessible relative-time primitive.
+ *
+ * Addresses Runner_Dashboard#725 (D6). Renders a semantic `<time>`
+ * element so screen readers announce e.g. "2 minutes ago" (via the
+ * formatted text) while the raw ISO value is preserved in the
+ * `dateTime` attribute and tooltip for power users.
+ *
+ * Engineering principles:
+ * - DRY: delegates to `useTimeAgo`; never inlines formatting logic.
+ * - Orthogonality: a render failure here cannot cascade — invalid input
+ *   degrades to the raw string, never throws.
+ */
+import { type HTMLAttributes } from 'react';
+import { useTimeAgo, type UseTimeAgoOptions } from '../hooks/useTimeAgo';
+
+export interface TimeAgoProps
+  extends Omit<HTMLAttributes<HTMLTimeElement>, 'title' | 'children'> {
+  /** ISO-8601 string or Date instance to render. */
+  iso: string | Date;
+  /**
+   * Tooltip override. Defaults to the raw ISO string so hovering reveals
+   * the precise timestamp.
+   */
+  title?: string;
+  /** Forwarded to `useTimeAgo`. */
+  live?: UseTimeAgoOptions['live'];
+}
+
+function toIsoString(value: string | Date): string {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value.toISOString() : '';
+  }
+  return value;
+}
+
+export function TimeAgo({ iso, title, live, ...rest }: TimeAgoProps) {
+  const formatted = useTimeAgo(iso, { live });
+  const isoString = toIsoString(iso);
+  return (
+    <time dateTime={isoString} title={title ?? isoString} {...rest}>
+      {formatted}
+    </time>
+  );
+}

--- a/frontend/src/primitives/__tests__/TimeAgo.test.tsx
+++ b/frontend/src/primitives/__tests__/TimeAgo.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Tests for <TimeAgo /> primitive.
+ *
+ * Covers issue #725 (D6).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TimeAgo } from '../TimeAgo';
+
+const NOW = new Date('2026-05-22T12:00:00Z').getTime();
+
+describe('<TimeAgo />', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders a <time> element with the ISO dateTime attribute', () => {
+    const iso = new Date(NOW - 60_000).toISOString();
+    render(<TimeAgo iso={iso} />);
+    const node = screen.getByText('1m ago');
+    expect(node.tagName).toBe('TIME');
+    expect(node).toHaveAttribute('datetime', iso);
+  });
+
+  it('exposes the full ISO timestamp as a tooltip via the title attribute', () => {
+    const iso = new Date(NOW - 60_000).toISOString();
+    render(<TimeAgo iso={iso} />);
+    expect(screen.getByText('1m ago')).toHaveAttribute('title', iso);
+  });
+
+  it('honours a custom title override (e.g. localized full date)', () => {
+    const iso = new Date(NOW - 60_000).toISOString();
+    render(<TimeAgo iso={iso} title="2026-05-22 11:59 UTC" />);
+    expect(screen.getByText('1m ago')).toHaveAttribute(
+      'title',
+      '2026-05-22 11:59 UTC',
+    );
+  });
+
+  it('falls back gracefully on invalid input by rendering the raw value', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<TimeAgo iso="not-a-date" />);
+    expect(screen.getByText('not-a-date')).toBeInTheDocument();
+    warnSpy.mockRestore();
+  });
+});

--- a/frontend/src/primitives/index.ts
+++ b/frontend/src/primitives/index.ts
@@ -37,3 +37,6 @@ export type {
 
 export { BottomSheet } from "./BottomSheet";
 export type { BottomSheetProps } from "./BottomSheet";
+
+export { TimeAgo } from "./TimeAgo";
+export type { TimeAgoProps } from "./TimeAgo";


### PR DESCRIPTION
## What

Adds a reusable relative-timestamp utility and accessible `<TimeAgo>` primitive so operators see `"2m ago"` rather than `2026-05-22T14:31:45.123Z` across the dashboard.

- `frontend/src/hooks/useTimeAgo.ts`
  - `formatTimeAgo(input, now?)` — pure formatter for one-off renders (e.g. inside table cells where running a hook per row is undesirable).
  - `useTimeAgo(input, { live })` — React hook; self-refreshes every 30 s for `<1h` ages and every 5 min for `<24h`. Older absolute dates never re-render.
- `frontend/src/primitives/TimeAgo.tsx`
  - `<TimeAgo iso={value} />` renders semantic `<time dateTime title>` so screen readers announce `"2 minutes ago"` while power users keep the raw ISO in the tooltip.

Thresholds: `just now` (`<60s`) → `Xm ago` (`<1h`) → `Xh ago` (`<24h`) → `yesterday` (`<48h`) → absolute month-day (same year) → absolute month-day-year (older). Future timestamps render `"soon"`; unparseable input degrades to the raw string with a `console.warn`.

Wired into `Reports/Mobile.tsx` "Modified" field as the first call-site. Remaining pages (Fleet, Queue, AgentDispatch, Remediation, Maxwell, Credentials) migrate in follow-up PRs so each wiring change stays review-sized.

## Why

Issue #725 (D6) — every visible timestamp currently renders as raw ISO. Operators have to mentally diff against "now" to judge freshness, which is hostile to fast incident response.

## How tested

- `frontend/src/hooks/__tests__/useTimeAgo.test.ts` — 13 cases. Parameterised threshold table (0 s, 30 s, 90 s, 2 h, 26 h, 8 d, 400 d), future-soon fallback, invalid-input guard, Date-instance acceptance, hook live re-render via `vi.useFakeTimers` + `act`, no-timer assertion when `live=false`.
- `frontend/src/primitives/__tests__/TimeAgo.test.tsx` — 4 cases. Asserts the rendered element is `<time>`, that the `dateTime` attribute carries the raw ISO, that the default tooltip shows the raw ISO, that `title` can be overridden, and that invalid input degrades to the raw value without throwing.
- Full vitest suite (`npx vitest run`): **184 passed / 31 skipped, no failures**.
- ESLint on the new files: clean.
- TypeScript: no new errors introduced (the existing `tsc -b` errors all pre-date this branch and live in `legacy/`, `storage.ts`, `main.tsx`, `PushSettings.tsx`, `router.tsx`).

## Engineering-principle checklist

- [x] **TDD** — failing tests committed first (`26e3a99`), implementation made them green in `c70627f`.
- [x] **DbC** — `formatTimeAgo` documents pre- and postconditions; invalid input is a documented, tested branch (warn + raw passthrough), never thrown across a module boundary.
- [x] **DRY** — primitive delegates to the hook; the hook delegates to the pure formatter. Threshold logic lives in exactly one place.
- [x] **LoD** — hook takes a flat `string | Date` scalar — no reaching through nested objects.
- [x] **Orthogonality** — invalid input cannot throw, so a bad timestamp in one tab cannot cascade into a render error elsewhere.
- [x] **Reusable** — exported through `primitives/index.ts`; sibling repos that consume our type bundle get the primitive for free.
- [x] **SPEC.md + CHANGELOG.md** updated (Spec Version bumped to 2.5.27).

## Risk

Low. New files (hook + primitive + tests) are net-additive. The only behavioural change to an existing surface is `Reports/Mobile.tsx` swapping `new Date(report.modified).toLocaleString()` for `<TimeAgo iso={report.modified} />` — same data, more readable, with the original ISO preserved on hover.

## Rollback

- `git revert <merge-sha>` cleanly reverts.
- The `Reports/Mobile.tsx` change is one swap; reverting just that line restores `toLocaleString()` output.

Closes #725