### PR TITLE
fix: WSL keepalive probe false-flags healthy distros (fleet-wide)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 **Spec Version:** 2.5.41
 **Application Version:** 4.1.2 (see `VERSION`)
-**Last Updated:** 2026-05-28T00:00:00-07:00
+**Last Updated:** 2026-05-29T00:00:00-07:00
 **Status:** Active
 
 - **2026-05-28 (2.5.40):** Storage-tier aware disk pressure metrics and classification (issue #754).

--- a/deploy/wsl-keepalive.ps1
+++ b/deploy/wsl-keepalive.ps1
@@ -168,19 +168,72 @@ function Get-BackoffSeconds {
     return [int][Math]::Min($cap, $base * [Math]::Pow(2, $shift))
 }
 
+# The probe runs `id` (a single-token argument -- Start-Process -ArgumentList
+# does not quote multi-word elements, so `/bin/sh -c 'echo x'` would split and
+# run `sh -c echo` with no output). A healthy distro's `id` output always
+# contains this token; wsl.exe's own STDOUT diagnostics (e.g. "There is no
+# distribution with the supplied name.") never do -- so it cleanly separates a
+# live distro from both an offline one and the null-exit-code false positive.
+$script:ProbeCommand = 'id'
+$script:ProbeToken = 'uid='
+
+function Test-ProbeSuccess {
+    <#
+    .SYNOPSIS
+        Decide whether a responsiveness probe succeeded from its observable
+        results. Pure: no I/O, no globals, so it can be unit-tested directly.
+
+    .DESCRIPTION
+        Success is deliberately NOT derived from the process exit code.
+        ``Start-Process -PassThru`` does not reliably populate the exit code
+        when the watchdog runs non-interactively (``powershell -File`` from a
+        scheduled task): it comes back ``$null``. The old gate compared that
+        null code against zero, judged it non-zero, and declared a perfectly
+        healthy distro unresponsive on EVERY cycle. In Watchdog mode that drove
+        a ``wsl --shutdown`` reboot loop that took the whole runner fleet (and
+        the dashboard) offline; in Resident mode it spammed false
+        ``unresponsive`` reports.
+
+        A bare "non-empty stdout" check is also wrong: ``wsl.exe`` prints its
+        own errors (bad distro name, etc.) to STDOUT, so an offline distro
+        still yields output. The reliable signal is that the probe exited
+        within the timeout AND its stdout contains the sentinel the in-distro
+        command emits (the probe runs `id`, whose output always contains
+        "uid=") -- which wsl.exe diagnostics never include.
+
+    .OUTPUTS
+        [bool] $true iff the probe exited and its stdout contains ExpectedToken.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][bool]$Exited,
+        [AllowNull()][AllowEmptyString()][string]$StdoutContent,
+        [Parameter(Mandatory)][string]$ExpectedToken
+    )
+    if (-not $Exited) { return $false }
+    if ([string]::IsNullOrEmpty($StdoutContent)) { return $false }
+    return $StdoutContent.Contains($ExpectedToken)
+}
+
 function Test-Responsive {
     <#
     .SYNOPSIS
         Run a trivial command inside the distro with a hard timeout.
 
     .OUTPUTS
-        [bool] $true iff the distro returned a non-empty stdout before timeout.
+        [bool] $true iff the distro echoed the probe sentinel before timeout.
 
     .NOTES
         Uses Start-Process + WaitForExit($ms) rather than a job because
         background jobs survive PowerShell crashes and we want hard
         cleanup. The output is captured via a temp file because Start-Process
         cannot stream stdout from a hidden window directly.
+
+        The success decision is delegated to Test-ProbeSuccess: clean exit +
+        stdout containing the probe sentinel. It does NOT read the process exit
+        code (Start-Process -PassThru leaves it null under non-interactive
+        execution) -- see that helper for the full incident rationale.
     #>
     [CmdletBinding()]
     [OutputType([bool])]
@@ -192,18 +245,19 @@ function Test-Responsive {
     $stdoutFile = [System.IO.Path]::GetTempFileName()
     $stderrFile = [System.IO.Path]::GetTempFileName()
     try {
-        $args = @('-d', $Distro, '--', '/bin/sh', '-c', 'echo alive')
+        $args = @('-d', $Distro, '--', $script:ProbeCommand)
         $p = Start-Process -FilePath $WslExe -ArgumentList $args `
             -NoNewWindow -PassThru `
             -RedirectStandardOutput $stdoutFile `
             -RedirectStandardError $stderrFile
-        if (-not $p.WaitForExit($TimeoutSeconds * 1000)) {
-            try { $p.Kill() } catch { }
-            return $false
+        $exited = $p.WaitForExit($TimeoutSeconds * 1000)
+        if (-not $exited) { try { $p.Kill() } catch { } }
+        $out = if ($exited) {
+            Get-Content -LiteralPath $stdoutFile -Raw -ErrorAction SilentlyContinue
+        } else {
+            $null
         }
-        if ($p.ExitCode -ne 0) { return $false }
-        $out = (Get-Content -LiteralPath $stdoutFile -Raw -ErrorAction SilentlyContinue)
-        return -not [string]::IsNullOrWhiteSpace($out)
+        return (Test-ProbeSuccess -Exited $exited -StdoutContent $out -ExpectedToken $script:ProbeToken)
     } finally {
         Remove-Item -LiteralPath $stdoutFile -Force -ErrorAction SilentlyContinue
         Remove-Item -LiteralPath $stderrFile -Force -ErrorAction SilentlyContinue

--- a/docs/runbooks/wsl-keepalive-probe-fix.md
+++ b/docs/runbooks/wsl-keepalive-probe-fix.md
@@ -1,0 +1,106 @@
+# Runbook: WSL Keepalive Probe Fix & Fleet Rollout
+
+The Windows-side WSL keepalive watchdog (`deploy/wsl-keepalive.ps1`) could
+declare a perfectly healthy WSL distro "unresponsive" on every cycle. On hosts
+running the legacy **Watchdog** mode this drove a `wsl --shutdown` reboot loop
+that took the entire runner fleet (and the dashboard) offline repeatedly. This
+runbook explains the root cause, the fix, and how to roll it out consistently
+across every host.
+
+## Symptom
+
+- Runners on a host flap offline/online every minute or two; GitHub shows them
+  disconnecting and reconnecting.
+- `journalctl --list-boots` inside WSL shows many short boots minutes apart
+  (some only seconds long) instead of one long uptime.
+- `Get-ScheduledTaskInfo` shows the keepalive task restarting frequently.
+- The keepalive JSONL log (`%LOCALAPPDATA%\runner-dashboard\wsl-keepalive.log`)
+  is full of `unresponsive_detected` / `recovery_failed` (Watchdog) or
+  `unresponsive_no_wsl_reset` (Resident) events even though a direct
+  `wsl -d <distro> -- id` returns instantly.
+
+## Severity
+
+**P1** when a host is in Watchdog mode — the whole fleet on that host cycles
+offline. **P3** in Resident mode — no WSL reset, but health reporting and
+dashboard auto-recovery are broken.
+
+## Root cause
+
+`Test-Responsive` decided success two ways, both wrong:
+
+1. It gated on the probe process exit code (`$p.ExitCode`). But
+   `Start-Process -PassThru` does **not** populate the exit code when the
+   watchdog runs non-interactively (`powershell -File` from a scheduled task) —
+   it comes back `$null`, which compared as "non-zero" and failed every probe.
+2. The fallback "non-empty stdout" idea is also unsafe: `wsl.exe` writes its
+   _own_ errors (e.g. `There is no distribution with the supplied name.`) to
+   **stdout**, so even an offline distro yields output.
+
+Additionally the probe command `/bin/sh -c 'echo alive'` is split by
+`Start-Process -ArgumentList` (it does not quote multi-word elements), so it
+ran `sh -c echo` and produced no output regardless.
+
+## Fix (shipped in `deploy/wsl-keepalive.ps1`)
+
+- The probe runs a **single-token** command, `id` (no argument-splitting
+  hazard).
+- Success is decided by a pure, unit-tested helper `Test-ProbeSuccess`:
+  the probe must exit within the timeout **and** its stdout must contain the
+  sentinel `uid=` (always present in `id` output, never in wsl.exe
+  diagnostics). The process exit code is never consulted.
+
+Regression coverage: `tests/deploy/test_wsl_keepalive_script.py`
+(`test_probe_does_not_gate_on_process_exit_code`,
+`test_probe_success_helper_ignores_exit_code`).
+
+## Fleet rollout (do this on every host)
+
+The fix is universal; every host must pick it up and run the **Resident**
+keepalive task (which never resets WSL), not the legacy Watchdog task.
+
+1. **Update the deployed dashboard** so the host has the fixed script:
+
+   ```bash
+   bash deploy/update-deployed.sh --repo /path/to/runner-dashboard
+   ```
+
+2. **Install/refresh the Resident keepalive task**, passing the host's actual
+   distro name:
+
+   ```powershell
+   pwsh -File deploy\install-wsl-keepalive-task.ps1 -Distro <distro-name>
+   ```
+
+   This registers `RunnerDashboard-WSL-Resident-KeepAlive` in Resident mode
+   with startup + logon triggers.
+
+3. **Retire any legacy Watchdog task** (e.g. `WSL-Runner-KeepAlive`) so a host
+   never has two keepalives, and the destructive `wsl --shutdown` path is gone:
+
+   ```powershell
+   Stop-ScheduledTask    -TaskName 'WSL-Runner-KeepAlive' -ErrorAction SilentlyContinue
+   Unregister-ScheduledTask -TaskName 'WSL-Runner-KeepAlive' -Confirm:$false -ErrorAction SilentlyContinue
+   ```
+
+4. **Verify** on the host:
+
+   ```powershell
+   pwsh -File deploy\wsl-keepalive.ps1 -Once -Distro <distro-name> -Mode Resident `
+       -CheckIntervalSeconds 10 -ProbeTimeoutSeconds 5 -LogDir $env:TEMP\kpcheck
+   # expect: {"outcome":"healthy",...}
+   ```
+
+   Inside WSL, confirm uptime climbs steadily (`uptime -p`) and runners stay
+   `active`.
+
+## Consistency guardrails
+
+- The dashboard's keepalive inspector
+  (`backend/diagnostics/keepalive_inspector.py`) surfaces task state per host;
+  use it to spot hosts still on a legacy task or a stale script. Its
+  `WSL_KEEPALIVE_TASK_NAME` constant should track the Resident task name as
+  hosts migrate.
+- Never hand-edit the deployed `wsl-keepalive.ps1` on a host — that is how
+  copies drift from this canonical source. Always change `deploy/` and
+  redeploy via `update-deployed.sh`.

--- a/tests/deploy/test_wsl_keepalive_script.py
+++ b/tests/deploy/test_wsl_keepalive_script.py
@@ -118,6 +118,20 @@ def test_script_has_resident_mode_without_wsl_reset() -> None:
     assert "unresponsive_no_wsl_reset" in text
 
 
+def test_probe_does_not_gate_on_process_exit_code() -> None:
+    """Regression guard for the fleet-wide false-unresponsive bug.
+
+    ``Start-Process -PassThru`` leaves ``ExitCode`` null when the watchdog
+    runs non-interactively (scheduled task), so gating on ``$p.ExitCode -ne
+    0`` declared every healthy distro unresponsive. The probe must instead
+    decide success from clean exit + non-empty stdout via Test-ProbeSuccess.
+    """
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "function Test-ProbeSuccess" in text, "pure success helper missing"
+    assert "Test-ProbeSuccess -Exited" in text, "Test-Responsive must delegate to Test-ProbeSuccess"
+    assert "$p.ExitCode -ne 0" not in text, "probe must not gate on process exit code"
+
+
 def test_resident_task_installer_registers_no_reset_mode() -> None:
     text = INSTALLER.read_text(encoding="utf-8")
     assert "Register-ScheduledTask" in text
@@ -210,6 +224,43 @@ def test_backoff_helper_is_pure_and_capped(tmp_path: Path) -> None:
     assert max(samples) == 1800, samples
     # monotonic non-decreasing
     assert samples == sorted(samples), samples
+
+
+@PWSH_REQUIRED
+def test_probe_success_helper_ignores_exit_code(tmp_path: Path) -> None:
+    """Test-ProbeSuccess must judge on exit + sentinel token, never exit code.
+
+    R1 is the decisive regression case: a probe that exited and echoed the
+    sentinel is healthy even though no exit code is supplied at all -- exactly
+    the scheduled-task scenario where ExitCode came back $null and the old
+    gate spuriously failed. R2 covers the other half of the bug: wsl.exe
+    writes "no distribution" errors to STDOUT, so a dead distro yields
+    non-empty output that must NOT be read as healthy.
+    """
+    token = "uid="
+    healthy_stdout = "uid=1000(runner) gid=1000(runner) groups=1000(runner)"
+    dead_distro_stdout = "There is no distribution with the supplied name."
+    driver = textwrap.dedent(
+        f"""
+        . '{SCRIPT.as_posix()}' -Once -Distro 'noop' `
+            -CheckIntervalSeconds 10 -ProbeTimeoutSeconds 2 `
+            -Mode Resident `
+            -LogDir '{(tmp_path / "logs").as_posix()}' *> $null
+        $tok = '{token}'
+        $ok = '{healthy_stdout}'
+        $dead = '{dead_distro_stdout}'
+        Write-Output ('R1=' + (Test-ProbeSuccess -Exited $true -StdoutContent $ok -ExpectedToken $tok))
+        Write-Output ('R2=' + (Test-ProbeSuccess -Exited $true -StdoutContent $dead -ExpectedToken $tok))
+        Write-Output ('R3=' + (Test-ProbeSuccess -Exited $true -StdoutContent $null -ExpectedToken $tok))
+        Write-Output ('R4=' + (Test-ProbeSuccess -Exited $false -StdoutContent $ok -ExpectedToken $tok))
+        """
+    )
+    result = _run_ps(driver)
+    out = result.stdout
+    assert "R1=True" in out, result.stdout + result.stderr
+    assert "R2=False" in out, result.stdout
+    assert "R3=False" in out, result.stdout
+    assert "R4=False" in out, result.stdout
 
 
 @PWSH_REQUIRED


### PR DESCRIPTION
## Summary

The Windows-side WSL keepalive watchdog (`deploy/wsl-keepalive.ps1`) declared a **healthy** WSL distro "unresponsive" on every cycle, on every host. On hosts in the legacy **Watchdog** mode this drove a `wsl --shutdown` reboot loop that took the entire runner fleet (and the dashboard) offline repeatedly; in **Resident** mode it spammed false `unresponsive` reports and disabled dashboard auto-recovery.

### Root cause (two compounding bugs in `Test-Responsive`)
1. **Exit-code gate.** Success was gated on `$p.ExitCode`, but `Start-Process -PassThru` does **not** populate the exit code when the watchdog runs non-interactively (`powershell -File` from a scheduled task) — it comes back `$null`, which compared as "non-zero" and failed every probe. Verified on a live host: a direct `wsl -d WSL -- id` returns in ~94 ms with exit 0, while the `Start-Process` probe reported a null exit code even after a blocking `WaitForExit()`.
2. **Unsafe stdout fallback + broken probe command.** `wsl.exe` writes its *own* errors (e.g. `There is no distribution with the supplied name.`) to **stdout**, so a bare "non-empty stdout" check would treat an offline distro as healthy. And the probe command `/bin/sh -c 'echo alive'` was split by `Start-Process -ArgumentList` (it doesn't quote multi-word elements), so it actually ran `sh -c echo` and emitted nothing.

### Fix
- Probe now runs a **single-token** command, `id` (no argument-splitting hazard).
- Success is decided by a new pure, unit-tested helper `Test-ProbeSuccess`: the probe must exit within the timeout **and** its stdout must contain the sentinel `uid=` (always in `id` output, never in `wsl.exe` diagnostics). The process exit code is never consulted.
- Preserves the existing Watchdog/Resident architecture — no behavioural change beyond making the probe correct.

Validated end-to-end on a live host: `-Once -Distro WSL -Mode Resident` now returns `{"outcome":"healthy"}`; WSL uptime climbs steadily instead of cycling.

## Fleet rollout
This is the universal fix. New runbook `docs/runbooks/wsl-keepalive-probe-fix.md` documents migrating every host to the Resident keepalive task (`install-wsl-keepalive-task.ps1`) and retiring any legacy Watchdog task.

## Test plan
- [x] `pytest tests/deploy/test_wsl_keepalive_script.py` — 15 passed
- [x] New `test_probe_does_not_gate_on_process_exit_code` (static guard) and `test_probe_success_helper_ignores_exit_code` (behavioural: healthy `uid=` output passes, dead-distro stdout fails, null stdout fails, non-exit fails)
- [x] Live host: canonical script `-Once` reports healthy against the real distro

🤖 Generated with [Claude Code](https://claude.com/claude-code)