### PR TITLE
Fix ControlTower SSD dashboard port deployment

### DIFF
--- a/backend/machine_registry.yml
+++ b/backend/machine_registry.yml
@@ -56,7 +56,7 @@ machines:
           - controltower-ssd
           - control-tower-ssd
           - controltower-bulk
-        dashboard_url: http://100.95.177.68:8321
+        dashboard_url: http://127.0.0.1:8322
         storage_tier: ssd
         runner_base_dir: /home/dieterolson/actions-runners
         runner_labels:

--- a/deploy/runner-dashboard.service
+++ b/deploy/runner-dashboard.service
@@ -23,12 +23,12 @@ ExecStartPre=/home/YOUR_USER/actions-runners/dashboard/refresh-token.sh
 # WSL2 mirrored networking the dashboard cannot bind a port that Windows
 # tailscaled is already serving (recurring crash loop, see
 # deploy/wsl-mirrored-port-helper.sh for the full story). No-op outside WSL.
-ExecStartPre=/home/YOUR_USER/actions-runners/dashboard/wsl-mirrored-port-helper.sh clear --port 8321
+ExecStartPre=/home/YOUR_USER/actions-runners/dashboard/wsl-mirrored-port-helper.sh clear --port ${DASHBOARD_PORT}
 ExecStart=/home/YOUR_USER/actions-runners/dashboard/.venv/bin/python /home/YOUR_USER/actions-runners/dashboard/backend/server.py
 # Restore the Tailnet bridge after the dashboard is bound. ``Type=notify``
 # means systemd only runs ExecStartPost after the dashboard signals
 # sd_notify(READY=1), so the bind has already succeeded by this point.
-ExecStartPost=-/home/YOUR_USER/actions-runners/dashboard/wsl-mirrored-port-helper.sh restore --port 8321
+ExecStartPost=-/home/YOUR_USER/actions-runners/dashboard/wsl-mirrored-port-helper.sh restore --port ${DASHBOARD_PORT}
 ExecStopPost=-/home/YOUR_USER/actions-runners/dashboard/collect-crash-diagnostics.sh runner-dashboard.service
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary
- deploy ControlTower-SSD dashboard on its own port (`8322`) so the NVMe hub can see it as a live sibling pool
- make the systemd mirrored-port helper honor `DASHBOARD_PORT` instead of hard-coding `8321`

## Validation
- `UV_PROJECT_ENVIRONMENT=/tmp/runner-dashboard-fleet-topology-test-venv uv run pytest tests/test_machine_registry.py tests/test_deploy_hardening.py` => 102 passed
- live NVMe dashboard healthy on `127.0.0.1:8321`
- live SSD dashboard healthy on `127.0.0.1:8322`
- NVMe fleet view shows ControlTower-SSD online