### PR TITLE
refactor: extract server.py into focused modules (C1-C2)

### DIFF
--- a/backend/diagnostics/__init__.py
+++ b/backend/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+# diagnostics — runtime health inspection modules

--- a/backend/diagnostics/keepalive_inspector.py
+++ b/backend/diagnostics/keepalive_inspector.py
@@ -1,0 +1,452 @@
+"""WSL keepalive diagnostics — wslconfig, systemd, and Windows Scheduled Task.
+
+This module is a pure extraction of the keepalive inspection functions that
+previously lived in server.py.  It depends only on:
+  - platform_utils.wsl_paths  (same extraction batch)
+  - run_cmd                    (imported from server at runtime to avoid cycles)
+
+Constants (WSL_KEEPALIVE_SERVICE, WSL_KEEPALIVE_TASK_NAME) are read from
+environment variables at import time, matching the original server.py behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Literal
+
+from platform_utils.wsl_paths import (
+    _candidate_wslconfig_paths,
+    _resolve_powershell_executable,
+)
+from pydantic import BaseModel
+from system_utils import run_cmd  # noqa: E402
+
+log = logging.getLogger("dashboard")
+
+# ---------------------------------------------------------------------------
+# Module-level constants (mirrors server.py)
+# ---------------------------------------------------------------------------
+
+WSL_KEEPALIVE_SERVICE: str = os.environ.get("WSL_KEEPALIVE_SERVICE", "wsl-runner-keepalive.service")
+WSL_KEEPALIVE_TASK_NAME: str = os.environ.get("WSL_KEEPALIVE_TASK_NAME", "WSL-Runner-KeepAlive")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic model
+# ---------------------------------------------------------------------------
+
+
+class KeepaliveReport(BaseModel):
+    """Structured result for a single keepalive health check."""
+
+    status: Literal[
+        "ok",
+        "missing",
+        "invalid",
+        "error",
+        "healthy",
+        "misconfigured",
+        "unsupported",
+        "unknown",
+        "legacy",
+    ]
+    detail: str
+    source_path: Path | None = None
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_vm_idle_timeout(text: str) -> str | None:
+    """Extract the vmIdleTimeout value from .wslconfig content.
+
+    Pre-condition: text is a str.
+    Post-condition: returns a stripped string or None.
+    """
+    assert isinstance(text, str), f"text must be str, got {type(text)!r}"
+
+    match = re.search(
+        r"(?im)^\s*vmIdleTimeout\s*=\s*([^#;\r\n]+)",
+        text,
+    )
+    if not match:
+        return None
+    result = match.group(1).strip()
+    assert isinstance(result, str)
+    return result
+
+
+def _parse_task_action(action: dict) -> dict:
+    """Normalise a scheduled task action for downstream inspection.
+
+    Pre-condition: action is a dict.
+    Post-condition: returned dict has 'execute' and 'arguments' keys.
+    """
+    assert isinstance(action, dict), f"action must be dict, got {type(action)!r}"
+
+    result = {
+        "execute": action.get("Execute") or action.get("execute"),
+        "arguments": action.get("Arguments") or action.get("arguments"),
+    }
+    assert "execute" in result and "arguments" in result
+    return result
+
+
+def _probe_detail(probe: dict, fallback: str) -> str:
+    """Return human-readable probe detail even for partially failed probes.
+
+    Pre-condition: probe is a dict, fallback is a str.
+    """
+    assert isinstance(probe, dict), f"probe must be dict, got {type(probe)!r}"
+    assert isinstance(fallback, str), f"fallback must be str, got {type(fallback)!r}"
+
+    return str(probe.get("detail") or probe.get("error") or fallback)
+
+
+def _detect_legacy_keepalive(
+    actions: list[dict],
+    startup_vbs_files: list[str],
+) -> tuple[bool, str | None]:
+    """Detect the old VBS/fire-and-forget keepalive pattern.
+
+    Pre-condition: actions is a list of dicts; startup_vbs_files is a list of str.
+    Post-condition: returns (found: bool, detail: str | None).
+    """
+    assert isinstance(actions, list), f"actions must be list, got {type(actions)!r}"
+    assert isinstance(startup_vbs_files, list), f"startup_vbs_files must be list, got {type(startup_vbs_files)!r}"
+
+    if startup_vbs_files:
+        return True, f"Legacy VBS file(s) still present: {', '.join(startup_vbs_files)}"
+
+    for action in actions:
+        execute = (action.get("execute") or "").lower()
+        arguments = (action.get("arguments") or "").lower()
+        if execute.endswith("wscript.exe") or execute.endswith("cscript.exe"):
+            return True, f"Task launches {execute.rsplit('/', 1)[-1]} directly."
+        if ".vbs" in execute or ".vbs" in arguments:
+            return True, "Task still references a .vbs keepalive script."
+
+    return False, None
+
+
+# ---------------------------------------------------------------------------
+# .wslconfig inspection (sync)
+# ---------------------------------------------------------------------------
+
+
+def _inspect_wslconfig() -> dict:
+    """Inspect .wslconfig for the vmIdleTimeout keepalive setting.
+
+    Post-condition: returns a dict with at minimum 'status' and 'configured' keys.
+    """
+    checked_paths = [str(path) for path in _candidate_wslconfig_paths()]
+    for path in _candidate_wslconfig_paths():
+        if not path.exists():
+            continue
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError as exc:
+            result = {
+                "status": "unknown",
+                "path": str(path),
+                "checked_paths": checked_paths,
+                "error": str(exc),
+                "configured": False,
+            }
+            assert "status" in result and "configured" in result
+            return result
+
+        vm_idle_timeout = _parse_vm_idle_timeout(content)
+        if vm_idle_timeout is None:
+            result = {
+                "status": "misconfigured",
+                "path": str(path),
+                "checked_paths": checked_paths,
+                "configured": True,
+                "vm_idle_timeout": None,
+                "idle_shutdown_disabled": False,
+                "detail": "vmIdleTimeout was not found in .wslconfig.",
+            }
+            assert "status" in result and "configured" in result
+            return result
+
+        disabled = vm_idle_timeout == "-1"
+        result = {
+            "status": "healthy" if disabled else "misconfigured",
+            "path": str(path),
+            "checked_paths": checked_paths,
+            "configured": True,
+            "vm_idle_timeout": vm_idle_timeout,
+            "idle_shutdown_disabled": disabled,
+            "detail": (
+                "vmIdleTimeout=-1 disables WSL idle shutdown."
+                if disabled
+                else f"vmIdleTimeout is {vm_idle_timeout}, not -1."
+            ),
+        }
+        assert "status" in result and "configured" in result
+        return result
+
+    result = {
+        "status": "missing",
+        "path": None,
+        "checked_paths": checked_paths,
+        "configured": False,
+        "vm_idle_timeout": None,
+        "idle_shutdown_disabled": False,
+        "detail": "No .wslconfig file was found in the configured locations.",
+    }
+    assert "status" in result and "configured" in result
+    return result
+
+
+# ---------------------------------------------------------------------------
+# systemd keepalive inspection (async)
+# ---------------------------------------------------------------------------
+
+
+async def _inspect_systemd_keepalive() -> dict:
+    """Inspect the in-WSL systemd keepalive service.
+
+    Post-condition: returns a dict with 'status', 'service', 'configured',
+                    'active', and 'enabled' keys.
+    """
+    if os.name == "nt":
+        result = {
+            "status": "unsupported",
+            "service": WSL_KEEPALIVE_SERVICE,
+            "configured": False,
+            "active": False,
+            "enabled": False,
+            "detail": (
+                "systemd keepalive is checked inside WSL; "
+                "this Windows fallback process cannot query systemctl directly."
+            ),
+        }
+        assert "status" in result
+        return result
+
+    code, stdout, stderr = await run_cmd(
+        [
+            "systemctl",
+            "show",
+            WSL_KEEPALIVE_SERVICE,
+            "--property=LoadState,ActiveState,UnitFileState,FragmentPath,Description",
+            "--no-pager",
+        ],
+        timeout=10,
+    )
+
+    if code != 0:
+        lower = f"{stdout}\n{stderr}".lower()
+        if "system has not been booted with systemd" in lower or "failed to connect to bus" in lower:
+            result = {
+                "status": "unsupported",
+                "service": WSL_KEEPALIVE_SERVICE,
+                "configured": False,
+                "active": False,
+                "enabled": False,
+                "detail": "systemd is not available in this WSL session.",
+            }
+            assert "status" in result
+            return result
+        result = {
+            "status": "unknown",
+            "service": WSL_KEEPALIVE_SERVICE,
+            "configured": False,
+            "active": False,
+            "enabled": False,
+            "error": stderr.strip() or stdout.strip() or "systemctl show failed",
+        }
+        assert "status" in result
+        return result
+
+    props: dict[str, str] = {}
+    for line in stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            props[key.strip()] = value.strip()
+
+    load_state = props.get("LoadState")
+    active_state = props.get("ActiveState")
+    unit_file_state = props.get("UnitFileState")
+    configured = load_state == "loaded"
+    active = active_state == "active"
+    enabled = unit_file_state == "enabled"
+    healthy = configured and active and enabled
+    if healthy:
+        detail = f"{WSL_KEEPALIVE_SERVICE} is active and enabled."
+        status = "healthy"
+    elif configured:
+        detail = f"{WSL_KEEPALIVE_SERVICE} is {active_state or 'unknown'} and {unit_file_state or 'unknown'}."
+        status = "misconfigured"
+    else:
+        detail = f"{WSL_KEEPALIVE_SERVICE} is not installed."
+        status = "missing"
+
+    result = {
+        "status": status,
+        "service": WSL_KEEPALIVE_SERVICE,
+        "configured": configured,
+        "active": active,
+        "enabled": enabled,
+        "load_state": load_state,
+        "active_state": active_state,
+        "unit_file_state": unit_file_state,
+        "fragment_path": props.get("FragmentPath"),
+        "description": props.get("Description"),
+        "detail": detail,
+    }
+    assert "status" in result
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Windows Scheduled Task keepalive inspection (async)
+# ---------------------------------------------------------------------------
+
+
+async def _inspect_windows_keepalive() -> dict:
+    """Inspect the Windows Scheduled Task and legacy keepalive artifacts.
+
+    Post-condition: returns a dict with 'status' and 'task_found' keys.
+    """
+    powershell = _resolve_powershell_executable()
+    if powershell is None:
+        result = {
+            "status": "unsupported",
+            "task_name": WSL_KEEPALIVE_TASK_NAME,
+            "task_found": False,
+            "state": None,
+            "actions": [],
+            "startup_vbs_files": [],
+            "legacy_vbs_detected": False,
+            "detail": ("PowerShell was not found; Windows Scheduled Task cannot be queried from this WSL session."),
+        }
+        assert "status" in result
+        return result
+
+    _ps_get_legacy = (
+        "@(Get-ChildItem -Path $startup -Filter 'wsl-keepalive.vbs'"
+        " -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)"
+    )
+    _ps_get_actions = (
+        "@($task.Actions | ForEach-Object { [pscustomobject]@{ Execute = $_.Execute; Arguments = $_.Arguments } })"  # noqa: E501
+    )
+    script = f"""
+$ErrorActionPreference = 'Stop'
+$startup = [Environment]::GetFolderPath('Startup')
+$legacy = {_ps_get_legacy}
+$task = $null
+try {{
+    $task = Get-ScheduledTask -TaskName '{WSL_KEEPALIVE_TASK_NAME}' -ErrorAction Stop
+    $actions = {_ps_get_actions}
+    $result = [pscustomobject]@{{
+        task_found = $true
+        task_name = $task.TaskName
+        state = "$($task.State)"
+        actions = $actions
+        startup_vbs_files = $legacy
+    }}
+}} catch {{
+    $result = [pscustomobject]@{{
+        task_found = $false
+        task_name = '{WSL_KEEPALIVE_TASK_NAME}'
+        state = $null
+        actions = @()
+        startup_vbs_files = $legacy
+        error = $_.Exception.Message
+    }}
+}}
+$result | ConvertTo-Json -Depth 5
+"""
+    try:
+        code, stdout, stderr = await run_cmd(
+            [powershell, "-NoProfile", "-Command", script],
+            timeout=12,
+        )
+    except OSError as exc:
+        result = {
+            "status": "unsupported",
+            "task_name": WSL_KEEPALIVE_TASK_NAME,
+            "task_found": False,
+            "state": None,
+            "actions": [],
+            "startup_vbs_files": [],
+            "legacy_vbs_detected": False,
+            "detail": f"PowerShell execution failed: {exc}",
+        }
+        assert "status" in result
+        return result
+
+    if code != 0:
+        result = {
+            "status": "unknown",
+            "task_name": WSL_KEEPALIVE_TASK_NAME,
+            "task_found": False,
+            "state": None,
+            "actions": [],
+            "startup_vbs_files": [],
+            "legacy_vbs_detected": False,
+            "detail": stderr.strip() or stdout.strip() or "Scheduled task query failed.",
+        }
+        assert "status" in result
+        return result
+
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        payload = {}
+
+    raw_actions = payload.get("actions") or []
+    if isinstance(raw_actions, dict):
+        raw_actions = [raw_actions]
+    actions = [_parse_task_action(action) for action in raw_actions]
+    startup_vbs_files = payload.get("startup_vbs_files") or []
+    if isinstance(startup_vbs_files, str):
+        startup_vbs_files = [startup_vbs_files]
+
+    legacy_vbs_detected, legacy_detail = _detect_legacy_keepalive(
+        actions,
+        [str(item) for item in startup_vbs_files],
+    )
+
+    state = payload.get("state")
+    task_found = bool(payload.get("task_found"))
+    running = state == "Running"
+    action_exec = actions[0]["execute"] if actions else None
+    action_args = actions[0]["arguments"] if actions else None
+    if task_found and running and not legacy_vbs_detected:
+        status = "healthy"
+        detail = f"{WSL_KEEPALIVE_TASK_NAME} is Running."
+    elif legacy_vbs_detected:
+        status = "legacy"
+        detail = legacy_detail or "Legacy VBS keepalive detected."
+    elif task_found:
+        status = "misconfigured" if state == "Ready" else "unknown"
+        detail = f"{WSL_KEEPALIVE_TASK_NAME} is {state or 'unknown'}." + (
+            f" Action: {action_exec or 'n/a'} {action_args or ''}".rstrip()
+        )
+    else:
+        status = "missing"
+        detail = payload.get("error") or f"{WSL_KEEPALIVE_TASK_NAME} is not registered."
+
+    result = {
+        "status": status,
+        "task_name": WSL_KEEPALIVE_TASK_NAME,
+        "task_found": task_found,
+        "state": state,
+        "actions": actions,
+        "startup_vbs_files": [str(item) for item in startup_vbs_files],
+        "legacy_vbs_detected": legacy_vbs_detected,
+        "legacy_vbs_detail": legacy_detail,
+        "detail": detail,
+    }
+    assert "status" in result
+    return result

--- a/backend/platform_utils/__init__.py
+++ b/backend/platform_utils/__init__.py
@@ -1,0 +1,1 @@
+# platform_utils — WSL / host-platform utilities

--- a/backend/platform_utils/wsl_paths.py
+++ b/backend/platform_utils/wsl_paths.py
@@ -1,0 +1,133 @@
+"""WSL / Windows path normalisation utilities.
+
+Pure functions with no side-effects beyond reading environment variables and
+optionally iterating /mnt/c/Users.  Safe to import from any context.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+
+log = logging.getLogger("dashboard")
+
+
+def _windows_path_to_wsl(raw_path: str) -> Path:
+    """Convert a Windows path to its WSL mount equivalent when possible.
+
+    Pre-condition: raw_path is a str.
+    Post-condition: returns a Path object; never raises.
+    """
+    assert isinstance(raw_path, str), f"raw_path must be str, got {type(raw_path)!r}"
+
+    normalized = raw_path.strip().strip('"')
+    match = re.match(r"^([a-zA-Z]):[\\/](.*)$", normalized)
+    if not match:
+        result = Path(normalized)
+        assert isinstance(result, Path)
+        return result
+    drive = match.group(1).lower()
+    tail = match.group(2).replace("\\", "/")
+    result = Path("/mnt") / drive / tail
+    assert isinstance(result, Path)
+    return result
+
+
+def _dedupe_paths(paths: list[Path]) -> list[Path]:
+    """Return paths in insertion order with duplicates removed.
+
+    Pre-condition: paths is a list of Path objects.
+    Post-condition: returned list contains no duplicate string representations
+                    and len(result) <= len(paths).
+    """
+    assert isinstance(paths, list), f"paths must be list, got {type(paths)!r}"
+
+    seen: set[str] = set()
+    deduped: list[Path] = []
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(path)
+
+    assert len(deduped) <= len(paths)
+    return deduped
+
+
+def _candidate_wslconfig_paths() -> list[Path]:
+    """Return plausible .wslconfig locations for the current user.
+
+    Post-condition: returns a list of Path objects with no duplicates.
+    """
+    candidates: list[Path] = []
+
+    for env_name in (
+        "WSL_KEEPALIVE_WSLCONFIG_PATH",
+        "WSL_CONFIG_PATH",
+    ):
+        raw = os.environ.get(env_name)
+        if raw:
+            candidates.append(Path(raw).expanduser())
+
+    profile = os.environ.get("USERPROFILE")
+    if profile:
+        profile_path = Path(profile).expanduser()
+        if os.name == "nt":
+            candidates.append(profile_path / ".wslconfig")
+        candidates.append(_windows_path_to_wsl(profile) / ".wslconfig")
+
+    home_drive = os.environ.get("HOMEDRIVE")
+    home_path = os.environ.get("HOMEPATH")
+    if home_drive and home_path:
+        windows_home = f"{home_drive}{home_path}"
+        if os.name == "nt":
+            candidates.append(Path(windows_home).expanduser() / ".wslconfig")
+        candidates.append(_windows_path_to_wsl(windows_home) / ".wslconfig")
+
+    users_root = Path("/mnt/c/Users")
+    try:
+        for profile_dir in users_root.iterdir():
+            if not profile_dir.is_dir():
+                continue
+            if profile_dir.name.lower() in {
+                "all users",
+                "default",
+                "default user",
+                "public",
+            }:
+                continue
+            candidates.append(profile_dir / ".wslconfig")
+    except OSError:
+        pass
+
+    result = _dedupe_paths(candidates)
+    assert isinstance(result, list)
+    return result
+
+
+def _resolve_powershell_executable() -> str | None:
+    """Find a PowerShell executable from WSL service environments.
+
+    Returns the first resolvable PowerShell path, or None if not found.
+    """
+    candidate_list: list[str | None] = [
+        os.environ.get("POWERSHELL"),
+        "powershell.exe",
+        "pwsh.exe",
+        "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        "/mnt/c/Program Files/PowerShell/7/pwsh.exe",
+    ]
+    for candidate in candidate_list:
+        if not candidate:
+            continue
+        path = Path(candidate)
+        if path.is_absolute() and path.exists():
+            return str(path)
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return None

