### PR TITLE
fix(deploy): reclaim docker under disk pressure so runner disks stop filling

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.41
-**Application Version:** 4.1.2 (see `VERSION`)
+**Spec Version:** 2.5.42
+**Application Version:** 4.1.3 (see `VERSION`)
 **Last Updated:** 2026-05-29T00:00:00-07:00
 **Status:** Active
 
@@ -502,6 +502,27 @@ distros in one shared utility VM. Two hardening steps keep them out of the
   and an `AtStartup` trigger. This keeps the host-side handle that holds the WSL
   VM resident across logoff, preventing the teardown that otherwise forces both
   distros to cold-boot together and race the 10s window.
+
+#### 2.3.2 Disk-pressure controls (`runner-cleanup.sh`)
+
+Docker (build cache + volumes + buildx builder containers) is the dominant disk
+consumer on runner hosts. Two controls keep a distro from filling to 100% (which
+crash-loops every runner with `No space left on device`):
+
+- **Aggressive docker prune under pressure.** When the root filesystem crosses
+  `DISK_PRESSURE_PERCENT` (default 85%), `runner-cleanup.sh` sets
+  `DOCKER_AGGRESSIVE=1`: it prunes **all** build cache (including `docker buildx`
+  builder caches), **all** unused images, and **dangling volumes**, ignoring the
+  routine `DOCKER_PRUNE_UNTIL` age window. Pruning only removes stopped
+  containers, unused images, dangling volumes, and idle cache, so running jobs
+  and in-use volumes are never affected. Below the threshold, the routine pass
+  keeps the age window so recent cache is preserved for build speed.
+- **Hourly disk guard.** `runner-cleanup.sh --disk-guard` is a lightweight,
+  runner-safe pass that reclaims docker + journal + `fstrim` **only** — it never
+  stops runner units, so `install-runner-maintenance.sh` schedules it on an
+  **hourly** `runner-disk-guard.timer` (the full cleanup, which bounces idle
+  runners to clear `_work`, stays daily). This catches docker bloat long before
+  the disk fills between daily cleanups.
 
 ---
 

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.1.2
+4.1.3

--- a/deploy/install-runner-maintenance.sh
+++ b/deploy/install-runner-maintenance.sh
@@ -92,6 +92,40 @@ Persistent=true
 WantedBy=timers.target
 TIMER
 
+# Disk guard: a lightweight, runner-safe pass that reclaims docker + journal +
+# fstrim ONLY (never bounces runner units), going aggressive on docker when the
+# filesystem crosses DISK_PRESSURE_PERCENT. Runs hourly so docker bloat is
+# reclaimed long before the disk fills between daily full cleanups. This is the
+# control that prevents recurrence of the 2026-05-29 nvme disk-full outage.
+sudo tee /etc/systemd/system/runner-disk-guard.service > /dev/null <<SERVICE
+[Unit]
+Description=Reclaim Docker/journal disk space under pressure (runner-safe)
+After=docker.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+User=root
+Environment=RUNNER_ROOT=${RUNNER_ROOT}
+Environment=RUNNER_ROOTS=${RUNNER_ROOTS}
+Environment=RUNNER_USER=${RUNNER_USER}
+Environment=DISK_PRESSURE_PERCENT=85
+ExecStart=/usr/local/bin/runner-cleanup --disk-guard
+SERVICE
+
+sudo tee /etc/systemd/system/runner-disk-guard.timer > /dev/null <<'TIMER'
+[Unit]
+Description=Run runner disk guard hourly
+
+[Timer]
+OnCalendar=hourly
+RandomizedDelaySec=5m
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMER
+
 sudo tee /etc/systemd/system/runner-scheduler.service > /dev/null <<SERVICE
 [Unit]
 Description=Apply scheduled GitHub runner capacity
@@ -192,7 +226,7 @@ Environment=TEXTFILE_COLLECTOR_DIR=${TEXTFILE_COLLECTOR_DIR}
 CONF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now runner-cleanup.timer runner-scheduler.timer runner-corruption-scan.timer runner-hooks-restore.timer
