### PR TITLE
chore(deploy): ensure runner-unit hardening (KillMode=mixed) on every deploy

### DIFF
--- a/deploy/update-deployed.sh
+++ b/deploy/update-deployed.sh
@@ -158,6 +158,51 @@ if ! dry_run "sudo systemctl restart $SERVICE"; then
     sudo systemctl restart "$SERVICE"
 fi
 
+# ── Ensure runner-unit hardening is present (idempotent) ─────────────────────
+# Hosts set up before deploy/migrate-runner-units.sh existed — or where
+# install-runner-maintenance.sh never ran — silently keep the runner units on
+# KillMode=process. On stop that orphans Runner.Worker children and abruptly
+# kills in-flight jobs instead of draining them. migrate-runner-units.sh writes
+# the KillMode=mixed + TimeoutStopSec=120 drop-ins; re-applying it on every
+# deploy means the hardening can never be silently missing on a host. It does
+# NOT restart any unit, so a busy runner's job is never interrupted — the
+# drop-in takes effect on the unit's next natural restart.
+ensure_runner_hardening() {
+    local migrate; migrate="$(dirname "$0")/migrate-runner-units.sh"
+    if [[ ! -x "$migrate" ]]; then
+        warn "migrate-runner-units.sh not found; skipping runner-unit hardening check"
+        return 0
+    fi
+
+    local missing=0 unit dropin
+    while IFS= read -r unit; do
+        [[ -n "$unit" ]] || continue
+        dropin="/etc/systemd/system/${unit}.d/10-runner-dashboard-busy-lock.conf"
+        grep -qs 'KillMode=mixed' "$dropin" || missing=1
+    done < <(systemctl list-unit-files --type=service --no-legend 2>/dev/null \
+        | awk '$1 ~ /^actions\.runner\..*\.service$/ {print $1}')
+
+    if [[ "$missing" == "0" ]]; then
+        ok "Runner units already hardened (KillMode=mixed drop-ins present)"
+        return 0
+    fi
+
+    if dry_run "sudo $migrate (apply KillMode=mixed runner hardening)"; then
+        return 0
+    fi
+    if sudo -n true 2>/dev/null; then
+        info "Applying runner-unit hardening (KillMode=mixed, TimeoutStopSec=120; no unit restart)..."
+        if sudo bash "$migrate"; then
+            ok "Runner-unit hardening applied (effective on each unit's next restart)"
+        else
+            warn "migrate-runner-units.sh failed; runner units may still be on KillMode=process"
+        fi
+    else
+        warn "Runner units missing KillMode=mixed hardening — run: sudo deploy/migrate-runner-units.sh"
+    fi
+}
+ensure_runner_hardening
+
 # ── Health-gate: verify service came up ──────────────────────────────────────
 _check_health() {
     curl -fsS --max-time 10 "http://localhost:${DASHBOARD_PORT}/health" >/dev/null 2>&1

--- a/tests/test_today_deploy_hardening.py
+++ b/tests/test_today_deploy_hardening.py
@@ -79,6 +79,30 @@ def test_migrate_runner_units_sets_kill_mode_mixed() -> None:
     assert "KillMode=mixed" in src, "drop-in must set KillMode=mixed"
 
 
+def test_update_deployed_ensures_runner_hardening() -> None:
+    """Routine deploys must re-apply the runner-unit hardening so a host
+    can never silently run KillMode=process.
+
+    install-runner-maintenance.sh applies the KillMode=mixed drop-ins, but
+    hosts set up before it existed (or where it never ran) keep
+    KillMode=process — which orphans Runner.Worker children and abruptly
+    kills in-flight jobs on stop. update-deployed.sh must idempotently
+    ensure the drop-ins exist on every deploy, without restarting busy
+    units (the drop-in takes effect on the unit's next natural restart).
+    Observed 2026-05-29 on DeskComputer: its runner units lacked the
+    drop-in entirely because no deploy step ever ensured it.
+    """
+    src = _read(_DEPLOY / "update-deployed.sh")
+    assert "ensure_runner_hardening" in src, "deploy must call ensure_runner_hardening"
+    assert "migrate-runner-units.sh" in src, "hardening must be applied via migrate-runner-units.sh"
+    assert "10-runner-dashboard-busy-lock.conf" in src, "must check for the drop-in file"
+    assert "KillMode=mixed" in src, "must verify KillMode=mixed presence"
+    # Must NOT restart units (busy runners are running jobs).
+    assert "--restart-units" not in src.split("ensure_runner_hardening()")[1].split("\n}")[0], (
+        "ensure_runner_hardening must not pass --restart-units (would kill in-flight jobs)"
+    )
+
+
 def test_migrate_runner_units_passes_unit_name_via_specifier() -> None:
     """The ExecStop= drop-in must pass %n (full unit name) to
     force-drain.sh as $1. systemd does NOT export $SYSTEMD_UNIT to


### PR DESCRIPTION
## Summary

Runner units need `KillMode=mixed` + `TimeoutStopSec=120` so that on stop they **drain the in-flight job and reap `Runner.Worker` children** instead of orphaning them and abruptly killing the job. `deploy/migrate-runner-units.sh` already writes those drop-ins — but it's only invoked from `install-runner-maintenance.sh`. Hosts set up before that existed, or where it never ran, silently keep `KillMode=process`.

This makes `update-deployed.sh` **idempotently ensure** the hardening on every deploy:
- Checks each `actions.runner.*.service` for the `10-runner-dashboard-busy-lock.conf` drop-in with `KillMode=mixed`.
- If any is missing, re-applies `migrate-runner-units.sh` (which writes the drop-ins + `daemon-reload`).
- **Never passes `--restart-units`** — a busy runner's job is never interrupted; the drop-in takes effect on the unit's next natural restart.
- When `sudo -n` isn't available, prints the exact remediation command instead of failing the deploy.

### Why now
Observed 2026-05-29 on **DeskComputer**: all 8 runner units were on `KillMode=process` / `TimeoutStopSec=5min` because no routine deploy step ever ensured the migration. Applying it by hand fixed the host; this PR prevents the gap fleet-wide.

## Test plan
- [x] `pytest tests/test_today_deploy_hardening.py` — 31 passed (added `test_update_deployed_ensures_runner_hardening`)
- [x] `bash -n deploy/update-deployed.sh` — syntax OK
- [x] Verified on DeskComputer: `migrate-runner-units.sh` applied `KillMode=mixed` + `TimeoutStopSec=120` to all 8 units (effective `KillMode=mixed`, `TimeoutStopUSec=2min`) with no unit restart while 5/8 runners were mid-job

🤖 Generated with [Claude Code](https://claude.com/claude-code)