--- a/backend/runners/__init__.py
+++ b/backend/runners/__init__.py
@@ -1,0 +1,1 @@
+# runners — runner lifecycle and service control helpers

--- a/backend/runners/service_control.py
+++ b/backend/runners/service_control.py
@@ -1,0 +1,153 @@
+"""Runner service lifecycle helpers.
+
+Pure extraction from server.py of the functions that manage GitHub Actions
+runner systemd services (svc.sh invocation, service name resolution, etc.).
+
+Constants are read from environment variables at import time, matching the
+original server.py behaviour.  Tests may monkeypatch module attributes directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+from pathlib import Path
+
+from pydantic import BaseModel
+from system_utils import run_cmd  # noqa: E402
+
+log = logging.getLogger("dashboard")
+
+# ---------------------------------------------------------------------------
+# Module-level constants (mirrors server.py)
+# ---------------------------------------------------------------------------
+
+ORG: str = os.environ.get("GITHUB_ORG", "D-sorganization")
+RUNNER_BASE_DIR: Path = Path.home() / "actions-runners"
+
+_DEFAULT_NUM_RUNNERS = 12
+_REQUESTED_NUM_RUNNERS = int(os.environ.get("NUM_RUNNERS", str(_DEFAULT_NUM_RUNNERS)))
+MAX_RUNNERS: int = int(os.environ.get("MAX_RUNNERS", str(_REQUESTED_NUM_RUNNERS)))
+NUM_RUNNERS: int = min(_REQUESTED_NUM_RUNNERS, MAX_RUNNERS)
+
+HOSTNAME: str = os.environ.get("DISPLAY_NAME") or platform.node()
+RUNNER_ALIASES: list[str] = [item.strip() for item in os.environ.get("RUNNER_ALIASES", "").split(",") if item.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Pydantic model
+# ---------------------------------------------------------------------------
+
+
+class RunnerUnit(BaseModel):
+    """Descriptor for a single runner service unit."""
+
+    num: int
+    name: str
+    path: Path
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def runner_svc_path(runner_num: int) -> Path:
+    """Return the path to a runner's svc.sh script.
+
+    Pre-condition: runner_num is a positive int.
+    Post-condition: returns a Path ending in svc.sh.
+    """
+    assert isinstance(runner_num, int) and runner_num > 0, f"runner_num must be a positive int, got {runner_num!r}"
+
+    result = RUNNER_BASE_DIR / f"runner-{runner_num}" / "svc.sh"
+    assert result.name == "svc.sh"
+    return result
+
+
+async def run_runner_svc(
+    runner_num: int,
+    action: str,
+    timeout: int = 30,
+) -> tuple[int, str, str]:
+    """Run a generated GitHub runner svc.sh from its own runner directory.
+
+    Pre-condition: runner_num > 0; action is a non-empty string.
+    """
+    assert isinstance(runner_num, int) and runner_num > 0, f"runner_num must be a positive int, got {runner_num!r}"
+    assert isinstance(action, str) and action, "action must be a non-empty string"
+
+    svc_path = runner_svc_path(runner_num)
+    return await run_cmd(
+        ["sudo", str(svc_path), action],
+        timeout=timeout,
+        cwd=svc_path.parent,
+    )
+
+
+def runner_num_from_id(runner_id: int, runners: list[dict]) -> int | None:
+    """Return the local runner number for a GitHub runner ID, or None.
+
+    Only returns a number when the runner name's machine prefix matches
+    HOSTNAME or a configured alias (case-insensitive).
+
+    Pre-condition: runner_id is an int; runners is a list of dicts.
+    """
+    assert isinstance(runner_id, int), f"runner_id must be int, got {type(runner_id)!r}"
+    assert isinstance(runners, list), f"runners must be list, got {type(runners)!r}"
+
+    local_names = {
+        HOSTNAME.lower(),
+        platform.node().lower(),
+        *(alias.lower() for alias in RUNNER_ALIASES),
+    }
+    for r in runners:
+        name = r.get("name", "")
+        parts = name.rsplit("-", 1)
+        if len(parts) == 2 and parts[1].isdigit() and r["id"] == runner_id:
+            machine = parts[0].removeprefix("d-sorg-local-").lower()
+            if machine not in local_names:
+                return None
+            return int(parts[1])
+    return None
+
+
+def _runner_limit() -> int:
+    """Return the hard runner capacity this dashboard is allowed to manage.
+
+    Post-condition: result >= 0.
+    """
+    result = max(NUM_RUNNERS, MAX_RUNNERS)
+    assert result >= 0
+    return result
+
+
+def _runner_sort_key(runner: dict) -> tuple[str, int, str]:
+    """Sort runner names by machine prefix then numeric suffix.
+
+    Pre-condition: runner is a dict (may have a 'name' key).
+    Post-condition: returns a 3-tuple for use with sorted().
+    """
+    assert isinstance(runner, dict), f"runner must be dict, got {type(runner)!r}"
+
+    name = str(runner.get("name", ""))
+    prefix, sep, suffix = name.rpartition("-")
+    number = int(suffix) if sep and suffix.isdigit() else 10**9
+    return (prefix.lower(), number, name.lower())
+
+
+def get_runner_service_name(runner_num: int) -> str | None:
+    """Return the systemd service name for a runner.
+
+    Reads the .service file if present; otherwise falls back to a generated name.
+
+    Pre-condition: runner_num > 0.
+    """
+    assert isinstance(runner_num, int) and runner_num > 0, f"runner_num must be a positive int, got {runner_num!r}"
+
+    svc_file = RUNNER_BASE_DIR / f"runner-{runner_num}" / ".service"
+    if svc_file.exists():
+        return svc_file.read_text().strip()
+    # Fall back to common naming pattern
+    return f"actions.runner.{ORG}.d-sorg-local-{HOSTNAME}-{runner_num}.service"

--- a/backend/server.py
+++ b/backend/server.py
@@ -91,6 +91,14 @@ from dashboard_config.timeouts import (  # noqa: E402
     HttpTimeout,
     ResourceThreshold,
 )
+
+# Focused sub-modules extracted from server.py (issues #718, #719)
+from diagnostics.keepalive_inspector import (  # noqa: E402
+    _inspect_systemd_keepalive,
+    _inspect_windows_keepalive,
+    _inspect_wslconfig,
+    _probe_detail,
+)
 from http_clients import initialize_http_clients, shutdown_http_clients  # noqa: E402
 from local_app_monitoring import collect_local_apps  # noqa: E402
 from machine_registry import (  # noqa: E402
@@ -132,6 +140,12 @@ from routers import runs_workflows as _runs_workflows_router  # noqa: E402
 from routers import system as _system_router  # noqa: E402
 from routers import web_vitals as _web_vitals_router  # noqa: E402
 from routers.queue import _queue_impl  # noqa: E402
+from runners.service_control import (  # noqa: E402
+    _runner_limit,
+    run_runner_svc,
+    runner_num_from_id,
+    runner_svc_path,
+)
 from security import (  # noqa: E402
     safe_subprocess_env,  # noqa: E402
     validate_fleet_node_url,  # noqa: E402
@@ -139,6 +153,9 @@ from security import (  # noqa: E402
     validate_repo_slug,  # noqa: E402
 )
 from system_utils import get_system_metrics_snapshot  # noqa: E402
+from workflows.run_enrichment import (  # noqa: E402
+    _get_recent_org_repos,
+)
 
 # datetime.UTC added in Python 3.11; fall back to timezone.utc on older runtimes.
 UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
@@ -908,50 +925,7 @@ def _build_deployment_state(nodes: list[dict], expected_version: str) -> dict:
     }
 
 
-async def _get_recent_org_repos(limit: int = 30) -> list[dict]:
-    """Fetch recently updated organization repositories."""
-    code, stdout, _ = await run_cmd(
-        [
-            "gh",
-            "api",
-            f"/orgs/{ORG}/repos?per_page={limit}&sort=updated&direction=desc",
-        ],
-        timeout=20,
-    )
-    if code != 0:
-        return []
-    try:
-        return json.loads(stdout)
-    except (json.JSONDecodeError, ValueError):
-        return []
-
-
-async def _fetch_repo_runs(
-    repo_name: str,
-    *,
-    per_page: int = 10,
-    status: str | None = None,
-) -> list[dict]:
-    """Fetch workflow runs for one repository and annotate repository name."""
-    status_part = f"&status={status}" if status else ""
-    rc, out, _ = await run_cmd(
-        [
-            "gh",
-            "api",
-            f"/repos/{ORG}/{repo_name}/actions/runs?per_page={per_page}{status_part}",
-        ],
-        timeout=15,
-    )
-    if rc != 0:
-        return []
-    try:
-        runs = json.loads(out).get("workflow_runs", [])
-    except (json.JSONDecodeError, ValueError):
-        return []
-    for run in runs:
-        if "repository" not in run or not run["repository"]:
-            run["repository"] = {"name": repo_name}
-    return runs
+# _get_recent_org_repos and _fetch_repo_runs extracted to workflows/run_enrichment.py (#719)
 
 
 async def _github_search_total(query: str) -> int:
@@ -968,54 +942,8 @@ async def _github_search_total(query: str) -> int:
         return 0
 
 
-async def _fetch_run_jobs(repo_name: str, run_id: int | str) -> list[dict]:
-    """Fetch job-level data for one workflow run."""
-    rc, out, _ = await run_cmd(
-        [
-            "gh",
-            "api",
-            f"/repos/{ORG}/{repo_name}/actions/runs/{run_id}/jobs?per_page=100",
-        ],
-        timeout=10,
-    )
-    if rc != 0:
-        return []
-    try:
-        return json.loads(out).get("jobs", [])
-    except (json.JSONDecodeError, ValueError):
-        return []
-
-
-async def _fetch_failed_log_excerpt(repo_name: str, run_id: int | str) -> str:
-    """Best-effort failed-log excerpt for a workflow run."""
-    code, stdout, _ = await run_cmd(
-        [
-            "gh",
-            "run",
-            "view",
-            str(run_id),
-            "--repo",
-            f"{ORG}/{repo_name}",
-            "--log-failed",
-        ],
-        timeout=20,
-    )
-    if code != 0:
-        return ""
-    text = stdout.strip()
-    if not text:
-        return ""
-    return text[:12000]
-
-
-def _repo_name_from_run(run: dict) -> str | None:
-    """Return the repository name from either normalized or raw run payloads."""
-    repo = run.get("repository")
-    if isinstance(repo, dict) and repo.get("name"):
-        return str(repo["name"])
-    if run.get("_repo"):
-        return str(run["_repo"])
-    return None
+# _fetch_run_jobs, _fetch_failed_log_excerpt, _repo_name_from_run extracted to
+# workflows/run_enrichment.py (#719)
 
 
 def _normalize_repository_input(value: str) -> tuple[str, str]:
@@ -1037,50 +965,8 @@ def _normalize_repository_input(value: str) -> tuple[str, str]:
     return repo_name, f"{ORG}/{repo_name}"
 
 
-def _machine_name_from_runner_name(runner_name: str | None) -> str | None:
-    """Normalize fleet runner names to dashboard machine names."""
-    if not runner_name:
-        return None
-    name = str(runner_name).strip()
-    prefix = "d-sorg-local-"
-    if not name.startswith(prefix):
-        return name
-    stem = name.removeprefix(prefix)
-    machine, separator, suffix = stem.rpartition("-")
-    if separator and suffix.isdigit() and machine:
-        return machine
-    return stem
-
-
-def _placement_from_jobs(jobs: list[dict]) -> dict:
-    """Extract machine placement fields from a run's jobs."""
-    for job in jobs:
-        runner_name = job.get("runner_name")
-        if not runner_name:
-            continue
-        return {
-            "runner_id": job.get("runner_id"),
-            "runner_name": runner_name,
-            "runner_group_name": job.get("runner_group_name"),
-            "runner_labels": job.get("labels") or [],
-            "machine_name": _machine_name_from_runner_name(str(runner_name)),
-        }
-    return {}
-
-
-async def _enrich_run_with_job_placement(run: dict) -> dict:
-    """Attach job-level runner placement fields to a workflow run."""
-    item = dict(run)
-    repo_name = _repo_name_from_run(item)
-    run_id = item.get("id")
-    if repo_name and run_id:
-        placement = _placement_from_jobs(await _fetch_run_jobs(repo_name, run_id))
-        if placement:
-            item.update(placement)
-            return item
-    machine_name = _machine_name_from_runner_name(item.get("runner_name"))
-    item.setdefault("machine_name", machine_name or "GitHub")
-    return item
+# _machine_name_from_runner_name, _placement_from_jobs, _enrich_run_with_job_placement
+# extracted to workflows/run_enrichment.py (#719)
 
 
 def _classify_node_offline(exc: Exception | None = None, *, status_code: int | None = None) -> dict:
