### PR TITLE
fix(deploy): self-heal runner job-pickup hooks via systemd timer

### DIFF
--- a/deploy/install-runner-maintenance.sh
+++ b/deploy/install-runner-maintenance.sh
@@ -26,10 +26,20 @@ sudo install -m 0755 "${SCRIPT_DIR}/heal-host.sh" /usr/local/bin/heal-host
 # drop-ins written by migrate-runner-units.sh. Installed at a stable
 # system path so the drop-ins don't depend on a repo checkout location.
 HOOK_INSTALL_DIR="/usr/local/bin/runner-hooks"
+HOOK_SRC_DIR_INSTALLED="/opt/runner-dashboard/deploy/runner-hooks"
 sudo install -d -m 0755 "${HOOK_INSTALL_DIR}"
 sudo install -m 0755 "${SCRIPT_DIR}/runner-hooks/job-started.sh"   "${HOOK_INSTALL_DIR}/job-started.sh"
 sudo install -m 0755 "${SCRIPT_DIR}/runner-hooks/job-completed.sh" "${HOOK_INSTALL_DIR}/job-completed.sh"
 sudo install -m 0755 "${SCRIPT_DIR}/runner-hooks/force-drain.sh"   "${HOOK_INSTALL_DIR}/force-drain.sh"
+# Self-heal pass — restores the three hook scripts if they go missing
+# between deploys. Idempotent; safe to run on a short timer. Wired up
+# below as runner-hooks-restore.{service,timer}. Root cause this
+# guards against: fleet outage 2026-05-27, where multiple runners
+# had ACTIONS_RUNNER_HOOK_JOB_COMPLETED env vars pointing at files
+# that had been removed from /usr/local/bin/runner-hooks/, producing
+# `##[error]File doesn't exist` on every job-completed callback and
+# stalling all CI fleet-wide.
+sudo install -m 0755 "${SCRIPT_DIR}/runner-hooks-restore.sh" /usr/local/bin/runner-hooks-restore
 # Lockfile dir consulted by job-started.sh, job-completed.sh, the
 # autoscaler busy-check (#664), and runner-cleanup.sh GC (#651).
 # Must be writable by the runner user.
@@ -136,6 +146,36 @@ Persistent=true
 WantedBy=timers.target
 TIMER
 
