### PR TITLE
fix(secrets): regenerate baseline to drop stale .pre-commit-config.yaml finding

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,16 +164,9 @@
       {
         "type": "Hex High Entropy String",
         "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "227125bec593ce36f9ad2551c9712b639f5e311a",
-        "is_verified": false,
-        "line_number": 73
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
         "hashed_secret": "86242b7a7b67c1fd83514757a6b319602d648e94",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 81
       }
     ],
     "assessments\\2026-04-26-Bitnet_Launcher-assessment.json": [
@@ -583,5 +576,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-26T17:02:23Z"
+  "generated_at": "2026-05-27T05:41:15Z"
 }


### PR DESCRIPTION
Pre-existing baseline drift. `.pre-commit-config.yaml` line 73 finding no longer exists; line 80 finding shifted to line 81. Re-ran `detect-secrets scan --baseline .secrets.baseline` to match the current tree. No new findings introduced.

This fails the `Audit baseline integrity` step on every PR. Fixes that fleet-wide.

Refs: blocks #768 and most open PRs.