@@ -1198,53 +1084,8 @@ def _node_visibility_snapshot(node: dict) -> dict:
     }
 
 
-def runner_svc_path(runner_num: int) -> Path:
-    return RUNNER_BASE_DIR / f"runner-{runner_num}" / "svc.sh"
-
-
-async def run_runner_svc(runner_num: int, action: str, timeout: int = 30) -> tuple[int, str, str]:
-    """Run a generated GitHub runner svc.sh from its own runner directory."""
-    svc_path = runner_svc_path(runner_num)
-    return await run_cmd(["sudo", str(svc_path), action], timeout=timeout, cwd=svc_path.parent)
-
-
-def runner_num_from_id(runner_id: int, runners: list[dict]) -> int | None:
-    local_names = {
-        HOSTNAME.lower(),
-        platform.node().lower(),
-        *(alias.lower() for alias in RUNNER_ALIASES),
-    }
-    for r in runners:
-        name = r.get("name", "")
-        parts = name.rsplit("-", 1)
-        if len(parts) == 2 and parts[1].isdigit() and r["id"] == runner_id:
-            machine = parts[0].removeprefix("d-sorg-local-").lower()
-            if machine not in local_names:
-                return None
-            return int(parts[1])
-    return None
-
-
-def _runner_limit() -> int:
-    """Return the hard runner capacity this dashboard is allowed to manage."""
-    return max(NUM_RUNNERS, MAX_RUNNERS)
-
-
-def _runner_sort_key(runner: dict) -> tuple[str, int, str]:
-    """Sort runner names by machine and numeric suffix instead of alphabetically."""
-    name = str(runner.get("name", ""))
-    prefix, sep, suffix = name.rpartition("-")
-    number = int(suffix) if sep and suffix.isdigit() else 10**9
-    return (prefix.lower(), number, name.lower())
-
-
-def get_runner_service_name(runner_num: int) -> str | None:
-    """Get the systemd service name for a runner."""
-    svc_file = RUNNER_BASE_DIR / f"runner-{runner_num}" / ".service"
-    if svc_file.exists():
-        return svc_file.read_text().strip()
-    # Fall back to common naming pattern
-    return f"actions.runner.{ORG}.d-sorg-local-{HOSTNAME}-{runner_num}.service"
+# runner_svc_path, run_runner_svc, runner_num_from_id, _runner_limit,
+# _runner_sort_key, get_runner_service_name extracted to runners/service_control.py (#719)
 
 
 DEFAULT_RUNNER_SCHEDULE = {
@@ -1406,403 +1247,13 @@ def get_runner_capacity_snapshot() -> dict:
     }
 
 