+sudo tee /etc/systemd/system/runner-hooks-restore.service > /dev/null <<SERVICE
+[Unit]
+Description=Restore /usr/local/bin/runner-hooks/*.sh if they go missing
+Documentation=https://github.com/D-sorganization/Runner_Dashboard/blob/main/deploy/runner-hooks-restore.sh
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=root
+Environment=HOOK_SRC_DIR=${HOOK_SRC_DIR_INSTALLED}
+Environment=HOOK_DIR=${HOOK_INSTALL_DIR}
+Environment=TEXTFILE_COLLECTOR_DIR=${TEXTFILE_COLLECTOR_DIR}
+ExecStart=/usr/local/bin/runner-hooks-restore
+Nice=10
+SERVICE
+
+sudo tee /etc/systemd/system/runner-hooks-restore.timer > /dev/null <<'TIMER'
+[Unit]
+Description=Self-heal the runner job-pickup hooks every five minutes
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=5min
+AccuracySec=15s
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMER
+
 # Ensure runner-cleanup writes its textfile metric to the same collector
 # directory used by node_exporter. The cleanup script defaults to
 # /var/lib/node_exporter/textfile_collector but honours TEXTFILE_COLLECTOR_DIR.
@@ -146,7 +186,7 @@ Environment=TEXTFILE_COLLECTOR_DIR=${TEXTFILE_COLLECTOR_DIR}
 CONF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now runner-cleanup.timer runner-scheduler.timer runner-corruption-scan.timer
+sudo systemctl enable --now runner-cleanup.timer runner-scheduler.timer runner-corruption-scan.timer runner-hooks-restore.timer
 
 # Apply (or re-apply) the per-unit drop-ins from #664. Idempotent.
 # Passes the installed hook dir explicitly so the drop-ins reference the
@@ -161,4 +201,4 @@ echo "Installed:"
 systemctl list-timers runner-cleanup.timer runner-scheduler.timer runner-corruption-scan.timer --all
 echo ""
 echo "Binaries:"
-ls -l /usr/local/bin/runner-cleanup /usr/local/bin/heal-host /usr/local/bin/runner-corruption-scan "${HOOK_INSTALL_DIR}"/ | grep -v '^total'
+ls -l /usr/local/bin/runner-cleanup /usr/local/bin/heal-host /usr/local/bin/runner-corruption-scan /usr/local/bin/runner-hooks-restore "${HOOK_INSTALL_DIR}"/ | grep -v '^total'

--- a/deploy/runner-hooks-restore.sh
+++ b/deploy/runner-hooks-restore.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Self-heal for the runner job-pickup hooks (issue #664, follow-up to
+# the 2026-05-27 fleet outage where multiple runners had
+# ACTIONS_RUNNER_HOOK_JOB_COMPLETED pointing at files that had been
+# deleted from /usr/local/bin/runner-hooks/, producing
+# `##[error]File doesn't exist` on every job and stalling all CI.
+#
+# Re-installs the three hook scripts from the deploy/runner-hooks
+# source dir into /usr/local/bin/runner-hooks/ if any of them are
+# missing or non-executable. Idempotent — a no-op when everything is
+# already in place — so it is safe to run on a short timer.
+#
+# Inputs (env, all optional):
+#   HOOK_SRC_DIR   — source dir containing the *.sh hooks
+#                    (default: /opt/runner-dashboard/deploy/runner-hooks)
+#   HOOK_DIR       — install dir consulted by the runner
+#                    (default: /usr/local/bin/runner-hooks)
+#   PROM_FILE      — Prometheus textfile output path
+#                    (default: $TEXTFILE_COLLECTOR_DIR/runner_hooks.prom)
+
+set -Eeuo pipefail
+
+HOOK_SRC_DIR="${HOOK_SRC_DIR:-/opt/runner-dashboard/deploy/runner-hooks}"
+HOOK_DIR="${HOOK_DIR:-/usr/local/bin/runner-hooks}"
+TEXTFILE_COLLECTOR_DIR="${TEXTFILE_COLLECTOR_DIR:-/var/lib/node_exporter/textfile_collector}"
+PROM_FILE="${PROM_FILE:-${TEXTFILE_COLLECTOR_DIR}/runner_hooks.prom}"
+
+HOOKS=(job-started.sh job-completed.sh force-drain.sh)
+
+restored=0
+missing_src=0
+
+if [[ ! -d "${HOOK_SRC_DIR}" ]]; then
+    echo "runner-hooks-restore: source dir ${HOOK_SRC_DIR} not present; nothing to do" >&2
+    missing_src=1
+else
+    install -d -m 0755 "${HOOK_DIR}"
+    for hook in "${HOOKS[@]}"; do
+        src="${HOOK_SRC_DIR}/${hook}"
+        dst="${HOOK_DIR}/${hook}"
+        if [[ ! -f "${src}" ]]; then
+            echo "runner-hooks-restore: source missing for ${hook} at ${src}" >&2
+            continue
+        fi
+        if [[ ! -x "${dst}" ]] || ! cmp -s "${src}" "${dst}"; then
+            install -m 0755 "${src}" "${dst}"
+            restored=$((restored + 1))
+            echo "runner-hooks-restore: restored ${dst} from ${src}"
+        fi
+    done
+fi
+
+if [[ -d "${TEXTFILE_COLLECTOR_DIR}" ]]; then
+    tmp="$(mktemp "${PROM_FILE}.XXXXXX")"
+    {
+        echo "# HELP runner_hooks_restore_total Hooks re-installed on the most recent self-heal pass."
+        echo "# TYPE runner_hooks_restore_total counter"
+        echo "runner_hooks_restore_total ${restored}"
+        echo "# HELP runner_hooks_source_missing 1 if the deploy hook source dir is absent on this host."
+        echo "# TYPE runner_hooks_source_missing gauge"
+        echo "runner_hooks_source_missing ${missing_src}"
+        echo "# HELP runner_hooks_last_check_timestamp_seconds Unix time of the last self-heal pass."
+        echo "# TYPE runner_hooks_last_check_timestamp_seconds gauge"
+        echo "runner_hooks_last_check_timestamp_seconds $(date +%s)"
+    } >"${tmp}"
+    mv -f "${tmp}" "${PROM_FILE}"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds a 5-minute systemd timer (`runner-hooks-restore.timer`) that re-copies `job-started.sh`, `job-completed.sh`, and `force-drain.sh` into `/usr/local/bin/runner-hooks/` if any go missing or drift from the deploy source.
- Idempotent — no-op when files match. Emits Prometheus textfile metrics (`runner_hooks_restore_total`, `runner_hooks_source_missing`, `runner_hooks_last_check_timestamp_seconds`) so the Fleet tab / Grafana can alert when self-heal fires more than once in a while.
- Code-only landing — operators still need to run `deploy/install-runner-maintenance.sh` once on each host to install the new timer.

## Root cause this prevents (fleet outage 2026-05-27)

Multiple `d-sorg-fleet` runners had `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` env vars (set by the per-unit drop-ins from #664) pointing at hook files that had been removed from `/usr/local/bin/runner-hooks/`. Every job-completed callback then logged:

```
A job completed hook has been configured by the self-hosted runner administrator
##[error]File doesn't exist
```

…which marked otherwise-green jobs as failed and stalled all CI fleet-wide (matches the documented `runner_corruption_pattern` signature and #640). Affected Gasification_Model, Maxwell_Daemon, Tools, Tools_Private, and UpstreamDrift PRs simultaneously.

## Test plan

- [ ] CI Standard green on this PR
- [ ] After merge, on each affected host:
  - `sudo deploy/install-runner-maintenance.sh`
  - `systemctl list-timers runner-hooks-restore.timer`
  - `rm /usr/local/bin/runner-hooks/job-completed.sh && sudo systemctl start runner-hooks-restore.service && ls /usr/local/bin/runner-hooks/`
- [ ] Confirm `runner_hooks_source_missing 0` in the node_exporter textfile output once the deploy dir is present
- [ ] Trigger a re-run on a previously-stalled PR (e.g. UpstreamDrift #6493) and confirm the completion hook no longer kills the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)