### PR TITLE
fix(queue): count job-level queued depth so /api/queue stops undercounting

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -811,12 +811,12 @@ env var.
 
 ### Queue
 
-| Method | Path                         | Description                                                                   |
-| ------ | ---------------------------- | ----------------------------------------------------------------------------- |
-| GET    | `/api/queue`                 | Current job queue (queued + in_progress)                                      |
-| GET    | `/api/queue/status`          | Queue data with per-run `timing` breakdown (queue_wait_seconds, exec_seconds) |
-| POST   | `/api/queue/cancel-workflow` | Cancel a queued workflow                                                      |
-| GET    | `/api/queue/diagnose`        | Diagnose queue stalls and blockages                                           |
+| Method | Path                         | Description                                                                                                                                                                                     |
+| ------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/queue`                 | Current job queue (queued + in_progress). Includes `queued_jobs_count` — true job-level queue depth, counting `queued` jobs inside in_progress runs too (run-level `queued_count` misses them). |
+| GET    | `/api/queue/status`          | Queue data with per-run `timing` breakdown (queue_wait_seconds, exec_seconds)                                                                                                                   |
+| POST   | `/api/queue/cancel-workflow` | Cancel a queued workflow                                                                                                                                                                        |
+| GET    | `/api/queue/diagnose`        | Diagnose queue stalls and blockages                                                                                                                                                             |
 
 ### Push Notifications
 

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.1.2
+4.2.0

--- a/backend/routers/queue.py
+++ b/backend/routers/queue.py
@@ -82,6 +82,7 @@ def _empty_queue_result() -> dict:
         "in_progress": [],
         "total": 0,
         "queued_count": 0,
+        "queued_jobs_count": 0,
         "in_progress_count": 0,
     }
 
@@ -135,6 +136,63 @@ async def _fetch_repo_runs(
         if "repository" not in run or not run["repository"]:
             run["repository"] = {"name": repo_name}
     return runs
+
+
+async def _count_queued_jobs_for_run(run: dict) -> int:
+    """Return the number of ``queued`` jobs inside a single workflow run.
+
+    GitHub Actions queues at the JOB level, not the run level: a multi-job run
+    flips its run-level status to ``in_progress`` the moment its first job
+    starts, while sibling jobs stay ``queued``. Counting only run-level
+    ``status == "queued"`` therefore undercounts true queue depth (those
+    queued sibling jobs become invisible). This helper fetches the run's jobs
+    and counts the ones still waiting for a runner.
+
+    On any failure (missing repo/id, gh api error, parse error) it raises so
+    the caller can fall back to the run-level assumption rather than silently
+    contributing 0 — mirroring the partial-failure handling in ``_queue_impl``.
+    """
+    repo_name = (run.get("repository") or {}).get("name")
+    run_id = run.get("id")
+    if not repo_name or run_id is None:
+        raise RuntimeError(f"run missing repo/id for job-level count: {run_id!r}")
+    repo_name = validate_repo_slug(repo_name)
+    rc, out, err = await run_cmd(
+        [
+            "gh",
+            "api",
+            f"/repos/{ORG}/{repo_name}/actions/runs/{run_id}/jobs?per_page=100",
+        ],
+        timeout=30,
+    )
+    if rc != 0:
+        raise RuntimeError(f"gh api jobs failed for {repo_name}#{run_id}: rc={rc} {err[:200]!r}")
+    jobs = json.loads(out).get("jobs", [])
+    return sum(1 for job in jobs if job.get("status") == "queued")
+
+
+async def _count_queued_jobs(runs: list[dict]) -> int:
+    """Aggregate job-level queued depth across active runs.
+
+    Fetches each run's jobs concurrently with ``return_exceptions=True`` so one
+    run's transient failure cannot zero the total. For any run whose job fetch
+    fails, we fall back to counting it as a single queued job if its run-level
+    status is ``queued`` (preserving the legacy lower bound), otherwise 0.
+    """
+    if not runs:
+        return 0
+    results = await asyncio.gather(
+        *[_count_queued_jobs_for_run(run) for run in runs],
+        return_exceptions=True,
+    )
+    total = 0
+    for run, result in zip(runs, results, strict=True):
+        if isinstance(result, BaseException):
+            log.warning("queued-jobs count failed for run %s: %r", run.get("id"), result)
+            total += 1 if run.get("status") == "queued" else 0
+        else:
+            total += result
+    return total
 
 
 # Cache TTL kept at 60s (down from 120s) so partial failures heal faster.
@@ -219,11 +277,18 @@ async def _queue_impl() -> dict:
         key=lambda r: r.get("run_started_at") or r.get("created_at", ""),
     )
 
+    # Job-level queue depth: count `queued` jobs across BOTH queued runs and
+    # in_progress runs (the latter can still have queued sibling jobs that the
+    # run-level `queued_count` misses). This is the figure the operator cares
+    # about — how many jobs are actually waiting for a runner.
+    queued_jobs_count = await _count_queued_jobs(queued + in_progress)
+
     payload: dict[Any, Any] = {
         "queued": queued,
         "in_progress": in_progress,
         "total": len(queued) + len(in_progress),
         "queued_count": len(queued),
+        "queued_jobs_count": queued_jobs_count,
         "in_progress_count": len(in_progress),
         "stats": {
             "repos_sampled": len(sample),

--- a/tests/api/test_queue_job_level_count.py
+++ b/tests/api/test_queue_job_level_count.py
@@ -1,0 +1,125 @@
+"""Tests for job-level queue depth in GET /api/queue.
+
+Root cause (Runner_Dashboard queue undercount): GitHub Actions queues at the
+JOB level, but ``/api/queue`` historically counted only at the workflow-RUN
+level using ``?status=queued``. A multi-job run flips its run-level status to
+``in_progress`` the instant its first job starts, while sibling jobs remain
+``queued`` — those queued jobs then vanish from the dashboard's count.
+
+These tests pin the additive ``queued_jobs_count`` field, which reflects true
+job-level queue depth (including queued jobs nested inside ``in_progress``
+runs), while leaving the legacy run-level ``queued_count`` untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+
+def _run(repo: str, run_id: int, status: str) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "status": status,
+        "name": "ci",
+        "created_at": "2026-05-29T10:00:00Z",
+        "run_started_at": "2026-05-29T10:01:00Z",
+        "repository": {"name": repo},
+    }
+
+
+def _jobs_payload(statuses: list[str]) -> str:
+    return json.dumps({"jobs": [{"id": i, "status": s} for i, s in enumerate(statuses)]})
+
+
+@pytest.fixture
+def queue_app(monkeypatch):
+    """Build a tiny app around the queue router and stub gh api calls."""
+    from routers import queue as queue_router  # noqa: PLC0415
+
+    # Avoid serving cached results from a previous test run.
+    monkeypatch.setattr(queue_router, "cache_get", lambda *a, **k: None)
+    monkeypatch.setattr(queue_router, "cache_set", lambda *a, **k: None)
+
+    # One repo with two active runs:
+    #   - run 100: run-level "queued"      -> 1 queued job
+    #   - run 200: run-level "in_progress" -> but 2 of its 3 jobs are STILL queued
+    # Run-level queued_count == 1; true job-level queued depth == 3.
+    async def fake_run_cmd(cmd: list[str], timeout: int = 30, cwd=None):  # noqa: ANN001, ARG001
+        url = cmd[-1]
+        if "/orgs/" in url and "/repos" in url:
+            return (0, json.dumps([{"name": "RepoA"}]), "")
+        if "/jobs" in url:
+            if "/100/jobs" in url:
+                return (0, _jobs_payload(["queued"]), "")
+            if "/200/jobs" in url:
+                return (0, _jobs_payload(["in_progress", "queued", "queued"]), "")
+            return (0, _jobs_payload([]), "")
+        if "status=queued" in url:
+            return (0, json.dumps({"workflow_runs": [_run("RepoA", 100, "queued")]}), "")
+        if "status=in_progress" in url:
+            return (0, json.dumps({"workflow_runs": [_run("RepoA", 200, "in_progress")]}), "")
+        return (0, json.dumps({"workflow_runs": []}), "")
+
+    monkeypatch.setattr(queue_router, "run_cmd", fake_run_cmd)
+
+    app = FastAPI()
+    app.include_router(queue_router.router)
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def test_queue_surfaces_job_level_queued_depth(queue_app: TestClient) -> None:
+    resp = queue_app.get("/api/queue")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Legacy run-level count is unchanged (1 run with run-level status=queued).
+    assert data["queued_count"] == 1
+
+    # New field reflects true job-level depth: 1 queued job in the queued run
+    # PLUS 2 queued jobs hidden inside the in_progress run.
+    assert data["queued_jobs_count"] == 3
+
+
+def test_queue_job_count_falls_back_when_jobs_fetch_fails(monkeypatch) -> None:
+    """If the per-run jobs fetch fails, we must not zero the queued depth."""
+    from routers import queue as queue_router  # noqa: PLC0415
+
+    monkeypatch.setattr(queue_router, "cache_get", lambda *a, **k: None)
+    monkeypatch.setattr(queue_router, "cache_set", lambda *a, **k: None)
+
+    async def fake_run_cmd(cmd: list[str], timeout: int = 30, cwd=None):  # noqa: ANN001, ARG001
+        url = cmd[-1]
+        if "/orgs/" in url and "/repos" in url:
+            return (0, json.dumps([{"name": "RepoA"}]), "")
+        if "/jobs" in url:
+            return (1, "", "boom")  # jobs fetch fails
+        if "status=queued" in url:
+            return (0, json.dumps({"workflow_runs": [_run("RepoA", 100, "queued")]}), "")
+        if "status=in_progress" in url:
+            return (0, json.dumps({"workflow_runs": []}), "")
+        return (0, json.dumps({"workflow_runs": []}), "")
+
+    monkeypatch.setattr(queue_router, "run_cmd", fake_run_cmd)
+
+    app = FastAPI()
+    app.include_router(queue_router.router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    data = client.get("/api/queue").json()
+    # Falls back to at least the run-level queued count (never silently 0).
+    assert data["queued_jobs_count"] >= data["queued_count"] == 1


### PR DESCRIPTION
## Root cause

The operator reported the dashboard undercounts queued jobs. Confirmed: `GET /api/queue` (`_queue_impl` / `_fetch_repo_runs` in `backend/routers/queue.py`) counts at the **workflow-RUN** level using GitHub's `?status=queued` filter on `/repos/{org}/{repo}/actions/runs`.

But GitHub Actions queues at the **JOB** level. A multi-job workflow run flips its run-level status to `in_progress` the instant its first job starts, while sibling jobs remain `queued`. Those queued jobs then disappear from the dashboard's `queued_count`, because the run they belong to is no longer counted as queued.

## Empirical evidence (measured live against http://localhost:8321 on 2026-05-29)

- Live `/api/queue` reported `queued_count=1`, `in_progress_count=9`.
- Cross-checking each active run's `/actions/runs/{id}/jobs`:
  - A snapshot caught `Maxwell_Daemon` run `26666784888` (run-level `queued`) holding a queued job that the run-level filter happened to catch — but several multi-job `in_progress` runs (e.g. `Gasification_Model` run `26671889407` with 8 completed + 7 in_progress jobs, `Tools_Private` `26671890528` with 5 completed + 3 in_progress) are exactly the shape that hides queued siblings once load is higher.
- The undercount is **bursty**: at a shallow-queue instant the gap is 0, but under matrix / multi-job load the run-level count structurally cannot see queued jobs nested in `in_progress` runs. The bug is in the counting model, not a transient.

## Fix (minimal, additive, orthogonal)

- New helper `_count_queued_jobs` fetches each active run's jobs (for **both** `queued` and `in_progress` runs) concurrently and counts `status == "queued"` jobs.
- New `queued_jobs_count` field on the `/api/queue` payload surfaces true job-level depth.
- Legacy run-level `queued_count` is **unchanged** — existing callers keep working (additive schema change, reversible).
- Per-run job fetches use `return_exceptions=True` and fall back to the run-level lower bound on failure, so one failed fetch can never zero the count (same defensive pattern as the #641 queue-drops-to-zero fix).

## Tests (TDD — written first, observed failing on `KeyError: 'queued_jobs_count'`)

`tests/api/test_queue_job_level_count.py`:
- `test_queue_surfaces_job_level_queued_depth` — 1 queued run (1 job) + 1 in_progress run hiding 2 queued jobs ⇒ `queued_count==1`, `queued_jobs_count==3`.
- `test_queue_job_count_falls_back_when_jobs_fetch_fails` — jobs fetch failing must not zero the depth.

Full queue suite green: `19 passed` (`tests/api/test_queue_job_level_count.py tests/test_queue_router.py tests/api/test_queue_stale_routes.py`). `ruff check` + `ruff format --check` clean.

SPEC.md updated (Queue endpoint table) and VERSION bumped 4.1.2 → 4.2.0 (additive feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)