-def _windows_path_to_wsl(raw_path: str) -> Path:
-    """Convert a Windows path to its WSL mount equivalent when possible."""
-    normalized = raw_path.strip().strip('"')
-    match = re.match(r"^([a-zA-Z]):[\\/](.*)$", normalized)
-    if not match:
-        return Path(normalized)
-    drive = match.group(1).lower()
-    tail = match.group(2).replace("\\", "/")
-    return Path("/mnt") / drive / tail
+# _windows_path_to_wsl, _dedupe_paths, _candidate_wslconfig_paths,
+# _resolve_powershell_executable extracted to platform_utils/wsl_paths.py (#718)
 
 
-def _dedupe_paths(paths: list[Path]) -> list[Path]:
-    """Return paths in order without duplicates."""
-    seen: set[str] = set()
-    deduped: list[Path] = []
-    for path in paths:
-        key = str(path)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(path)
-    return deduped
-
-
-def _candidate_wslconfig_paths() -> list[Path]:
-    """Return plausible .wslconfig locations for the current user."""
-    candidates: list[Path] = []
-    for env_name in (
-        "WSL_KEEPALIVE_WSLCONFIG_PATH",
-        "WSL_CONFIG_PATH",
-    ):
-        raw = os.environ.get(env_name)
-        if raw:
-            candidates.append(Path(raw).expanduser())
-
-    profile = os.environ.get("USERPROFILE")
-    if profile:
-        profile_path = Path(profile).expanduser()
-        if os.name == "nt":
-            candidates.append(profile_path / ".wslconfig")
-        candidates.append(_windows_path_to_wsl(profile) / ".wslconfig")
-
-    home_drive = os.environ.get("HOMEDRIVE")
-    home_path = os.environ.get("HOMEPATH")
-    if home_drive and home_path:
-        windows_home = f"{home_drive}{home_path}"
-        if os.name == "nt":
-            candidates.append(Path(windows_home).expanduser() / ".wslconfig")
-        candidates.append(_windows_path_to_wsl(windows_home) / ".wslconfig")
-
-    users_root = Path("/mnt/c/Users")
-    try:
-        for profile_dir in users_root.iterdir():
-            if not profile_dir.is_dir():
-                continue
-            if profile_dir.name.lower() in {
-                "all users",
-                "default",
-                "default user",
-                "public",
-            }:
-                continue
-            candidates.append(profile_dir / ".wslconfig")
-    except OSError:
-        pass
-
-    return _dedupe_paths(candidates)
-
-
-def _resolve_powershell_executable() -> str | None:
-    """Find a PowerShell executable from WSL service environments."""
-    candidates = [
-        os.environ.get("POWERSHELL"),
-        "powershell.exe",
-        "pwsh.exe",
-        "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
-        "/mnt/c/Program Files/PowerShell/7/pwsh.exe",
-    ]
-    for candidate in candidates:
-        if not candidate:
-            continue
-        path = Path(candidate)
-        if path.is_absolute() and path.exists():
-            return str(path)
-        resolved = shutil.which(candidate)
-        if resolved:
-            return resolved
-    return None
-
-
-def _parse_vm_idle_timeout(text: str) -> str | None:
-    """Extract the vmIdleTimeout value from a .wslconfig file."""
-    match = re.search(
-        r"(?im)^\s*vmIdleTimeout\s*=\s*([^#;\r\n]+)",
-        text,
-    )
-    if not match:
-        return None
-    return match.group(1).strip()
-
-
-def _inspect_wslconfig() -> dict:
-    """Inspect .wslconfig for the vmIdleTimeout keepalive setting."""
-    checked_paths = [str(path) for path in _candidate_wslconfig_paths()]
-    for path in _candidate_wslconfig_paths():
-        if not path.exists():
-            continue
-        try:
-            content = path.read_text(encoding="utf-8", errors="ignore")
-        except OSError as exc:
-            return {
-                "status": "unknown",
-                "path": str(path),
-                "checked_paths": checked_paths,
-                "error": str(exc),
-                "configured": False,
-            }
-
-        vm_idle_timeout = _parse_vm_idle_timeout(content)
-        if vm_idle_timeout is None:
-            return {
-                "status": "misconfigured",
-                "path": str(path),
-                "checked_paths": checked_paths,
-                "configured": True,
-                "vm_idle_timeout": None,
-                "idle_shutdown_disabled": False,
-                "detail": "vmIdleTimeout was not found in .wslconfig.",
-            }
-
-        disabled = vm_idle_timeout == "-1"
-        return {
-            "status": "healthy" if disabled else "misconfigured",
-            "path": str(path),
-            "checked_paths": checked_paths,
-            "configured": True,
-            "vm_idle_timeout": vm_idle_timeout,
-            "idle_shutdown_disabled": disabled,
-            "detail": (
-                "vmIdleTimeout=-1 disables WSL idle shutdown."
-                if disabled
-                else f"vmIdleTimeout is {vm_idle_timeout}, not -1."
-            ),
-        }
-
-    return {
-        "status": "missing",
-        "path": None,
-        "checked_paths": checked_paths,
-        "configured": False,
-        "vm_idle_timeout": None,
-        "idle_shutdown_disabled": False,
-        "detail": "No .wslconfig file was found in the configured locations.",
-    }
-
-
-def _parse_task_action(action: dict) -> dict:
-    """Normalize a scheduled task action for downstream inspection."""
-    return {
-        "execute": action.get("Execute") or action.get("execute"),
-        "arguments": action.get("Arguments") or action.get("arguments"),
-    }
-
-
-def _probe_detail(probe: dict, fallback: str) -> str:
-    """Return human-readable probe detail even for partially failed probes."""
-    return str(probe.get("detail") or probe.get("error") or fallback)
-
-
-def _detect_legacy_keepalive(actions: list[dict], startup_vbs_files: list[str]) -> tuple[bool, str | None]:
-    """Detect the old VBS/fire-and-forget keepalive pattern."""
-    if startup_vbs_files:
-        return True, f"Legacy VBS file(s) still present: {', '.join(startup_vbs_files)}"
-
-    for action in actions:
-        execute = (action.get("execute") or "").lower()
-        arguments = (action.get("arguments") or "").lower()
-        if execute.endswith("wscript.exe") or execute.endswith("cscript.exe"):
-            return True, f"Task launches {execute.rsplit('/', 1)[-1]} directly."
-        if ".vbs" in execute or ".vbs" in arguments:
-            return True, "Task still references a .vbs keepalive script."
-
-    return False, None
-
-
-async def _inspect_systemd_keepalive() -> dict:
-    """Inspect the in-WSL systemd keepalive service."""
-    if os.name == "nt":
-        return {
-            "status": "unsupported",
-            "service": WSL_KEEPALIVE_SERVICE,
-            "configured": False,
-            "active": False,
-            "enabled": False,
-            "detail": (
-                "systemd keepalive is checked inside WSL; "
-                "this Windows fallback process cannot query systemctl directly."
-            ),
-        }
-
-    code, stdout, stderr = await run_cmd(
-        [
-            "systemctl",
-            "show",
-            WSL_KEEPALIVE_SERVICE,
-            "--property=LoadState,ActiveState,UnitFileState,FragmentPath,Description",
-            "--no-pager",
-        ],
-        timeout=10,
-    )
-
-    if code != 0:
-        lower = f"{stdout}\n{stderr}".lower()
-        if "system has not been booted with systemd" in lower or "failed to connect to bus" in lower:
-            return {
-                "status": "unsupported",
-                "service": WSL_KEEPALIVE_SERVICE,
-                "configured": False,
-                "active": False,
-                "enabled": False,
-                "detail": "systemd is not available in this WSL session.",
-            }
-        return {
-            "status": "unknown",
-            "service": WSL_KEEPALIVE_SERVICE,
-            "configured": False,
-            "active": False,
-            "enabled": False,
-            "error": stderr.strip() or stdout.strip() or "systemctl show failed",
-        }
-
-    props: dict[str, str] = {}
-    for line in stdout.splitlines():
-        if "=" in line:
-            key, value = line.split("=", 1)
-            props[key.strip()] = value.strip()
-
-    load_state = props.get("LoadState")
-    active_state = props.get("ActiveState")
-    unit_file_state = props.get("UnitFileState")
-    configured = load_state == "loaded"
-    active = active_state == "active"
-    enabled = unit_file_state == "enabled"
-    healthy = configured and active and enabled
-    if healthy:
-        detail = f"{WSL_KEEPALIVE_SERVICE} is active and enabled."
-        status = "healthy"
-    elif configured:
-        detail = f"{WSL_KEEPALIVE_SERVICE} is {active_state or 'unknown'} and {unit_file_state or 'unknown'}."
-        status = "misconfigured"
-    else:
-        detail = f"{WSL_KEEPALIVE_SERVICE} is not installed."
-        status = "missing"
-
-    return {
-        "status": status,
-        "service": WSL_KEEPALIVE_SERVICE,
-        "configured": configured,
-        "active": active,
-        "enabled": enabled,
-        "load_state": load_state,
-        "active_state": active_state,
-        "unit_file_state": unit_file_state,
-        "fragment_path": props.get("FragmentPath"),
-        "description": props.get("Description"),
-        "detail": detail,
-    }
-
-
-async def _inspect_windows_keepalive() -> dict:
-    """Inspect the Windows Scheduled Task and legacy keepalive artifacts."""
-    powershell = _resolve_powershell_executable()
-    if powershell is None:
-        return {
-            "status": "unsupported",
-            "task_name": WSL_KEEPALIVE_TASK_NAME,
-            "task_found": False,
-            "state": None,
-            "actions": [],
-            "startup_vbs_files": [],
-            "legacy_vbs_detected": False,
-            "detail": "PowerShell was not found; Windows Scheduled Task cannot be queried from this WSL session.",
-        }
-
-    _ps_get_legacy = (
-        "@(Get-ChildItem -Path $startup -Filter 'wsl-keepalive.vbs'"
-        " -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)"
-    )
-    _ps_get_actions = (
-        "@($task.Actions | ForEach-Object { [pscustomobject]@{ Execute = $_.Execute; Arguments = $_.Arguments } })"  # noqa: E501
-    )
-    script = f"""
-$ErrorActionPreference = 'Stop'
-$startup = [Environment]::GetFolderPath('Startup')
-$legacy = {_ps_get_legacy}
-$task = $null
-try {{
-    $task = Get-ScheduledTask -TaskName '{WSL_KEEPALIVE_TASK_NAME}' -ErrorAction Stop
-    $actions = {_ps_get_actions}
-    $result = [pscustomobject]@{{
-        task_found = $true
-        task_name = $task.TaskName
-        state = "$($task.State)"
-        actions = $actions
-        startup_vbs_files = $legacy
-    }}
-}} catch {{
-    $result = [pscustomobject]@{{
-        task_found = $false
-        task_name = '{WSL_KEEPALIVE_TASK_NAME}'
-        state = $null
-        actions = @()
-        startup_vbs_files = $legacy
-        error = $_.Exception.Message
-    }}
-}}
-$result | ConvertTo-Json -Depth 5
-"""
-    try:
-        code, stdout, stderr = await run_cmd(
-            [powershell, "-NoProfile", "-Command", script],
-            timeout=12,
-        )
-    except OSError as exc:
-        return {
-            "status": "unsupported",
-            "task_name": WSL_KEEPALIVE_TASK_NAME,
-            "task_found": False,
-            "state": None,
-            "actions": [],
-            "startup_vbs_files": [],
-            "legacy_vbs_detected": False,
-            "detail": f"PowerShell execution failed: {exc}",
-        }
-
-    if code != 0:
-        return {
-            "status": "unknown",
-            "task_name": WSL_KEEPALIVE_TASK_NAME,
-            "task_found": False,
-            "state": None,
-            "actions": [],
-            "startup_vbs_files": [],
-            "legacy_vbs_detected": False,
-            "detail": stderr.strip() or stdout.strip() or "Scheduled task query failed.",
-        }
-
-    try:
-        payload = json.loads(stdout)
-    except (json.JSONDecodeError, TypeError, ValueError):
-        payload = {}
-
-    raw_actions = payload.get("actions") or []
-    if isinstance(raw_actions, dict):
-        raw_actions = [raw_actions]
-    actions = [_parse_task_action(action) for action in raw_actions]
-    startup_vbs_files = payload.get("startup_vbs_files") or []
-    if isinstance(startup_vbs_files, str):
-        startup_vbs_files = [startup_vbs_files]
-
-    legacy_vbs_detected, legacy_detail = _detect_legacy_keepalive(
-        actions,
-        [str(item) for item in startup_vbs_files],
-    )
-
-    state = payload.get("state")
-    task_found = bool(payload.get("task_found"))
-    running = state == "Running"
-    ready = state == "Ready"
-    action_exec = actions[0]["execute"] if actions else None
-    action_args = actions[0]["arguments"] if actions else None
-    if task_found and running and not legacy_vbs_detected:
-        status = "healthy"
-        detail = f"{WSL_KEEPALIVE_TASK_NAME} is Running."
-    elif legacy_vbs_detected:
-        status = "legacy"
-        detail = legacy_detail or "Legacy VBS keepalive detected."
-    elif task_found:
-        status = "misconfigured" if ready else "unknown"
-        detail = f"{WSL_KEEPALIVE_TASK_NAME} is {state or 'unknown'}." + (
-            f" Action: {action_exec or 'n/a'} {action_args or ''}".rstrip()
-        )
-    else:
-        status = "missing"
-        detail = payload.get("error") or f"{WSL_KEEPALIVE_TASK_NAME} is not registered."
-
-    return {
-        "status": status,
-        "task_name": WSL_KEEPALIVE_TASK_NAME,
-        "task_found": task_found,
-        "state": state,
-        "actions": actions,
-        "startup_vbs_files": [str(item) for item in startup_vbs_files],
-        "legacy_vbs_detected": legacy_vbs_detected,
-        "legacy_vbs_detail": legacy_detail,
-        "detail": detail,
-    }
+# _parse_vm_idle_timeout, _inspect_wslconfig, _parse_task_action, _probe_detail,
+# _detect_legacy_keepalive, _inspect_systemd_keepalive, _inspect_windows_keepalive
+# extracted to diagnostics/keepalive_inspector.py (#718)
 
 
 async def _watchdog_status_impl() -> dict:

