### PR TITLE
fix(keepalive): pin the distro with a persistent session so the idle fleet stays online

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -5,6 +5,18 @@
 **Last Updated:** 2026-05-29T00:00:00-07:00
 **Status:** Active
 
+- **2026-05-29 (2.5.44):** Keep the WSL distro resident between keepalive probes
+  so the idle runner fleet stays online. A WSL2 distro is torn down a few seconds
+  after the last active `wsl.exe` session ends; in-distro systemd services
+  (including `wsl-runner-keepalive.service`'s `sleep 600`) do not keep it alive,
+  and the watchdog's periodic probe attaches/detaches each cycle, so an idle host
+  let the distro terminate between probes and dropped every runner offline.
+  `deploy/wsl-keepalive.ps1` now maintains exactly one persistent
+  `wsl --exec /bin/sleep infinity` session (new `Set-DistroPin` helper, called
+  every loop and restarted if a shutdown kills it). Complements #784 (correct
+  probe) and #783 (S4U task survives logoff; docker boot decouple) — neither
+  keeps the distro resident between probes. New static regression test
+  `test_script_pins_distro_with_persistent_session`.
 - **2026-05-29 (2.5.43):** Hardened autoscaler scale-down against undeployed
   runner drain drop-ins (issue #785). Before `backend/autoscaler_systemd.py`
   calls `systemctl stop` for any `actions.runner.*` unit, it now verifies the

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.1.3
+4.1.4

--- a/deploy/wsl-keepalive.ps1
+++ b/deploy/wsl-keepalive.ps1
@@ -634,6 +634,77 @@ if ($Once) {
     exit 0
 }
 
+function Set-DistroPin {
+    <#
+    .SYNOPSIS
+        Ensure exactly one persistent ``wsl --exec sleep infinity`` session is
+        attached to ``$Distro``, (re)starting it if absent.
+
+    .DESCRIPTION
+        A WSL2 distro is torn down a few seconds after the last ACTIVE
+        ``wsl.exe`` session ends. Background systemd services inside the distro
+        (even the ``wsl-runner-keepalive.service`` ``sleep 600`` unit) do NOT
+        keep it alive — only a host-side session does. The periodic probe in
+        this watchdog attaches and detaches each cycle, so on an idle host the
+        distro terminates between probes and the whole runner fleet drops
+        offline (runners only stay registered while the distro runs). Long jobs
+        masked this because a running job holds its own session.
+
+        Confirmed on OGLaptop 2026-05-29: with only the periodic probe, pid 1
+        (systemd) uptime stayed ~7-8s across samples 45s apart (the distro
+        re-initialised every cycle); a single persistent ``sleep infinity``
+        session made uptime climb monotonically and all 8 runners stay online.
+
+        Complements #783 (the S4U keepalive task survives logoff so THIS script
+        keeps running) and #784 (correct probe): neither keeps the distro
+        resident between probes — this does.
+
+    .OUTPUTS
+        [bool] $true if a pin session is present (already or newly started).
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)][string]$Distro,
+        [Parameter(Mandatory)][string]$LogPath,
+        [Parameter(Mandatory)][int]$MaxBytes,
+        [Parameter(Mandatory)][int]$Backups,
+        [string]$WslExe = 'wsl.exe'
+    )
+    $pinned = $false
+    try {
+        foreach ($wp in (Get-CimInstance Win32_Process -Filter "Name='wsl.exe'" -ErrorAction Stop)) {
+            if ($wp.CommandLine -and $wp.CommandLine -like "*$Distro*" -and $wp.CommandLine -like "*sleep*infinity*") {
+                $pinned = $true
+                break
+            }
+        }
+    } catch {
+        # CIM unavailable -> fall through and (re)start a pin defensively.
+    }
+    if (-not $pinned) {
+        try {
+            Start-Process -FilePath $WslExe `
+                -ArgumentList @('-d', $Distro, '--exec', '/bin/sleep', 'infinity') `
+                -WindowStyle Hidden -ErrorAction Stop | Out-Null
+            Write-EventLine -LogPath $LogPath -MaxBytes $MaxBytes -Backups $Backups -Event @{
+                level = 'info'
+                event = 'distro_pin_started'
+                distro = $Distro
+            }
+            $pinned = $true
+        } catch {
+            Write-EventLine -LogPath $LogPath -MaxBytes $MaxBytes -Backups $Backups -Event @{
+                level = 'warn'
+                event = 'distro_pin_failed'
+                distro = $Distro
+                message = $_.Exception.Message
+            }
+        }
+    }
+    return $pinned
+}
+
 # Continuous mode: scheduled-task entry point.
 Write-EventLine -LogPath $LogPath -MaxBytes $MaxLogBytes -Backups $LogBackups -Event @{
     level = 'info'
@@ -647,6 +718,11 @@ Write-EventLine -LogPath $LogPath -MaxBytes $MaxLogBytes -Backups $LogBackups -E
 
 while ($true) {
     try {
+        # Keep the distro resident so the idle fleet stays online (see
+        # Set-DistroPin). Runs every cycle so a pin killed by a shutdown is
+        # re-established on the next pass.
+        $null = Set-DistroPin -Distro $Distro -LogPath $LogPath -MaxBytes $MaxLogBytes -Backups $LogBackups
+
         $result = Invoke-OneCycle `
             -Distro $Distro `
             -ProbeTimeoutSeconds $ProbeTimeoutSeconds `

--- a/tests/deploy/test_wsl_keepalive_script.py
+++ b/tests/deploy/test_wsl_keepalive_script.py
@@ -118,6 +118,19 @@ def test_script_has_resident_mode_without_wsl_reset() -> None:
     assert "unresponsive_no_wsl_reset" in text
 
 
+def test_script_pins_distro_with_persistent_session() -> None:
+    """The idle fleet stays online only if a host-side session keeps the distro
+    resident. Periodic probes attach/detach and let the distro idle-terminate
+    between cycles; a persistent ``wsl --exec sleep infinity`` session does not.
+    Regression guard: the watchdog loop must maintain that pin.
+    """
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "function Set-DistroPin" in text, "distro pin helper missing"
+    assert "Set-DistroPin -Distro" in text, "main loop must call Set-DistroPin every cycle"
+    assert "'/bin/sleep', 'infinity'" in text, "pin must hold a persistent sleep-infinity session"
+    assert "distro_pin_started" in text, "pin (re)starts should be logged"
+
+
 def test_probe_does_not_gate_on_process_exit_code() -> None:
     """Regression guard for the fleet-wide false-unresponsive bug.
 


### PR DESCRIPTION
## Summary

Captures the one piece of the OGLaptop runner-fleet stability fix that the recent merged work does **not** yet cover: **keeping the WSL distro resident between probes**.

A WSL2 distro is torn down a few seconds after the last **active `wsl.exe` session** ends. The in-distro systemd services — including `wsl-runner-keepalive.service`'s `while true; sleep 600` — do **not** keep it alive; only a host-side session does. The watchdog's periodic probe attaches and detaches each cycle, so on an **idle** host the distro terminates between probes and every runner drops offline (a runner only stays registered while its distro runs). Long-running CI jobs masked this because a running job holds its own session.

### Fix
The watchdog loop now maintains exactly one persistent `wsl --exec /bin/sleep infinity` session (new `Set-DistroPin` helper), re-establishing it if a shutdown kills it. Adds a static regression test.

### Verified on OGLaptop
- Periodic probe only → `pid 1` (systemd) uptime stayed ~7–8s across samples 45s apart (the distro re-initialised every cycle), runners offline.
- With the pin → uptime climbs monotonically, **all 8 runners stay online while idle**.

## How this fits the recent fleet work (reviewed in detail)

| PR | What it fixed | Relationship |
|----|---------------|--------------|
| **#784** | Probe false-flagged healthy distros (null `ExitCode` + split probe command) → `id`/`uid=` + `Test-ProbeSuccess` | ✅ This PR sits on top of it (correct probe). |
| **#783** | Split-disk distros crash-looping at boot (docker boot decouple + timer) **and** keepalive task dying at logoff (S4U principal so the task survives logoff) | ✅ Complementary. #783 keeps the **task** running across logoff; this keeps the **distro** resident between the task's probes. |
| **#787** | Autoscaler refuses unsafe scale-down (requires `KillMode=mixed` + `TimeoutStopUSec≥120s`) | ✅ Independent; both needed. |

I deliberately **dropped** the other changes from this branch's first revision (a `/health → /api/health` swap — both return 200, so it was wrong — and a probe-timeout bump that's redundant once the probe is correct and the distro stays warm) so this PR is surgical.

## Operational follow-ups for OGLaptop (not in this PR)

The live OGLaptop host was running a **hand-patched legacy `C:\Users\diete\wsl-keepalive.ps1`**, not the canonical script. To make live == repo:
1. **Redeploy the canonical keepalive** via `deploy/install-wsl-keepalive-task.ps1` (S4U) so it picks up #784's probe + #783's logoff fix + this pin. (I patched the live copy with the pin already, so the fleet is stable now, but it should be reconciled to the installer.)
2. **Apply #783's `deploy/decouple-docker-boot.sh`** (I used a temporary `docker.service` `After=multi-user.target` drop-in to get boot < 10s; #783's script + `docker-delayed-start.timer` is the canonical version and gets boot to ~1.5s).
3. **Recommendation worth a maintainer decision:** flip the script's default `-Mode` from `Watchdog` to `Resident`. #784's runbook already migrates every host to Resident; defaulting to it would prevent a future un-migrated host from re-entering the `wsl --shutdown` reboot loop that corrupted this host's ext4 filesystem (root-caused separately: 415 hard VM kills → `e2fsck` found 48 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
