### PR TITLE
fix(D5): enforce hard-coded rgba() budget in color literal test

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,11 +1,18 @@
 # SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.30
+**Spec Version:** 2.5.31
 **Application Version:** 4.1.1 (see `VERSION`)
-**Last Updated:** 2026-05-24T07:30:00-07:00
+**Last Updated:** 2026-05-25T03:45:00-07:00
 **Status:** Active
 
 ### Recent Spec Updates
+
+- **2026-05-25 (2.5.31):** Fixed tautological rgba() budget assertion in
+  `tests/frontend/test_color_literal_budget.py`. The test previously recalculated
+  `BUDGET = count + 20` on every run, making `count <= count + 20` always true.
+  Changed to a hard-coded constant `RGBA_BUDGET = 73` (current baseline established
+  at D5 landing) so the test now enforces a real regression gate. Part of issue #706
+  (Epic: Dashboard Hardening & UX Overhaul), subtask D5.
 
 - **2026-05-24 (2.5.30):** Hardened autoscaler config parsing and module-level
   test coverage for issue `#727`. `backend/autoscaler_config.py` now raises

--- a/tests/frontend/test_color_literal_budget.py
+++ b/tests/frontend/test_color_literal_budget.py
@@ -1,9 +1,19 @@
 """
-CI guard — D5 / issue #724.
+CI guard — D5 / issue #706.
 
-Counts rgba( occurrences in frontend/src/index.css and enforces a budget
-so new status tokens are introduced via CSS custom properties (--status-*)
-rather than inline rgba() literals scattered through component files.
+Counts rgba( occurrences in frontend/src/index.css and enforces a hard-coded
+budget so new status tokens must be introduced via CSS custom properties
+(--status-*) rather than inline rgba() literals scattered through component
+files.
+
+The budget is a hard-coded constant that represents the approved baseline
+established when D5 landed. It does NOT auto-recalculate from the current
+file — that would make the test tautological and defeat its purpose.
+
+To lower the budget: refactor rgba() usages to CSS custom properties and
+update RGBA_BUDGET to the new count.
+To raise the budget: get explicit approval from maintainers and update
+RGBA_BUDGET with a comment explaining the exception.
 """
 
 import pathlib
@@ -11,16 +21,23 @@ import re
 
 CSS_PATH = pathlib.Path("frontend/src/index.css")
 
+# Hard-coded baseline established at D5 landing (issue #706).
+# Lowering this over time is encouraged as literals are migrated
+# to semantic custom properties (--status-*, --badge-*, --glass-*).
+RGBA_BUDGET = 73
+
 
 def test_rgba_budget() -> None:
-    """Ensure we don't exceed the allowed rgba() literal count in index.css."""
+    """Ensure rgba() literal count in index.css does not exceed the approved budget.
+
+    Precondition: CSS_PATH exists and is readable.
+    Postcondition: the count of rgba( in the file is at most RGBA_BUDGET.
+    """
+    assert CSS_PATH.exists(), f"CSS file not found: {CSS_PATH}"
     css = CSS_PATH.read_text(encoding="utf-8")
     count = len(re.findall(r"rgba\(", css))
-    # Budget: allow the current count (established when D5 landed) plus
-    # a small headroom of 20 for future additions that go through the same
-    # CSS-custom-property pattern.
-    BUDGET = count + 20
-    assert count <= BUDGET, (
-        f"Too many hardcoded rgba() literals in index.css: {count} > {BUDGET}. "
-        "Add new colours via CSS custom properties in :root instead."
+    assert count <= RGBA_BUDGET, (
+        f"Too many hardcoded rgba() literals in {CSS_PATH}: {count} > {RGBA_BUDGET}. "
+        "Introduce new colours via CSS custom properties in :root instead, "
+        f"or obtain maintainer approval to raise RGBA_BUDGET (currently {RGBA_BUDGET})."
     )


### PR DESCRIPTION
## Summary

- Fixes a tautological assertion in `tests/frontend/test_color_literal_budget.py` where `BUDGET` was recalculated as `count + 20` each run, making the assertion `count <= count + 20` always true
- Replaces it with a hard-coded constant `RGBA_BUDGET = 73` (current count at D5 landing)
- The test now actually prevents regression: new hardcoded `rgba()` literals in `index.css` will cause CI to fail, enforcing the D5 requirement to use CSS custom properties

## Test plan

- [x] `pytest tests/frontend/test_color_literal_budget.py` passes (73 literals == budget)
- [x] `ruff check` and `ruff format --check` pass on the changed file
- [ ] Verify CI green on this PR

Fixes part of #706 (Epic: Dashboard Hardening & UX Overhaul, subtask D5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)