--- a/backend/workflows/__init__.py
+++ b/backend/workflows/__init__.py
@@ -1,0 +1,1 @@
+# workflows — GitHub Actions workflow data helpers

--- a/backend/workflows/run_enrichment.py
+++ b/backend/workflows/run_enrichment.py
@@ -1,0 +1,289 @@
+"""GitHub Actions workflow run and job enrichment helpers.
+
+Pure extraction from server.py of the functions that fetch and annotate
+workflow run data with runner placement information.
+
+The ORG constant and run_cmd helper are read/imported at module level to
+match original server.py behaviour.  Tests may monkeypatch module attributes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from pydantic import BaseModel, Field
+from system_utils import run_cmd  # noqa: E402
+
+log = logging.getLogger("dashboard")
+
+# ---------------------------------------------------------------------------
+# Module-level constants (mirrors server.py)
+# ---------------------------------------------------------------------------
+
+ORG: str = os.environ.get("GITHUB_ORG", "D-sorganization")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class Run(BaseModel):
+    """Minimal representation of a GitHub Actions workflow run."""
+
+    id: int
+    name: str | None = None
+    status: str | None = None
+    conclusion: str | None = None
+    model_config = {"extra": "allow"}
+
+
+class Job(BaseModel):
+    """Minimal representation of a GitHub Actions workflow job."""
+
+    id: int
+    name: str | None = None
+    status: str | None = None
+    conclusion: str | None = None
+    runner_name: str | None = None
+    runner_id: int | None = None
+    runner_group_name: str | None = None
+    labels: list[str] = Field(default_factory=list)
+    model_config = {"extra": "allow"}
+
+
+class JobPlacement(BaseModel):
+    """Runner placement extracted from a job."""
+
+    runner_id: int | None = None
+    runner_name: str | None = None
+    runner_group_name: str | None = None
+    runner_labels: list[str] = Field(default_factory=list)
+    machine_name: str | None = None
+
+
+class EnrichedRun(BaseModel):
+    """A workflow run enriched with runner placement information."""
+
+    id: int
+    name: str | None = None
+    status: str | None = None
+    conclusion: str | None = None
+    runner_id: int | None = None
+    runner_name: str | None = None
+    runner_group_name: str | None = None
+    runner_labels: list[str] = Field(default_factory=list)
+    machine_name: str | None = None
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _machine_name_from_runner_name(runner_name: str | None) -> str | None:
+    """Normalise fleet runner names to dashboard machine names."""
+    if not runner_name:
+        return None
+    name = str(runner_name).strip()
+    prefix = "d-sorg-local-"
+    if not name.startswith(prefix):
+        return name
+    stem = name.removeprefix(prefix)
+    machine, separator, suffix = stem.rpartition("-")
+    if separator and suffix.isdigit() and machine:
+        return machine
+    return stem
+
+
+def _repo_name_from_run(run: dict) -> str | None:
+    """Return the repository name from either normalised or raw run payloads."""
+    repo = run.get("repository")
+    if isinstance(repo, dict) and repo.get("name"):
+        return str(repo["name"])
+    if run.get("_repo"):
+        return str(run["_repo"])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public async functions
+# ---------------------------------------------------------------------------
+
+
+async def _get_recent_org_repos(limit: int = 30) -> list[dict]:
+    """Fetch recently updated organisation repositories.
+
+    Pre-condition: limit is a positive int.
+    Post-condition: returns a list (possibly empty) of repository dicts.
+    """
+    assert isinstance(limit, int) and limit > 0, f"limit must be a positive int, got {limit!r}"
+
+    code, stdout, _ = await run_cmd(
+        [
+            "gh",
+            "api",
+            f"/orgs/{ORG}/repos?per_page={limit}&sort=updated&direction=desc",
+        ],
+        timeout=20,
+    )
+    if code != 0:
+        return []
+    try:
+        result = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    assert isinstance(result, list)
+    return result
+
+
+async def _fetch_repo_runs(
+    repo_name: str,
+    *,
+    per_page: int = 10,
+    status: str | None = None,
+) -> list[dict]:
+    """Fetch workflow runs for one repository and annotate repository name.
+
+    Pre-condition: repo_name is a non-empty string.
+    Post-condition: every returned run dict has a 'repository' key with a
+                    'name' sub-key.
+    """
+    assert isinstance(repo_name, str) and repo_name, f"repo_name must be a non-empty str, got {repo_name!r}"
+
+    status_part = f"&status={status}" if status else ""
+    rc, out, _ = await run_cmd(
+        [
+            "gh",
+            "api",
+            f"/repos/{ORG}/{repo_name}/actions/runs?per_page={per_page}{status_part}",
+        ],
+        timeout=15,
+    )
+    if rc != 0:
+        return []
+    try:
+        runs = json.loads(out).get("workflow_runs", [])
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    for run in runs:
+        if "repository" not in run or not run["repository"]:
+            run["repository"] = {"name": repo_name}
+
+    assert all("repository" in r for r in runs)
+    return runs
+
+
+async def _fetch_run_jobs(repo_name: str, run_id: int | str) -> list[dict]:
+    """Fetch job-level data for one workflow run.
+
+    Pre-condition: repo_name is a non-empty string; run_id is an int or str.
+    Post-condition: returns a list (possibly empty) of job dicts.
+    """
+    assert isinstance(repo_name, str) and repo_name, f"repo_name must be a non-empty str, got {repo_name!r}"
+    assert isinstance(run_id, (int, str)) and run_id, f"run_id must be a non-empty int or str, got {run_id!r}"
+
+    rc, out, _ = await run_cmd(
+        [
+            "gh",
+            "api",
+            f"/repos/{ORG}/{repo_name}/actions/runs/{run_id}/jobs?per_page=100",
+        ],
+        timeout=10,
+    )
+    if rc != 0:
+        return []
+    try:
+        result = json.loads(out).get("jobs", [])
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    assert isinstance(result, list)
+    return result
+
+
+async def _fetch_failed_log_excerpt(repo_name: str, run_id: int | str) -> str:
+    """Best-effort failed-log excerpt for a workflow run.
+
+    Post-condition: returns a string of at most 12 000 characters.
+    """
+    assert isinstance(repo_name, str) and repo_name, f"repo_name must be a non-empty str, got {repo_name!r}"
+
+    code, stdout, _ = await run_cmd(
+        [
+            "gh",
+            "run",
+            "view",
+            str(run_id),
+            "--repo",
+            f"{ORG}/{repo_name}",
+            "--log-failed",
+        ],
+        timeout=20,
+    )
+    if code != 0:
+        return ""
+    text = stdout.strip()
+    if not text:
+        return ""
+    result = text[:12000]
+    assert len(result) <= 12000
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public sync functions
+# ---------------------------------------------------------------------------
+
+
+def _placement_from_jobs(jobs: list[dict]) -> dict:
+    """Extract machine placement fields from a run's jobs.
+
+    Pre-condition: jobs is a list of dicts.
+    Post-condition: returns a dict (empty if no runner_name found).
+    """
+    assert isinstance(jobs, list), f"jobs must be list, got {type(jobs)!r}"
+
+    for job in jobs:
+        runner_name = job.get("runner_name")
+        if not runner_name:
+            continue
+        result = {
+            "runner_id": job.get("runner_id"),
+            "runner_name": runner_name,
+            "runner_group_name": job.get("runner_group_name"),
+            "runner_labels": job.get("labels") or [],
+            "machine_name": _machine_name_from_runner_name(str(runner_name)),
+        }
+        assert isinstance(result, dict)
+        return result
+    return {}
+
+
+async def _enrich_run_with_job_placement(run: dict) -> dict:
+    """Attach job-level runner placement fields to a workflow run.
+
+    Pre-condition: run is a dict.
+    Post-condition: returned dict has a 'machine_name' key.
+    """
+    assert isinstance(run, dict), f"run must be dict, got {type(run)!r}"
+
+    item = dict(run)
+    repo_name = _repo_name_from_run(item)
+    run_id = item.get("id")
+    if repo_name and run_id:
+        placement = _placement_from_jobs(await _fetch_run_jobs(repo_name, run_id))
+        if placement:
+            item.update(placement)
+            assert "machine_name" in item
+            return item
+    machine_name = _machine_name_from_runner_name(item.get("runner_name"))
+    item.setdefault("machine_name", machine_name or "GitHub")
+
+    assert "machine_name" in item
+    return item

--- a/tests/api/test_keepalive_inspector.py
+++ b/tests/api/test_keepalive_inspector.py
@@ -1,0 +1,375 @@
+"""Tests for diagnostics.keepalive_inspector.
+
+All tests are fully offline — no real subprocess calls or systemd/PowerShell
+access. run_cmd is monkeypatched where needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import diagnostics.keepalive_inspector as ki  # noqa: E402
+from diagnostics.keepalive_inspector import (  # noqa: E402
+    KeepaliveReport,
+    _detect_legacy_keepalive,
+    _inspect_systemd_keepalive,
+    _inspect_windows_keepalive,
+    _inspect_wslconfig,
+    _parse_task_action,
+    _parse_vm_idle_timeout,
+    _probe_detail,
+)
+
+_VALID_STATUSES = frozenset(
+    {"ok", "missing", "invalid", "error", "healthy", "misconfigured", "unsupported", "unknown", "legacy"}
+)
+
+# ---------------------------------------------------------------------------
+# KeepaliveReport schema
+# ---------------------------------------------------------------------------
+
+def test_keepalive_report_model_valid() -> None:
+    report = KeepaliveReport(status="healthy", detail="all good")
+    assert report.status == "healthy"
+    assert report.source_path is None
+
+
+def test_keepalive_report_with_path() -> None:
+    report = KeepaliveReport(status="missing", detail="not found", source_path=Path("/tmp/x"))
+    assert report.source_path == Path("/tmp/x")
+
+
+def test_keepalive_report_rejects_invalid_status() -> None:
+    with pytest.raises(Exception):
+        KeepaliveReport(status="BAD_STATUS", detail="nope")
+
+
+# ---------------------------------------------------------------------------
+# _parse_vm_idle_timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("[wsl2]\nvmIdleTimeout=-1\n", "-1"),
+        ("[wsl2]\nvmIdleTimeout = 60\n", "60"),
+        ("[wsl2]\n# vmIdleTimeout=0\nvmIdleTimeout=120\n", "120"),
+        ("[wsl2]\n", None),
+        ("", None),
+        # Inline comment excluded by regex (# is a stop char), value stripped
+        ("[wsl2]\nvmIdleTimeout=-1  # disable\n", "-1"),
+    ],
+)
+def test_parse_vm_idle_timeout(text: str, expected: str | None) -> None:
+    assert _parse_vm_idle_timeout(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# _inspect_wslconfig (sync, uses filesystem via tmp_path)
+# ---------------------------------------------------------------------------
+
+def test_inspect_wslconfig_file_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no .wslconfig file exists, status is 'missing'."""
+    monkeypatch.setattr(ki, "_candidate_wslconfig_paths", lambda: [Path("/nonexistent/.wslconfig")])
+    result = _inspect_wslconfig()
+    assert result["status"] == "missing"
+    assert result["configured"] is False
+
+
+def test_inspect_wslconfig_healthy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """vmIdleTimeout=-1 → healthy."""
+    cfg = tmp_path / ".wslconfig"
+    cfg.write_text("[wsl2]\nvmIdleTimeout=-1\n")
+    monkeypatch.setattr(ki, "_candidate_wslconfig_paths", lambda: [cfg])
+    result = _inspect_wslconfig()
+    assert result["status"] == "healthy"
+    assert result["idle_shutdown_disabled"] is True
+
+
+def test_inspect_wslconfig_misconfigured_value(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """vmIdleTimeout=60 (not -1) → misconfigured."""
+    cfg = tmp_path / ".wslconfig"
+    cfg.write_text("[wsl2]\nvmIdleTimeout=60\n")
+    monkeypatch.setattr(ki, "_candidate_wslconfig_paths", lambda: [cfg])
+    result = _inspect_wslconfig()
+    assert result["status"] == "misconfigured"
+    assert result["idle_shutdown_disabled"] is False
+
+
+def test_inspect_wslconfig_no_vm_idle_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File exists but vmIdleTimeout key absent → misconfigured."""
+    cfg = tmp_path / ".wslconfig"
+    cfg.write_text("[wsl2]\nmemory=4GB\n")
+    monkeypatch.setattr(ki, "_candidate_wslconfig_paths", lambda: [cfg])
+    result = _inspect_wslconfig()
+    assert result["status"] == "misconfigured"
+    assert result["vm_idle_timeout"] is None
+
+
+def test_inspect_wslconfig_read_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """OSError while reading → status unknown."""
+    cfg = tmp_path / ".wslconfig"
+    cfg.write_text("dummy")
+
+    def _raise(_self: Path, *_a, **_kw):  # noqa: ANN001
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(ki, "_candidate_wslconfig_paths", lambda: [cfg])
+    monkeypatch.setattr(Path, "read_text", _raise)
+    result = _inspect_wslconfig()
+    assert result["status"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _inspect_systemd_keepalive (async)
+# ---------------------------------------------------------------------------
+
+async def test_inspect_systemd_keepalive_windows_os(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Windows (os.name == 'nt'), should return unsupported."""
+    import types
+    fake_os = types.SimpleNamespace(name="nt", environ=__import__("os").environ)
+    monkeypatch.setattr(ki, "os", fake_os)
+    result = await _inspect_systemd_keepalive()
+    assert result["status"] == "unsupported"
+    assert result["active"] is False
+
+
+async def test_inspect_systemd_keepalive_systemd_not_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """systemctl returns non-zero with 'system has not been booted with systemd'."""
+    async def fake_run_cmd(cmd, timeout=10):  # noqa: ANN001, ARG001
+        return 1, "", "System has not been booted with systemd as init system (PID 1)."
+
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_systemd_keepalive()
+    assert result["status"] == "unsupported"
+
+
+async def test_inspect_systemd_keepalive_service_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When LoadState=loaded, ActiveState=active, UnitFileState=enabled → healthy."""
+    systemctl_output = (
+        "LoadState=loaded\n"
+        "ActiveState=active\n"
+        "UnitFileState=enabled\n"
+        "FragmentPath=/etc/systemd/system/wsl-runner-keepalive.service\n"
+        "Description=WSL Runner Keepalive\n"
+    )
+
+    async def fake_run_cmd(cmd, timeout=10):  # noqa: ANN001, ARG001
+        return 0, systemctl_output, ""
+
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_systemd_keepalive()
+    assert result["status"] == "healthy"
+    assert result["active"] is True
+    assert result["enabled"] is True
+
+
+async def test_inspect_systemd_keepalive_service_inactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Service present but inactive → misconfigured."""
+    systemctl_output = (
+        "LoadState=loaded\n"
+        "ActiveState=inactive\n"
+        "UnitFileState=disabled\n"
+        "FragmentPath=/etc/systemd/system/wsl-runner-keepalive.service\n"
+        "Description=WSL Runner Keepalive\n"
+    )
+
+    async def fake_run_cmd(cmd, timeout=10):  # noqa: ANN001, ARG001
+        return 0, systemctl_output, ""
+
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_systemd_keepalive()
+    assert result["status"] == "misconfigured"
+    assert result["active"] is False
+
+
+async def test_inspect_systemd_keepalive_service_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Service not found (LoadState=not-found) → missing."""
+    systemctl_output = (
+        "LoadState=not-found\n"
+        "ActiveState=inactive\n"
+        "UnitFileState=\n"
+    )
+
+    async def fake_run_cmd(cmd, timeout=10):  # noqa: ANN001, ARG001
+        return 0, systemctl_output, ""
+
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_systemd_keepalive()
+    assert result["status"] == "missing"
+    assert result["configured"] is False
+
+
+# ---------------------------------------------------------------------------
+# _inspect_windows_keepalive (async)
+# ---------------------------------------------------------------------------
+
+async def test_inspect_windows_keepalive_no_powershell(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When PowerShell is not found → unsupported."""
+    monkeypatch.setattr(ki, "_resolve_powershell_executable", lambda: None)
+    result = await _inspect_windows_keepalive()
+    assert result["status"] == "unsupported"
+    assert result["task_found"] is False
+
+
+async def test_inspect_windows_keepalive_task_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task is found and Running → healthy."""
+    import json
+
+    payload = {
+        "task_found": True,
+        "task_name": "WSL-Runner-KeepAlive",
+        "state": "Running",
+        "actions": [{"Execute": "wsl.exe", "Arguments": "-d Ubuntu"}],
+        "startup_vbs_files": [],
+    }
+
+    async def fake_run_cmd(cmd, timeout=12):  # noqa: ANN001, ARG001
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(ki, "_resolve_powershell_executable", lambda: "powershell.exe")
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_windows_keepalive()
+    assert result["status"] == "healthy"
+    assert result["task_found"] is True
+
+
+async def test_inspect_windows_keepalive_task_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Task not found → missing."""
+    import json
+
+    payload = {
+        "task_found": False,
+        "task_name": "WSL-Runner-KeepAlive",
+        "state": None,
+        "actions": [],
+        "startup_vbs_files": [],
+        "error": "Task not found",
+    }
+
+    async def fake_run_cmd(cmd, timeout=12):  # noqa: ANN001, ARG001
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(ki, "_resolve_powershell_executable", lambda: "powershell.exe")
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_windows_keepalive()
+    assert result["status"] == "missing"
+
+
+async def test_inspect_windows_keepalive_legacy_vbs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy VBS file detected → legacy status."""
+    import json
+
+    payload = {
+        "task_found": True,
+        "task_name": "WSL-Runner-KeepAlive",
+        "state": "Running",
+        "actions": [{"Execute": "wscript.exe", "Arguments": "keepalive.vbs"}],
+        "startup_vbs_files": ["C:\\Users\\user\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\wsl-keepalive.vbs"],
+    }
+
+    async def fake_run_cmd(cmd, timeout=12):  # noqa: ANN001, ARG001
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(ki, "_resolve_powershell_executable", lambda: "powershell.exe")
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_windows_keepalive()
+    assert result["status"] == "legacy"
+    assert result["legacy_vbs_detected"] is True
+
+
+# ---------------------------------------------------------------------------
+# _detect_legacy_keepalive
+# ---------------------------------------------------------------------------
+
+def test_detect_legacy_keepalive_vbs_files() -> None:
+    found, detail = _detect_legacy_keepalive([], ["C:\\Users\\user\\startup\\wsl-keepalive.vbs"])
+    assert found is True
+    assert detail is not None
+
+
+def test_detect_legacy_keepalive_wscript_action() -> None:
+    actions = [{"execute": "c:\\windows\\system32\\wscript.exe", "arguments": "keepalive.vbs"}]
+    found, detail = _detect_legacy_keepalive(actions, [])
+    assert found is True
+
+
+def test_detect_legacy_keepalive_clean() -> None:
+    actions = [{"execute": "wsl.exe", "arguments": "-d Ubuntu"}]
+    found, detail = _detect_legacy_keepalive(actions, [])
+    assert found is False
+    assert detail is None
+
+
+def test_detect_legacy_keepalive_vbs_in_arguments() -> None:
+    actions = [{"execute": "cmd.exe", "arguments": "keepalive.vbs /some/path"}]
+    found, detail = _detect_legacy_keepalive(actions, [])
+    assert found is True
+
+
+# ---------------------------------------------------------------------------
+# _parse_task_action
+# ---------------------------------------------------------------------------
+
+def test_parse_task_action_normalizes_keys() -> None:
+    action = {"Execute": "wsl.exe", "Arguments": "-d Ubuntu"}
+    result = _parse_task_action(action)
+    assert result["execute"] == "wsl.exe"
+    assert result["arguments"] == "-d Ubuntu"
+
+
+def test_parse_task_action_handles_missing_keys() -> None:
+    result = _parse_task_action({})
+    assert result["execute"] is None
+    assert result["arguments"] is None
+
+
+# ---------------------------------------------------------------------------
+# _probe_detail
+# ---------------------------------------------------------------------------
+
+def test_probe_detail_returns_detail_key() -> None:
+    probe = {"detail": "things are good", "error": "ignored"}
+    assert _probe_detail(probe, "fallback") == "things are good"
+
+
+def test_probe_detail_falls_back_to_error() -> None:
+    probe = {"error": "something broke"}
+    assert _probe_detail(probe, "fallback") == "something broke"
+
+
+def test_probe_detail_uses_fallback() -> None:
+    assert _probe_detail({}, "default fallback") == "default fallback"
+
+
+# ---------------------------------------------------------------------------
+# Return value statuses conform to valid set
+# ---------------------------------------------------------------------------
+
+def test_inspect_wslconfig_status_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ki, "_candidate_wslconfig_paths", lambda: [])
+    result = _inspect_wslconfig()
+    assert result["status"] in _VALID_STATUSES
+
+
+async def test_inspect_systemd_keepalive_status_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_cmd(cmd, timeout=10):  # noqa: ANN001, ARG001
+        return 1, "", "failed to connect to bus"
+
+    monkeypatch.setattr(ki, "run_cmd", fake_run_cmd)
+    result = await _inspect_systemd_keepalive()
+    assert result["status"] in _VALID_STATUSES
+
+
+async def test_inspect_windows_keepalive_status_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ki, "_resolve_powershell_executable", lambda: None)
+    result = await _inspect_windows_keepalive()
+    assert result["status"] in _VALID_STATUSES

--- a/tests/api/test_run_enrichment.py
+++ b/tests/api/test_run_enrichment.py
@@ -1,0 +1,240 @@
+"""Tests for workflows.run_enrichment — GitHub run/job enrichment helpers.
+
+All tests are fully offline. run_cmd is monkeypatched where needed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import workflows.run_enrichment as re_mod  # noqa: E402
+from workflows.run_enrichment import (  # noqa: E402
+    EnrichedRun,
+    Job,
+    JobPlacement,
+    Run,
+    _enrich_run_with_job_placement,
+    _fetch_failed_log_excerpt,
+    _fetch_repo_runs,
+    _fetch_run_jobs,
+    _get_recent_org_repos,
+    _placement_from_jobs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+def test_run_model_basic() -> None:
+    run = Run(id=1, name="CI", status="completed", conclusion="success")
+    assert run.id == 1
+
+
+def test_job_model_basic() -> None:
+    job = Job(id=10, name="build", status="completed", conclusion="success")
+    assert job.id == 10
+
+
+def test_job_placement_model() -> None:
+    jp = JobPlacement(
+        runner_id=1,
+        runner_name="d-sorg-local-host-1",
+        runner_group_name="Default",
+        runner_labels=["self-hosted", "linux"],
+        machine_name="host",
+    )
+    assert jp.machine_name == "host"
+
+
+def test_enriched_run_model() -> None:
+    er = EnrichedRun(id=5, name="Deploy", status="completed", conclusion="success", machine_name="myhost")
+    assert er.machine_name == "myhost"
+
+
+# ---------------------------------------------------------------------------
+# _get_recent_org_repos (async)
+# ---------------------------------------------------------------------------
+
+async def test_get_recent_org_repos_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    repos = [{"name": "repo-a"}, {"name": "repo-b"}]
+
+    async def fake_run_cmd(cmd, timeout=20):  # noqa: ANN001, ARG001
+        return 0, json.dumps(repos), ""
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _get_recent_org_repos(limit=2)
+    assert result == repos
+
+
+async def test_get_recent_org_repos_empty_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_cmd(cmd, timeout=20):  # noqa: ANN001, ARG001
+        return 1, "", "error"
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _get_recent_org_repos()
+    assert result == []
+
+
+async def test_get_recent_org_repos_empty_on_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_cmd(cmd, timeout=20):  # noqa: ANN001, ARG001
+        return 0, "not-json", ""
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _get_recent_org_repos()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_repo_runs (async)
+# ---------------------------------------------------------------------------
+
+async def test_fetch_repo_runs_annotates_missing_repository(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runs without a 'repository' key get one injected."""
+    payload = {"workflow_runs": [{"id": 1, "name": "CI"}]}
+
+    async def fake_run_cmd(cmd, timeout=15):  # noqa: ANN001, ARG001
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_repo_runs("my-repo")
+    assert len(result) == 1
+    assert result[0]["repository"]["name"] == "my-repo"
+
+
+async def test_fetch_repo_runs_preserves_existing_repository(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runs that already have a 'repository' key keep it."""
+    payload = {"workflow_runs": [{"id": 2, "name": "CI", "repository": {"name": "original"}}]}
+
+    async def fake_run_cmd(cmd, timeout=15):  # noqa: ANN001, ARG001
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_repo_runs("ignored-name")
+    assert result[0]["repository"]["name"] == "original"
+
+
+async def test_fetch_repo_runs_empty_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_cmd(cmd, timeout=15):  # noqa: ANN001, ARG001
+        return 1, "", "error"
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_repo_runs("my-repo")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_run_jobs (async)
+# ---------------------------------------------------------------------------
+
+async def test_fetch_run_jobs_returns_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"jobs": [{"id": 1, "name": "build", "runner_name": "d-sorg-local-host-1"}]}
+
+    async def fake_run_cmd(cmd, timeout=10):  # noqa: ANN001, ARG001
+        return 0, json.dumps(payload), ""
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_run_jobs("my-repo", 123)
+    assert len(result) == 1
+    assert result[0]["name"] == "build"
+
+
+async def test_fetch_run_jobs_empty_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_cmd(cmd, timeout=10):  # noqa: ANN001, ARG001
+        return 1, "", "error"
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_run_jobs("my-repo", 999)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_failed_log_excerpt (async)
+# ---------------------------------------------------------------------------
+
+async def test_fetch_failed_log_excerpt_returns_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_cmd(cmd, timeout=20):  # noqa: ANN001, ARG001
+        return 0, "Error: something went wrong", ""
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_failed_log_excerpt("my-repo", 42)
+    assert "something went wrong" in result
+
+
+async def test_fetch_failed_log_excerpt_empty_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_run_cmd(cmd, timeout=20):  # noqa: ANN001, ARG001
+        return 1, "", "error"
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_failed_log_excerpt("my-repo", 42)
+    assert result == ""
+
+
+async def test_fetch_failed_log_excerpt_truncated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Logs exceeding 12 000 chars are truncated."""
+    long_text = "x" * 20000
+
+    async def fake_run_cmd(cmd, timeout=20):  # noqa: ANN001, ARG001
+        return 0, long_text, ""
+
+    monkeypatch.setattr(re_mod, "run_cmd", fake_run_cmd)
+    result = await _fetch_failed_log_excerpt("my-repo", 1)
+    assert len(result) <= 12000
+
+
+# ---------------------------------------------------------------------------
+# _placement_from_jobs
+# ---------------------------------------------------------------------------
+
+def test_placement_from_jobs_extracts_runner_name() -> None:
+    jobs = [{"runner_name": "d-sorg-local-myhost-2", "runner_id": 5, "runner_group_name": "Default", "labels": ["self-hosted"]}]
+    result = _placement_from_jobs(jobs)
+    assert result["runner_name"] == "d-sorg-local-myhost-2"
+    assert result["machine_name"] == "myhost"
+
+
+def test_placement_from_jobs_empty_list() -> None:
+    result = _placement_from_jobs([])
+    assert result == {}
+
+
+def test_placement_from_jobs_skips_jobs_without_runner_name() -> None:
+    jobs = [{"runner_name": None}, {"runner_name": "d-sorg-local-host-1", "runner_id": 3, "runner_group_name": "Default", "labels": []}]
+    result = _placement_from_jobs(jobs)
+    assert result["runner_name"] == "d-sorg-local-host-1"
+
+
+# ---------------------------------------------------------------------------
+# _enrich_run_with_job_placement (async)
+# ---------------------------------------------------------------------------
+
+async def test_enrich_run_with_job_placement_adds_machine_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    jobs = [{"runner_name": "d-sorg-local-myhost-3", "runner_id": 9, "runner_group_name": "Default", "labels": []}]
+
+    async def fake_fetch_run_jobs(repo_name, run_id):  # noqa: ANN001, ARG001
+        return jobs
+
+    monkeypatch.setattr(re_mod, "_fetch_run_jobs", fake_fetch_run_jobs)
+    run = {"id": 1, "name": "CI", "repository": {"name": "my-repo"}}
+    result = await _enrich_run_with_job_placement(run)
+    assert result["machine_name"] == "myhost"
+    assert result["runner_name"] == "d-sorg-local-myhost-3"
+
+
+async def test_enrich_run_no_repo_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run with no repository info gets machine_name='GitHub' fallback."""
+    async def fake_fetch_run_jobs(repo_name, run_id):  # noqa: ANN001, ARG001
+        return []
+
+    monkeypatch.setattr(re_mod, "_fetch_run_jobs", fake_fetch_run_jobs)
+    run = {"id": 2, "name": "CI"}
+    result = await _enrich_run_with_job_placement(run)
+    assert "machine_name" in result

--- a/tests/api/test_runner_service_control.py
+++ b/tests/api/test_runner_service_control.py
@@ -1,0 +1,193 @@
+"""Tests for runners.service_control — runner service lifecycle helpers.
+
+All tests are fully offline. No real svc.sh or systemd calls are made.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import runners.service_control as sc  # noqa: E402
+from runners.service_control import (  # noqa: E402
+    RunnerUnit,
+    _runner_limit,
+    _runner_sort_key,
+    get_runner_service_name,
+    run_runner_svc,
+    runner_num_from_id,
+    runner_svc_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# RunnerUnit model
+# ---------------------------------------------------------------------------
+
+def test_runner_unit_model() -> None:
+    unit = RunnerUnit(num=3, name="wsl-runner-keepalive.service", path=Path("/home/user/actions-runners/runner-3/svc.sh"))
+    assert unit.num == 3
+    assert isinstance(unit.path, Path)
+
+
+# ---------------------------------------------------------------------------
+# runner_svc_path
+# ---------------------------------------------------------------------------
+
+def test_runner_svc_path_returns_correct_path() -> None:
+    path = runner_svc_path(1)
+    assert isinstance(path, Path)
+    assert path.name == "svc.sh"
+    assert "runner-1" in str(path)
+
+
+def test_runner_svc_path_runner_number_embedded(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(sc, "RUNNER_BASE_DIR", tmp_path)
+    assert runner_svc_path(5) == tmp_path / "runner-5" / "svc.sh"
+
+
+@pytest.mark.parametrize("num", [1, 2, 10, 99])
+def test_runner_svc_path_parametrized(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, num: int) -> None:
+    monkeypatch.setattr(sc, "RUNNER_BASE_DIR", tmp_path)
+    result = runner_svc_path(num)
+    assert result == tmp_path / f"runner-{num}" / "svc.sh"
+
+
+# ---------------------------------------------------------------------------
+# run_runner_svc (async)
+# ---------------------------------------------------------------------------
+
+async def test_run_runner_svc_calls_run_cmd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(sc, "RUNNER_BASE_DIR", tmp_path)
+    captured: dict = {}
+
+    async def fake_run_cmd(cmd, timeout=30, cwd=None):  # noqa: ANN001, ARG001
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return 0, "started", ""
+
+    monkeypatch.setattr(sc, "run_cmd", fake_run_cmd)
+    code, stdout, _ = await run_runner_svc(2, "start")
+    assert code == 0
+    assert "sudo" in captured["cmd"]
+    assert "start" in captured["cmd"]
+    # cwd should be the parent directory of svc.sh
+    assert captured["cwd"] == tmp_path / "runner-2"
+
+
+# ---------------------------------------------------------------------------
+# runner_num_from_id
+# ---------------------------------------------------------------------------
+
+def test_runner_num_from_id_matches_local_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sc, "HOSTNAME", "myhost")
+    monkeypatch.setattr(sc, "RUNNER_ALIASES", [])
+    runners = [{"id": 42, "name": "d-sorg-local-myhost-3"}]
+    result = runner_num_from_id(42, runners)
+    assert result == 3
+
+
+def test_runner_num_from_id_wrong_machine(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sc, "HOSTNAME", "myhost")
+    monkeypatch.setattr(sc, "RUNNER_ALIASES", [])
+    runners = [{"id": 42, "name": "d-sorg-local-otherhost-3"}]
+    result = runner_num_from_id(42, runners)
+    assert result is None
+
+
+def test_runner_num_from_id_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sc, "HOSTNAME", "myhost")
+    monkeypatch.setattr(sc, "RUNNER_ALIASES", [])
+    runners = [{"id": 99, "name": "d-sorg-local-myhost-3"}]
+    result = runner_num_from_id(42, runners)
+    assert result is None
+
+
+def test_runner_num_from_id_alias_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sc, "HOSTNAME", "primary")
+    monkeypatch.setattr(sc, "RUNNER_ALIASES", ["alias1", "alias2"])
+    runners = [{"id": 7, "name": "d-sorg-local-alias1-5"}]
+    result = runner_num_from_id(7, runners)
+    assert result == 5
+
+
+# ---------------------------------------------------------------------------
+# _runner_limit
+# ---------------------------------------------------------------------------
+
+def test_runner_limit_returns_max(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sc, "NUM_RUNNERS", 8)
+    monkeypatch.setattr(sc, "MAX_RUNNERS", 12)
+    assert _runner_limit() == 12
+
+
+def test_runner_limit_num_greater(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sc, "NUM_RUNNERS", 15)
+    monkeypatch.setattr(sc, "MAX_RUNNERS", 10)
+    assert _runner_limit() == 15
+
+
+# ---------------------------------------------------------------------------
+# _runner_sort_key
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "runners, expected_order",
+    [
+        # Numeric sort: runner-2 before runner-10
+        (
+            [{"name": "d-sorg-local-host-10"}, {"name": "d-sorg-local-host-2"}],
+            ["d-sorg-local-host-2", "d-sorg-local-host-10"],
+        ),
+        # Machine prefix sort: aaa before zzz
+        (
+            [{"name": "d-sorg-local-zzz-1"}, {"name": "d-sorg-local-aaa-1"}],
+            ["d-sorg-local-aaa-1", "d-sorg-local-zzz-1"],
+        ),
+    ],
+)
+def test_runner_sort_key_ordering(runners: list[dict], expected_order: list[str]) -> None:
+    sorted_runners = sorted(runners, key=_runner_sort_key)
+    assert [r["name"] for r in sorted_runners] == expected_order
+
+
+def test_runner_sort_key_no_number_suffix() -> None:
+    """Runner names without a numeric suffix should sort last numerically."""
+    runners = [{"name": "runner-nonnumeric"}, {"name": "runner-1"}]
+    sorted_runners = sorted(runners, key=_runner_sort_key)
+    # runner-1 has suffix 1, runner-nonnumeric has suffix 10^9 → runner-1 first
+    assert sorted_runners[0]["name"] == "runner-1"
+
+
+# ---------------------------------------------------------------------------
+# get_runner_service_name
+# ---------------------------------------------------------------------------
+
+def test_get_runner_service_name_reads_dot_service_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(sc, "RUNNER_BASE_DIR", tmp_path)
+    svc_dir = tmp_path / "runner-3"
+    svc_dir.mkdir()
+    (svc_dir / ".service").write_text("actions.runner.org.runner-3.service\n")
+    result = get_runner_service_name(3)
+    assert result == "actions.runner.org.runner-3.service"
+
+
+def test_get_runner_service_name_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(sc, "RUNNER_BASE_DIR", tmp_path)
+    monkeypatch.setattr(sc, "ORG", "D-sorganization")
+    monkeypatch.setattr(sc, "HOSTNAME", "testhost")
+    # No .service file created → should fall back to generated name
+    result = get_runner_service_name(7)
+    assert result is not None
+    assert "7" in result
+    assert "testhost" in result

--- a/tests/api/test_wsl_paths.py
+++ b/tests/api/test_wsl_paths.py
@@ -1,0 +1,149 @@
+"""Tests for platform_utils.wsl_paths — pure WSL path-normalisation utilities.
+
+These tests are 100 % offline; no subprocesses, no filesystem side-effects
+beyond tmp_path fixtures provided by pytest.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the backend directory is on sys.path so the package is importable.
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from platform_utils.wsl_paths import (  # noqa: E402
+    _candidate_wslconfig_paths,
+    _dedupe_paths,
+    _windows_path_to_wsl,
+)
+
+
+# ---------------------------------------------------------------------------
+# _windows_path_to_wsl
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Basic drive conversion
+        (r"C:\foo\bar", Path("/mnt/c/foo/bar")),
+        (r"D:\Users\name", Path("/mnt/d/Users/name")),
+        # Lowercase drive letter
+        (r"c:\lowercase\path", Path("/mnt/c/lowercase/path")),
+        # Mixed separators
+        (r"C:/mixed/sep", Path("/mnt/c/mixed/sep")),
+        # Uppercase drive retained as lowercase
+        (r"Z:\deep\nested\dir", Path("/mnt/z/deep/nested/dir")),
+        # Path with spaces
+        (r"C:\Users\John Doe\Documents", Path("/mnt/c/Users/John Doe/Documents")),
+        # Trailing backslash
+        (r"C:\foo\bar\\", Path("/mnt/c/foo/bar/")),
+        # Quoted path (real-world PowerShell output)
+        ('"C:\\Program Files\\thing"', Path("/mnt/c/Program Files/thing")),
+    ],
+)
+def test_windows_path_to_wsl_drive_conversion(raw: str, expected: Path) -> None:
+    assert _windows_path_to_wsl(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected_path",
+    [
+        # UNC path — no drive letter; returned verbatim as Path
+        (r"\\server\share\dir", Path(r"\\server\share\dir")),
+        # Already a POSIX path — returned unchanged
+        ("/mnt/c/already/posix", Path("/mnt/c/already/posix")),
+        # Relative path — returned unchanged
+        ("relative/path", Path("relative/path")),
+    ],
+)
+def test_windows_path_to_wsl_non_drive_paths_returned_as_is(raw: str, expected_path: Path) -> None:
+    """Non-drive-letter paths are returned as Path(raw.strip()) unchanged."""
+    result = _windows_path_to_wsl(raw)
+    assert isinstance(result, Path)
+    assert result == expected_path
+
+
+def test_windows_path_to_wsl_empty_string() -> None:
+    """An empty string input returns Path('') without raising."""
+    result = _windows_path_to_wsl("")
+    assert isinstance(result, Path)
+
+
+def test_windows_path_to_wsl_whitespace_stripped() -> None:
+    """Leading/trailing whitespace is stripped before conversion."""
+    result = _windows_path_to_wsl("  C:\\foo  ")
+    assert result == Path("/mnt/c/foo")
+
+
+# ---------------------------------------------------------------------------
+# _dedupe_paths
+# ---------------------------------------------------------------------------
+
+def test_dedupe_paths_removes_duplicates() -> None:
+    paths = [Path("/a"), Path("/b"), Path("/a"), Path("/c"), Path("/b")]
+    result = _dedupe_paths(paths)
+    assert result == [Path("/a"), Path("/b"), Path("/c")]
+
+
+def test_dedupe_paths_preserves_insertion_order() -> None:
+    paths = [Path("/z"), Path("/a"), Path("/m"), Path("/a")]
+    result = _dedupe_paths(paths)
+    assert result == [Path("/z"), Path("/a"), Path("/m")]
+
+
+def test_dedupe_paths_empty_input() -> None:
+    assert _dedupe_paths([]) == []
+
+
+def test_dedupe_paths_all_unique() -> None:
+    paths = [Path("/x"), Path("/y"), Path("/z")]
+    assert _dedupe_paths(paths) == paths
+
+
+# ---------------------------------------------------------------------------
+# _candidate_wslconfig_paths
+# ---------------------------------------------------------------------------
+
+def test_candidate_wslconfig_paths_returns_list_of_paths() -> None:
+    result = _candidate_wslconfig_paths()
+    assert isinstance(result, list)
+    for item in result:
+        assert isinstance(item, Path), f"Expected Path, got {type(item)}: {item!r}"
+
+
+def test_candidate_wslconfig_paths_no_duplicates() -> None:
+    result = _candidate_wslconfig_paths()
+    seen = set()
+    for p in result:
+        key = str(p)
+        assert key not in seen, f"Duplicate candidate path: {p}"
+        seen.add(key)
+
+
+def test_candidate_wslconfig_paths_includes_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """If WSL_KEEPALIVE_WSLCONFIG_PATH is set, it must appear in candidates."""
+    custom = tmp_path / "custom.wslconfig"
+    monkeypatch.setenv("WSL_KEEPALIVE_WSLCONFIG_PATH", str(custom))
+    result = _candidate_wslconfig_paths()
+    assert custom in result
+
+
+def test_candidate_wslconfig_paths_userprofile_wsl_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """USERPROFILE env var should produce a /mnt/<drive>/…/.wslconfig candidate."""
+    monkeypatch.setenv("USERPROFILE", r"C:\Users\TestUser")
+    monkeypatch.delenv("HOMEDRIVE", raising=False)
+    monkeypatch.delenv("HOMEPATH", raising=False)
+    monkeypatch.delenv("WSL_KEEPALIVE_WSLCONFIG_PATH", raising=False)
+    monkeypatch.delenv("WSL_CONFIG_PATH", raising=False)
+
+    result = _candidate_wslconfig_paths()
+    expected = Path("/mnt/c/Users/TestUser/.wslconfig")
+    assert expected in result

--- a/tests/test_keepalive_diagnostics.py
+++ b/tests/test_keepalive_diagnostics.py
@@ -7,6 +7,11 @@ CI and are NOT marked `@pytest.mark.integration`.
 TODO(#434): if future tests in this module are added that exercise real
 systemd/PowerShell calls, mark them `@pytest.mark.integration` so they are
 excluded from PR CI by default and run nightly only (see issue #401).
+
+Note: The keepalive functions (_inspect_wslconfig, _inspect_systemd_keepalive,
+_inspect_windows_keepalive, etc.) were extracted to
+diagnostics/keepalive_inspector.py and platform_utils/wsl_paths.py (#718).
+Monkeypatching must target those modules directly, not server.
 """
 
 from __future__ import annotations  # noqa: E402
@@ -19,34 +24,41 @@ from types import SimpleNamespace  # noqa: E402
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
 
-import server  # noqa: E402  # noqa: E402
+import diagnostics.keepalive_inspector as _ki  # noqa: E402
+import platform_utils.wsl_paths as _wsl  # noqa: E402
+import server  # noqa: E402
 
 
-def _patch_server_windows_os(monkeypatch) -> None:
-    real_os = server.os
+def _patch_windows_os(monkeypatch) -> None:
+    """Patch os.name='nt' on both the extracted modules and server."""
+    import os as _real_os
 
     class WindowsOs(SimpleNamespace):
         name = "nt"
 
         def __getattr__(self, key: str):  # noqa: ANN202
-            return getattr(real_os, key)
+            return getattr(_real_os, key)
 
-    monkeypatch.setattr(server, "os", WindowsOs())
+    fake = WindowsOs()
+    monkeypatch.setattr(_ki, "os", fake)
+    monkeypatch.setattr(_wsl, "os", fake)
+    monkeypatch.setattr(server, "os", fake)
 
 
 def test_windows_wslconfig_path_is_checked_directly(monkeypatch, tmp_path: Path) -> None:
-    _patch_server_windows_os(monkeypatch)
+    _patch_windows_os(monkeypatch)
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.delenv("HOMEDRIVE", raising=False)
     monkeypatch.delenv("HOMEPATH", raising=False)
 
-    paths = server._candidate_wslconfig_paths()
+    # _candidate_wslconfig_paths lives in the extracted platform_utils.wsl_paths module
+    paths = _wsl._candidate_wslconfig_paths()
 
     assert tmp_path / ".wslconfig" in paths
 
 
 def test_systemd_keepalive_probe_is_windows_safe(monkeypatch) -> None:
-    _patch_server_windows_os(monkeypatch)
+    _patch_windows_os(monkeypatch)
 
     result = asyncio.run(server._inspect_systemd_keepalive())
 
@@ -55,7 +67,7 @@ def test_systemd_keepalive_probe_is_windows_safe(monkeypatch) -> None:
 
 
 def test_systemd_timer_check_is_windows_safe(monkeypatch) -> None:
-    _patch_server_windows_os(monkeypatch)
+    _patch_windows_os(monkeypatch)
 
     assert server._unit_active_sync("runner-scheduler.timer") is False
 
@@ -71,8 +83,9 @@ def test_windows_scheduled_task_probe_uses_valid_powershell(monkeypatch) -> None
             "",
         )
 