+sudo systemctl enable --now runner-cleanup.timer runner-disk-guard.timer runner-scheduler.timer runner-corruption-scan.timer runner-hooks-restore.timer
 
 # Apply (or re-apply) the per-unit drop-ins from #664. Idempotent.
 # Passes the installed hook dir explicitly so the drop-ins reference the
@@ -204,7 +238,7 @@ if [[ -x "${SCRIPT_DIR}/migrate-runner-units.sh" ]]; then
 fi
 
 echo "Installed:"
-systemctl list-timers runner-cleanup.timer runner-scheduler.timer runner-corruption-scan.timer --all
+systemctl list-timers runner-cleanup.timer runner-disk-guard.timer runner-scheduler.timer runner-corruption-scan.timer --all
 echo ""
 echo "Binaries:"
 ls -l /usr/local/bin/runner-cleanup /usr/local/bin/heal-host /usr/local/bin/runner-corruption-scan /usr/local/bin/runner-hooks-restore "${HOOK_INSTALL_DIR}"/ | grep -v '^total'

--- a/deploy/runner-cleanup.sh
+++ b/deploy/runner-cleanup.sh
@@ -23,6 +23,19 @@ JOURNAL_MAX_SIZE="${JOURNAL_MAX_SIZE:-1G}"
 DISK_PRESSURE_PERCENT="${DISK_PRESSURE_PERCENT:-85}"
 AGGRESSIVE_ON_PRESSURE="${AGGRESSIVE_ON_PRESSURE:-1}"
 PRUNE_DOCKER_VOLUMES="${PRUNE_DOCKER_VOLUMES:-0}"
+# Set to 1 automatically when disk pressure is detected (see main()). When on,
+# cleanup_docker() ignores age windows and reclaims ALL build cache (incl.
+# buildx builders), unused images, and dangling volumes. Docker is the dominant
+# space consumer on these hosts (build cache + volumes), and the routine
+# age-windowed prune alone let the disk fill to 100% between daily runs
+# (2026-05-29 nvme outage). Pruning never stops/removes running containers or
+# in-use volumes, so live jobs are unaffected.
+DOCKER_AGGRESSIVE="${DOCKER_AGGRESSIVE:-0}"
+# Disk-guard mode: a lightweight, runner-safe pass that reclaims docker +
+# journal + fstrim ONLY. It never stops runner units, so it is safe to run
+# frequently (hourly timer) to catch docker bloat long before the daily full
+# cleanup. The full cleanup still bounces idle runners to clear _work.
+DISK_GUARD="${DISK_GUARD:-0}"
 DRY_RUN="${DRY_RUN:-0}"
 COMPACT_VHD="${COMPACT_VHD:-0}"
 COMPACT_VHD_ONLY="${COMPACT_VHD_ONLY:-0}"
@@ -48,17 +61,24 @@ while [[ $# -gt 0 ]]; do
         --compact-vhd-distro)
             COMPACT_VHD_DISTRO="${2:?--compact-vhd-distro requires a value}"
             shift 2 ;;
+        --disk-guard)        DISK_GUARD=1; shift ;;
         --dry-run)           DRY_RUN=1; shift ;;
         -h|--help)
             cat <<'EOF'
 Usage: runner-cleanup.sh [--compact-vhd] [--compact-vhd-only]
-                         [--compact-vhd-distro NAME] [--dry-run]
+                         [--compact-vhd-distro NAME] [--disk-guard] [--dry-run]
 
 Environment overrides: RUNNER_ROOT, RUNNER_USER, LOG_DIR, RUNNER_WORK_DAYS,
 RUNNER_TEMP_DAYS, TOOL_CACHE_DAYS, DOCKER_PRUNE_UNTIL, JOURNAL_MAX_SIZE,
 DISK_PRESSURE_PERCENT, AGGRESSIVE_ON_PRESSURE, PRUNE_DOCKER_VOLUMES,
