### PR TITLE
fix(cleanup): support multiple RUNNER_ROOTS so nvme runners are cleaned

### DIFF
--- a/deploy/install-runner-maintenance.sh
+++ b/deploy/install-runner-maintenance.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 RUNNER_ROOT="${RUNNER_ROOT:-$HOME/actions-runners}"
+# Colon-separated list of parent dirs to manage (see runner-cleanup.sh).
+# Defaults to RUNNER_ROOT for backwards compat. Hosts that serve runners
+# from multiple disks (e.g. HDD + NVMe) should set this explicitly, e.g.
+#   RUNNER_ROOTS="$HOME/actions-runners:$HOME/actions-runners-nvme"
+RUNNER_ROOTS="${RUNNER_ROOTS:-$RUNNER_ROOT}"
 RUNNER_USER="${RUNNER_USER:-$USER}"
 SCHEDULE_CONFIG="${RUNNER_SCHEDULE_CONFIG:-$HOME/.config/runner-dashboard/runner-schedule.json}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-$(command -v systemctl)}"
@@ -64,6 +69,7 @@ Wants=docker.service
 Type=oneshot
 User=root
 Environment=RUNNER_ROOT=${RUNNER_ROOT}
+Environment=RUNNER_ROOTS=${RUNNER_ROOTS}
 Environment=RUNNER_USER=${RUNNER_USER}
 Environment=RUNNER_WORK_DAYS=3
 Environment=RUNNER_TEMP_DAYS=1

--- a/deploy/runner-cleanup.sh
+++ b/deploy/runner-cleanup.sh
@@ -2,6 +2,17 @@
 set -Eeuo pipefail
 
 RUNNER_ROOT="${RUNNER_ROOT:-$HOME/actions-runners}"
+# RUNNER_ROOTS lets a single host serve runners from multiple parent
+# directories (e.g. one set under HDD storage, another set under NVMe).
+# Format: colon-separated absolute paths, each containing runner-<N>
+# subdirs. If unset, falls back to RUNNER_ROOT for backwards compat.
+# The cleanup pass accepts a runner workdir if it sits under ANY of
+# these roots. Guards against: 2026-05-28 disk fill where
+# /home/dieterolson/actions-runners-nvme/runner-*/_work grew unbounded
+# because the daily cleanup only knew about
+# /home/dieterolson/actions-runners/runner-* and silently skipped
+# every nvme unit with "unexpected WorkingDirectory".
+RUNNER_ROOTS="${RUNNER_ROOTS:-$RUNNER_ROOT}"
 RUNNER_USER="${RUNNER_USER:-${SUDO_USER:-$USER}}"
 LOG_DIR="${LOG_DIR:-/var/log/runner-cleanup}"
 RUNNER_WORK_DAYS="${RUNNER_WORK_DAYS:-3}"
@@ -277,8 +288,22 @@ cleanup_runners() {
     while read -r unit; do
         [[ -n "$unit" ]] || continue
         runner_dir="$(service_workdir "$unit")"
-        if [[ -z "$runner_dir" || ! -d "$runner_dir" || "$runner_dir" != "$RUNNER_ROOT"/runner-* ]]; then
+        if [[ -z "$runner_dir" || ! -d "$runner_dir" ]]; then
             log "skip $unit: unexpected WorkingDirectory '$runner_dir'"
+            continue
+        fi
+        # Accept the workdir if it sits directly under any configured runner root.
+        local _matched=0 _root
+        IFS=':' read -r -a _roots_arr <<<"$RUNNER_ROOTS"
+        for _root in "${_roots_arr[@]}"; do
+            [[ -n "$_root" ]] || continue
+            if [[ "$runner_dir" == "$_root"/runner-* ]]; then
+                _matched=1
+                break
+            fi
+        done
+        if (( _matched == 0 )); then
+            log "skip $unit: workdir '$runner_dir' not under any RUNNER_ROOTS entry ($RUNNER_ROOTS)"
             continue
         fi
         if runner_busy "$runner_dir"; then


### PR DESCRIPTION
## Summary

Root cause of the 2026-05-28 disk-fill incident on the nvme-backed runner host: the daily `runner-cleanup.service` was a **silent no-op for all 8 `/home/dieterolson/actions-runners-nvme/runner-*` units**.

`cleanup_runners()` in `deploy/runner-cleanup.sh` was using a single-root allow-list:

```bash
if [[ ... || "$runner_dir" != "$RUNNER_ROOT"/runner-* ]]; then
    log "skip $unit: unexpected WorkingDirectory '$runner_dir'"
    continue
fi
```

Every nvme unit got skipped with `unexpected WorkingDirectory '/home/.../actions-runners-nvme/runner-N'`. `_work/` and `_diag/` grew unbounded across rebuilds until the rootfs hit 100% and every runner crash-looped on `No space left on device`.

The hook self-heal timer landed in #772 papered over the symptom but couldn't reclaim space.

## Fix

- New env var `RUNNER_ROOTS` (colon-separated list of parent dirs)
- Cleanup workdir gate now accepts any direct child `runner-<N>` under ANY configured root
- Backwards-compat: defaults to `$RUNNER_ROOT` so single-root hosts are unaffected
- `install-runner-maintenance.sh` plumbs the new env into the systemd unit

For hosts with multi-disk runner layouts, set explicitly:
```bash
RUNNER_ROOTS="$HOME/actions-runners:$HOME/actions-runners-nvme" \
    sudo -E deploy/install-runner-maintenance.sh
```

## Test plan

- [ ] CI green
- [ ] After merge, on the affected host: re-run `deploy/install-runner-maintenance.sh` with `RUNNER_ROOTS=$HOME/actions-runners:$HOME/actions-runners-nvme` and confirm `systemctl show runner-cleanup.service -p Environment` shows the new var
- [ ] Manually trigger: `sudo systemctl start runner-cleanup.service && journalctl -u runner-cleanup.service -n 50` — should no longer skip nvme runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)