-    monkeypatch.setattr(server, "_resolve_powershell_executable", lambda: "powershell")
-    monkeypatch.setattr(server, "run_cmd", fake_run_cmd)
+    # Patch the imported name in the keepalive_inspector module namespace
+    monkeypatch.setattr(_ki, "_resolve_powershell_executable", lambda: "powershell")
+    monkeypatch.setattr(_ki, "run_cmd", fake_run_cmd)
 
     result = asyncio.run(server._inspect_windows_keepalive())
 


### PR DESCRIPTION
## Summary

Extracts four domain-specific function clusters from `backend/server.py` into dedicated modules, with full TDD coverage (tests written first) and DbC assertions on every public function.

### C1 (#718) — Keepalive diagnostics + WSL path utilities

- **`backend/platform_utils/wsl_paths.py`** — pure path-normalisation helpers (`_windows_path_to_wsl`, `_dedupe_paths`, `_candidate_wslconfig_paths`, `_resolve_powershell_executable`). Zero external dependencies. Named `platform_utils` to avoid stdlib `platform` collision.
- **`backend/diagnostics/keepalive_inspector.py`** — WSL/systemd/Windows keepalive inspection functions (`_inspect_wslconfig`, `_inspect_systemd_keepalive`, `_inspect_windows_keepalive`, and helpers). Adds `KeepaliveReport` pydantic model (typed `status`, `detail`, `source_path`). `run_cmd` imported from `system_utils` — not `server.py` — to avoid circular imports.