-COMPACT_VHD, COMPACT_VHD_ONLY, COMPACT_VHD_DISTRO, DRY_RUN.
+DOCKER_AGGRESSIVE, DISK_GUARD, COMPACT_VHD, COMPACT_VHD_ONLY,
+COMPACT_VHD_DISTRO, DRY_RUN.
 
+--disk-guard        Lightweight, runner-safe pass: reclaim docker + journal +
+                    fstrim ONLY (never stops runner units). Goes aggressive on
+                    docker when used% >= DISK_PRESSURE_PERCENT. Safe to run
+                    frequently (hourly timer) to keep docker bloat in check
+                    between the daily full cleanups.
 --compact-vhd       After cleanup, invoke scripts/compact-wsl-vhd.sh to
                     shrink the WSL2 ext4.vhdx back to Windows.
                     Requires UAC elevation on the Windows host.
@@ -345,10 +365,27 @@ cleanup_docker() {
         log "docker unavailable; skipping docker cleanup"
         return 0
     fi
-    run docker container prune --force --filter "until=72h"
-    run docker builder prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL}"
-    run docker image prune --force --filter "until=${DOCKER_PRUNE_UNTIL}"
-    [[ "$PRUNE_DOCKER_VOLUMES" == "1" ]] && run docker volume prune --force
+    if [[ "$DOCKER_AGGRESSIVE" == "1" ]]; then
+        # Disk pressure: reclaim everything reclaimable, ignoring age windows.
+        # `prune` only ever removes STOPPED containers, UNUSED images, DANGLING
+        # volumes, and idle build cache, so running jobs / in-use volumes /
+        # active buildx builders are never touched.
+        run docker container prune --force
+        run docker builder prune --all --force
+        # buildx builders keep their own cache pools; prune those too when the
+        # buildx plugin is present (the moby/buildkit builder containers on this
+        # host accumulate tens of GB of cache).
+        if docker buildx version >/dev/null 2>&1; then
+            run docker buildx prune --all --force
+        fi
+        run docker image prune --all --force
+        run docker volume prune --force
+    else
+        run docker container prune --force --filter "until=72h"
+        run docker builder prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL}"
+        run docker image prune --force --filter "until=${DOCKER_PRUNE_UNTIL}"
+        [[ "$PRUNE_DOCKER_VOLUMES" == "1" ]] && run docker volume prune --force
+    fi
 }
 
 cleanup_common_caches() {
@@ -397,12 +434,22 @@ main() {
     used="$(root_used_percent)"
     log "runner cleanup starting root_used=${used}% root_size=$(bytes_human "$before") dry_run=$DRY_RUN"
     if [[ "$AGGRESSIVE_ON_PRESSURE" == "1" && "$used" -ge "$DISK_PRESSURE_PERCENT" ]]; then
-        log "disk pressure detected; lowering retention windows"
+        log "disk pressure detected (${used}% >= ${DISK_PRESSURE_PERCENT}%); pruning docker aggressively and lowering retention windows"
         RUNNER_WORK_DAYS=0
         RUNNER_TEMP_DAYS=0
         TOOL_CACHE_DAYS=7
+        DOCKER_AGGRESSIVE=1
     fi
-    if [[ "$COMPACT_VHD_ONLY" != "1" ]]; then
+    if [[ "$DISK_GUARD" == "1" ]]; then
+        # Runner-safe fast pass: reclaim docker + journal + trim only. Never
+        # touches runner units, so it can run on a frequent timer without
+        # bouncing idle runners every pass. Goes aggressive on docker when the
+        # pressure block above fired.
+        log "disk-guard mode: docker + journal + fstrim only (no runner bounce)"
+        cleanup_docker
+        command -v journalctl >/dev/null 2>&1 && run journalctl --vacuum-size="$JOURNAL_MAX_SIZE"
+        command -v fstrim >/dev/null 2>&1 && run fstrim -av
+    elif [[ "$COMPACT_VHD_ONLY" != "1" ]]; then
         cleanup_runners
         cleanup_docker
         cleanup_common_caches

--- a/tests/deploy/test_runner_cleanup_disk_guard.py
+++ b/tests/deploy/test_runner_cleanup_disk_guard.py
@@ -1,0 +1,93 @@
+"""Tests for the disk-pressure docker controls in deploy/runner-cleanup.sh.
+
+Context: on 2026-05-29 the nvme WSL distro filled to 100% and every runner
+crash-looped on `No space left on device`. Root cause: the daily cleanup's
+disk-pressure path only shortened the runner _work/_temp retention windows; it
+never pruned docker harder, and docker (build cache + volumes + buildx builders)
+was the dominant consumer. These tests pin the controls that prevent recurrence:
+
+  1. Under disk pressure, docker is pruned aggressively (all build cache incl.
+     buildx, all unused images, dangling volumes) ignoring age windows.
+  2. A `--disk-guard` mode reclaims docker/journal/fstrim ONLY and never bounces
+     runner units, so it is safe to run on a frequent (hourly) timer.
+  3. The installer ships and enables an hourly runner-disk-guard timer.
+
+All static analysis — no bash execution, no Linux host required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DEPLOY = Path(__file__).resolve().parents[2] / "deploy"
+CLEANUP = DEPLOY / "runner-cleanup.sh"
+INSTALLER = DEPLOY / "install-runner-maintenance.sh"
+
+
+@pytest.fixture(scope="module")
+def cleanup_text() -> str:
+    assert CLEANUP.is_file(), f"missing {CLEANUP}"
+    return CLEANUP.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def installer_text() -> str:
+    assert INSTALLER.is_file(), f"missing {INSTALLER}"
+    return INSTALLER.read_text(encoding="utf-8")
+
+
+class TestAggressiveDockerUnderPressure:
+    def test_pressure_block_enables_aggressive_docker(self, cleanup_text: str) -> None:
+        """When used% >= DISK_PRESSURE_PERCENT the script must flip
+        DOCKER_AGGRESSIVE on, not just lower the _work retention windows."""
+        assert "DISK_PRESSURE_PERCENT" in cleanup_text
+        assert "DOCKER_AGGRESSIVE=1" in cleanup_text, "disk-pressure path must enable aggressive docker pruning"
+
+    def test_aggressive_branch_prunes_everything(self, cleanup_text: str) -> None:
+        """Aggressive mode must reclaim ALL build cache, unused images, and
+        dangling volumes (no age filter), plus buildx builder caches."""
+        assert 'if [[ "$DOCKER_AGGRESSIVE" == "1" ]]; then' in cleanup_text
+        # All build cache (no until= filter on the aggressive path).
+        assert "docker builder prune --all --force" in cleanup_text
+        assert "docker buildx prune --all --force" in cleanup_text
+        assert "docker image prune --all --force" in cleanup_text
+        assert "docker volume prune --force" in cleanup_text
+
+    def test_routine_path_keeps_age_window(self, cleanup_text: str) -> None:
+        """Non-pressure runs must still use the DOCKER_PRUNE_UNTIL age window so
+        recent build cache is preserved for build speed."""
+        assert "until=${DOCKER_PRUNE_UNTIL}" in cleanup_text
+
+
+class TestDiskGuardMode:
+    def test_disk_guard_flag_and_env(self, cleanup_text: str) -> None:
+        assert "--disk-guard)" in cleanup_text
+        assert 'DISK_GUARD="${DISK_GUARD:-0}"' in cleanup_text
+
+    def test_disk_guard_is_runner_safe(self, cleanup_text: str) -> None:
+        """The disk-guard branch must NOT call cleanup_runners (which stops/starts
+        idle runner units). It only reclaims docker + journal + fstrim."""
+        guard_idx = cleanup_text.index('if [[ "$DISK_GUARD" == "1" ]]; then')
+        elif_idx = cleanup_text.index("elif", guard_idx)
+        guard_block = cleanup_text[guard_idx:elif_idx]
+        assert "cleanup_runners" not in guard_block, "disk-guard must never bounce runner units"
+        assert "cleanup_docker" in guard_block
+        assert "journalctl --vacuum-size" in guard_block
+
+
+class TestInstallerShipsDiskGuardTimer:
+    def test_service_runs_disk_guard(self, installer_text: str) -> None:
+        assert "runner-disk-guard.service" in installer_text
+        assert "/usr/local/bin/runner-cleanup --disk-guard" in installer_text
+
+    def test_timer_is_hourly(self, installer_text: str) -> None:
+        assert "runner-disk-guard.timer" in installer_text
+        guard_timer_idx = installer_text.index("runner-disk-guard.timer")
+        # the timer heredoc with OnCalendar=hourly should appear near it
+        assert "OnCalendar=hourly" in installer_text[guard_timer_idx : guard_timer_idx + 600]
+
+    def test_timer_is_enabled(self, installer_text: str) -> None:
+        enable_lines = [ln for ln in installer_text.splitlines() if "enable --now" in ln]
+        assert any("runner-disk-guard.timer" in ln for ln in enable_lines), "runner-disk-guard.timer must be enabled"


### PR DESCRIPTION
## Problem

On 2026-05-29 the nvme WSL distro filled to **100%** and every runner crash-looped on `No space left on device` (the Node runner can't even write `_diag/Runner_*.log`). The existing cleanup *had* disk-pressure logic, but under pressure it only **shortened runner `_work`/`_temp` retention** — it never pruned docker harder. Docker was the dominant consumer (build cache ~23G, **99G of volumes**, plus ~9 stale `buildx_buildkit_builder` containers), and the full cleanup ran only **once a day** (`04:20`).

## Fix

- **Aggressive docker prune under pressure** (`runner-cleanup.sh`): when used% ≥ `DISK_PRESSURE_PERCENT` (85%), set `DOCKER_AGGRESSIVE=1` → prune **all** build cache (incl. `docker buildx` builder caches), **all** unused images, and **dangling volumes**, ignoring the routine `DOCKER_PRUNE_UNTIL` age window. Prune only removes stopped containers / unused images / dangling volumes / idle cache, so **running jobs and in-use volumes are never touched**. Below threshold, the routine pass keeps the age window for build-cache reuse.
- **Hourly disk guard** (`runner-cleanup.sh --disk-guard` + `install-runner-maintenance.sh`): a lightweight, **runner-safe** pass that reclaims docker + journal + `fstrim` **only** — it never stops runner units, so it runs on a new **hourly** `runner-disk-guard.timer`. The full cleanup (which bounces idle runners to clear `_work`) stays daily. This catches docker bloat long before the disk fills.

## Why this is the right shape

`cleanup_runners` stops→cleans→restarts *idle* runner units, so running the full cleanup hourly would needlessly bounce idle runners every hour. Splitting out a docker-only guard lets us reclaim the dominant consumer frequently with **zero runner disruption**.

## Tests

`tests/deploy/test_runner_cleanup_disk_guard.py` (static contract):
- pressure path flips `DOCKER_AGGRESSIVE=1`; aggressive branch prunes all build cache + buildx + unused images + dangling volumes
- routine path retains the `DOCKER_PRUNE_UNTIL` window
- disk-guard branch never calls `cleanup_runners` (runner-safe)
- installer ships + enables an hourly `runner-disk-guard.timer` running `--disk-guard`

`81 passed` in tests/deploy. SPEC 2.5.41→2.5.42 (new §2.3.2), VERSION 4.1.2→4.1.3.

## Test plan
- [ ] CI green
- [ ] After merge: run `deploy/install-runner-maintenance.sh` on ControlTower to install the hourly disk-guard timer (and pick up the aggressive-prune cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)