### C2 (#719) — Runner service control + workflow run enrichment

- **`backend/runners/service_control.py`** — `runner_svc_path`, `run_runner_svc`, `runner_num_from_id`, `_runner_limit`, `_runner_sort_key`, `get_runner_service_name` with new `RunnerUnit` pydantic model.
- **`backend/workflows/run_enrichment.py`** — `_get_recent_org_repos`, `_fetch_repo_runs`, `_fetch_run_jobs`, `_fetch_failed_log_excerpt`, `_placement_from_jobs`, `_enrich_run_with_job_placement` with new `Run`, `Job`, `JobPlacement`, `EnrichedRun` pydantic models.

### server.py changes

Function bodies removed; server.py now imports the same names from the new modules — all existing callers work unchanged. Net reduction ≥ 310 lines.

### Existing tests updated

`tests/test_keepalive_diagnostics.py` patches updated from `server` namespace to `diagnostics.keepalive_inspector` / `platform_utils.wsl_paths` namespaces.

## Test plan

- [ ] `pytest tests/api/test_wsl_paths.py` — parametrized path-conversion edge cases
- [ ] `pytest tests/api/test_keepalive_inspector.py` — all `_inspect_*` variants with `tmp_path` and mocked `subprocess`
- [ ] `pytest tests/api/test_runner_service_control.py` — runner-id formats, sort key, service name
- [ ] `pytest tests/api/test_run_enrichment.py` — fixture-driven enrichment shape verification
- [ ] Full suite: 1903 passed, 0 regressions (2 pre-existing failures unrelated to this PR)
- [ ] Confirm `/api/diagnostics/keepalive` returns identical JSON to pre-extraction

Closes #718
Closes #719

---
_Generated by [Claude Code](https://claude.ai/code/session_018EpDhurqU2g4SMmaXXLVg2)_