### PR TITLE
fix(deploy): per-runner Python tool-cache isolation to end shared-cache corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Per-runner Python tool-cache isolation (`deploy/migrate-runner-units.sh`):
+  every `actions.runner.*.service` drop-in now exports a private
+  `RUNNER_TOOL_CACHE` (default `<WorkingDirectory>/_work/_tool`, overridable via
+  `RUNNER_TOOL_CACHE_ROOT`). This eliminates the shared-`.shared-tool-cache`
+  race where concurrent jobs on one host corrupted `actions/setup-python`
+  ("Directory not empty", exit-127 "python: command not found",
+  "ModuleNotFoundError: No module named 'http'"). `deploy/runner-cleanup.sh`
+  already GCs `_work/_tool`, so the private caches stay bounded.
+- `deploy/runner-corruption-scan.sh` now emits a third Prometheus signal,
+  `kind="python_toolcache"`, counting incomplete Python tool-cache trees
+  (a `<version>/<arch>` dir missing the toolkit's `.complete` marker) so the
+  fleet can watch the corruption trend toward zero after rollout.
 - Corrected broken issue reference `#944` to `#161` in `pyproject.toml` and CI workflow.
 - Restored missing `PROVIDERS_WITH_MODEL` definition in frontend bundle.
 - Removed stale `agent_remediation_140.py` from repo root and added `/*_[0-9]*.py` to `.gitignore`.

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.2.0
+4.2.1

--- a/deploy/migrate-runner-units.sh
+++ b/deploy/migrate-runner-units.sh
@@ -18,6 +18,13 @@
 #      Environment=RUNNER_NAME=<unit-derived> — so the hooks know which
 #      runner they belong to. The hook scripts maintain a lockfile that
 #      both the autoscaler and cleanup consult as a second busy signal.
+#   4. Environment=RUNNER_TOOL_CACHE=<per-runner dir> — gives every runner
+#      its OWN tool cache so concurrent jobs on one host never race on a
+#      shared .shared-tool-cache during actions/setup-python. That race
+#      corrupted the Python tree ("Directory not empty" during the old
+#      force-clean, exit-127 "python: command not found", and
+#      "ModuleNotFoundError: No module named 'http'"). Default cache dir is
+#      <WorkingDirectory>/_work/_tool; override via RUNNER_TOOL_CACHE_ROOT.
 #
 # Usage:
 #   sudo deploy/migrate-runner-units.sh                 # apply
@@ -39,6 +46,16 @@ LOCK_DIR="${LOCK_DIR:-/var/run/runner-busy}"
 TIMEOUT_STOP_SEC="${TIMEOUT_STOP_SEC:-120}"
 DRY_RUN="${DRY_RUN:-0}"
 RESTART_UNITS="${RESTART_UNITS:-0}"
+# Per-runner private tool cache. Each runner gets its OWN RUNNER_TOOL_CACHE so
+# concurrent jobs on the same host never race on a shared cache while
+# actions/setup-python extracts Python. The shared `.shared-tool-cache` design
+# let one job's clean/extract collide with another's, corrupting the Python
+# tree ("Directory not empty", exit-127 "python: command not found",
+# "ModuleNotFoundError: No module named 'http'"). When empty, the cache is
+# derived per-unit as <WorkingDirectory>/_work/_tool — the runner-local default
+# that deploy/runner-cleanup.sh already garbage-collects. Set this to override
+# with a per-runner-name dir under a custom root (e.g. a dedicated NVMe path).
+RUNNER_TOOL_CACHE_ROOT="${RUNNER_TOOL_CACHE_ROOT:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -106,8 +123,36 @@ for unit in "${units[@]}"; do
     log "migrating $unit (runner_name=$runner_name)"
     run install -d -m 0755 "$override_dir"
 
+    # Derive this runner's PRIVATE tool cache. Prefer an explicit
+    # RUNNER_TOOL_CACHE_ROOT/<runner_name>; otherwise use the runner-local
+    # default <WorkingDirectory>/_work/_tool (already GC'd by runner-cleanup.sh).
+    tool_cache_stanza=""
+    tool_cache_dir=""
+    if [[ -n "$RUNNER_TOOL_CACHE_ROOT" ]]; then
+        tool_cache_dir="${RUNNER_TOOL_CACHE_ROOT%/}/${runner_name}"
+    else
+        unit_workdir="$(systemctl show "$unit" --property=WorkingDirectory --value 2>/dev/null || true)"
+        if [[ -n "$unit_workdir" && "$unit_workdir" != "/" ]]; then
+            tool_cache_dir="${unit_workdir%/}/_work/_tool"
+        fi
+    fi
+    if [[ -n "$tool_cache_dir" ]]; then
+        # Create the cache dir owned by the runner user so the first job can
+        # populate it. Best-effort: a missing dir is recreated by setup-python.
+        run install -d -m 0755 -o "$runner_user" -g "$runner_user" "$tool_cache_dir" \
+            2>/dev/null || run mkdir -p "$tool_cache_dir" || true
+        tool_cache_stanza=$'# Per-runner private Python tool cache (RUNNER_TOOL_CACHE): each runner\n'
+        tool_cache_stanza+=$'# extracts Python into its OWN cache so concurrent jobs on this host never\n'
+        tool_cache_stanza+=$'# race on a shared .shared-tool-cache (which corrupted setup-python with\n'
+        tool_cache_stanza+=$'# dir-not-empty / "python: command not found" / missing-stdlib failures).\n'
+        tool_cache_stanza+="Environment=RUNNER_TOOL_CACHE=${tool_cache_dir}"
+    else
+        log "warn: $unit — could not resolve a tool-cache dir; RUNNER_TOOL_CACHE not set for this unit"
+    fi
+
     if [[ "$DRY_RUN" == "1" ]]; then
         log "[dry-run] would write ${override_file}"
+        [[ -n "$tool_cache_dir" ]] && log "[dry-run]   with RUNNER_TOOL_CACHE=${tool_cache_dir}"
     else
         cat > "$override_file" <<EOF
 # Managed by deploy/migrate-runner-units.sh — do not hand-edit.
@@ -126,6 +171,8 @@ Environment=ACTIONS_RUNNER_HOOK_JOB_STARTED=${HOOK_DIR}/job-started.sh
 Environment=ACTIONS_RUNNER_HOOK_JOB_COMPLETED=${HOOK_DIR}/job-completed.sh
 Environment=RUNNER_BUSY_LOCK_DIR=${LOCK_DIR}
 Environment=RUNNER_NAME=${runner_name}
+
+${tool_cache_stanza}
 
 # Belt-and-suspenders for WSL2 hosts where the cgroup-wide kill can
 # fail with EINVAL ("Failed to kill control group ...: Invalid argument").

--- a/deploy/runner-corruption-scan.sh
+++ b/deploy/runner-corruption-scan.sh
@@ -17,12 +17,22 @@
 #     $DIAG_PAGES_MIN_AGE_DAYS.  Two runs colliding on a UUID will abort
 #     the runner with "the file '.../<uuid>_<uuid>_1.log' already exists".
 #
+#   * python_toolcache — incomplete Python tool-cache trees under
+#     <runner>/_work/_tool/Python/.  The actions/toolkit writes a sibling
+#     marker <version>/<arch>.complete only after a SUCCESSFUL extraction.
+#     A <version>/<arch> directory present WITHOUT that marker is a partial
+#     extraction — the residue left when a shared cache was raced by a
+#     concurrent job, and what makes the next actions/setup-python fail with
+#     "Directory not empty", exit-127 "python: command not found", or
+#     "ModuleNotFoundError: No module named 'http'".
+#
 # Output format (gauge):
 #
 #   # HELP runner_corruption_residue_count Stale corruption-residue file count by kind.
 #   # TYPE runner_corruption_residue_count gauge
 #   runner_corruption_residue_count{host="HOST",runner="runner-01",kind="file_commands"} 3
 #   runner_corruption_residue_count{host="HOST",runner="runner-01",kind="diag_pages"} 1
+#   runner_corruption_residue_count{host="HOST",runner="runner-01",kind="python_toolcache"} 0
 #
 # Designed to be invoked from a 5-minute systemd timer
 # (runner-corruption-scan.timer) and scraped by node_exporter's
@@ -70,6 +80,27 @@ count_diag_pages() {
     fi
 }
 
+count_python_toolcache() {
+    # Count incomplete Python tool-cache trees under <runner>/_work/_tool.
+    # Layout written by the actions/toolkit:
+    #   _tool/Python/<version>/<arch>/        (extracted interpreter)
+    #   _tool/Python/<version>/<arch>.complete (marker, written last)
+    # A <version>/<arch> directory whose sibling .complete marker is missing
+    # is a partial/corrupt extraction. We do not filter by age: by contract a
+    # cached version is either complete or absent.
+    local runner_dir="$1"
+    local pyroot="${runner_dir}/_work/_tool/Python"
+    [[ -d "$pyroot" ]] || { printf '0'; return; }
+    local count=0 archdir
+    while IFS= read -r archdir; do
+        [[ -n "$archdir" ]] || continue
+        if [[ ! -f "${archdir}.complete" ]]; then
+            count=$((count + 1))
+        fi
+    done < <(find "$pyroot" -mindepth 2 -maxdepth 2 -type d 2>/dev/null)
+    printf '%s' "$count"
+}
+
 if [[ -d "$RUNNER_ROOT" ]]; then
     # shellcheck disable=SC2044  # paths under RUNNER_ROOT are operator-controlled
     while IFS= read -r runner_dir; do
@@ -77,10 +108,13 @@ if [[ -d "$RUNNER_ROOT" ]]; then
         runner_name="$(basename -- "$runner_dir")"
         fc_count="$(count_file_commands "$runner_dir")"
         dp_count="$(count_diag_pages "$runner_dir")"
+        ptc_count="$(count_python_toolcache "$runner_dir")"
         printf 'runner_corruption_residue_count{host="%s",runner="%s",kind="file_commands"} %s\n' \
             "$FLEET_NODE_NAME" "$runner_name" "$fc_count" >>"$tmp_file"
         printf 'runner_corruption_residue_count{host="%s",runner="%s",kind="diag_pages"} %s\n' \
             "$FLEET_NODE_NAME" "$runner_name" "$dp_count" >>"$tmp_file"
+        printf 'runner_corruption_residue_count{host="%s",runner="%s",kind="python_toolcache"} %s\n' \
+            "$FLEET_NODE_NAME" "$runner_name" "$ptc_count" >>"$tmp_file"
     done < <(find "$RUNNER_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'runner-*' 2>/dev/null | sort)
 fi
 

--- a/tests/deploy/test_runner_corruption_scan.py
+++ b/tests/deploy/test_runner_corruption_scan.py
@@ -220,6 +220,55 @@ def test_multiple_runners_are_reported_independently(tmp_path: Path) -> None:
     assert _metric_value(content, "runner-b", "file_commands") == 4
 
 
+def _make_python_toolcache(runner_root: Path, runner: str, version: str, *, complete: bool, arch: str = "x64") -> None:
+    """Build a synthetic Python tool-cache tree for one runner+version.
+
+    Mirrors the actions/toolkit layout:
+        _work/_tool/Python/<version>/<arch>/      (extracted tree)
+        _work/_tool/Python/<version>/<arch>.complete (marker, present only
+                                                      after a successful cache)
+    """
+    arch_dir = runner_root / runner / "_work" / "_tool" / "Python" / version / arch
+    arch_dir.mkdir(parents=True)
+    (arch_dir / "python").write_text("#!/bin/sh\n")
+    if complete:
+        (arch_dir.parent / f"{arch}.complete").write_text("")
+
+
+def test_python_toolcache_zero_when_all_complete(tmp_path: Path) -> None:
+    runner_root = tmp_path / "runners"
+    _make_python_toolcache(runner_root, "runner-01", "3.11.9", complete=True)
+    _make_python_toolcache(runner_root, "runner-01", "3.12.4", complete=True)
+
+    prom = tmp_path / "out.prom"
+    content = _run_scan(runner_root, prom)
+    assert _metric_value(content, "runner-01", "python_toolcache") == 0
+
+
+def test_python_toolcache_counts_incomplete_trees(tmp_path: Path) -> None:
+    runner_root = tmp_path / "runners"
+    # One good extraction, two partial ones (missing .complete marker).
+    _make_python_toolcache(runner_root, "runner-01", "3.10.14", complete=True)
+    _make_python_toolcache(runner_root, "runner-01", "3.11.9", complete=False)
+    _make_python_toolcache(runner_root, "runner-01", "3.12.4", complete=False)
+
+    prom = tmp_path / "out.prom"
+    content = _run_scan(runner_root, prom)
+    assert _metric_value(content, "runner-01", "python_toolcache") == 2
+    # The other kinds must still report zero for this runner.
+    assert _metric_value(content, "runner-01", "file_commands") == 0
+
+
+def test_python_toolcache_absent_cache_reports_zero(tmp_path: Path) -> None:
+    runner_root = tmp_path / "runners"
+    # Runner exists (has a diag dir) but never provisioned a Python tool cache.
+    (runner_root / "runner-07" / "_diag" / "pages").mkdir(parents=True)
+
+    prom = tmp_path / "out.prom"
+    content = _run_scan(runner_root, prom)
+    assert _metric_value(content, "runner-07", "python_toolcache") == 0
+
+
 def test_emits_atomic_write(tmp_path: Path) -> None:
     """The script must write via a temp file then rename for atomicity.
 

--- a/tests/deploy/test_runner_toolcache_isolation.py
+++ b/tests/deploy/test_runner_toolcache_isolation.py
@@ -1,0 +1,91 @@
+"""Contract tests for the per-runner tool-cache isolation in
+``deploy/migrate-runner-units.sh``.
+
+Root cause this guards against: on hosts where several runners shared a single
+``.shared-tool-cache``, one job's ``actions/setup-python`` extraction raced
+another job's cache access, corrupting the Python tree. The symptoms were
+``rm: ... Directory not empty``, exit-127 ``python: command not found``, and
+``ModuleNotFoundError: No module named 'http'``.
+
+The fix gives every runner its OWN ``RUNNER_TOOL_CACHE`` via the per-unit
+systemd drop-in that ``migrate-runner-units.sh`` already writes. These tests
+are deliberately source-level (no systemd required): they assert the script is
+syntactically valid and that the drop-in writer emits a per-runner
+``RUNNER_TOOL_CACHE`` derived from each unit's working directory.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "deploy" / "migrate-runner-units.sh"
+
+
+def _find_bash() -> str | None:
+    candidates = [
+        os.environ.get("BASH"),
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+        r"C:\Program Files\Git\bin\bash.exe",
+        "/usr/bin/bash",
+        "/bin/bash",
+        shutil.which("bash"),
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            if candidate.lower().endswith(r"system32\bash.exe"):
+                continue
+            return candidate
+    return None
+
+
+BASH = _find_bash()
+
+
+def _as_bash_path(p: Path) -> str:
+    return str(p).replace("\\", "/")
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), f"missing script: {SCRIPT}"
+
+
+@pytest.mark.skipif(BASH is None, reason="POSIX bash required for `bash -n`")
+def test_script_is_syntactically_valid() -> None:
+    result = subprocess.run(
+        [BASH or "bash", "-n", _as_bash_path(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_dropin_sets_per_runner_tool_cache() -> None:
+    """The drop-in writer must emit a RUNNER_TOOL_CACHE Environment= line."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "Environment=RUNNER_TOOL_CACHE=" in src, (
+        "drop-in must export a per-runner RUNNER_TOOL_CACHE so runners stop sharing a tool cache"
+    )
+
+
+def test_tool_cache_defaults_to_runner_local_work_tool() -> None:
+    """When RUNNER_TOOL_CACHE_ROOT is unset, the cache must default to the
+    runner-local ``<WorkingDirectory>/_work/_tool`` — the path that
+    deploy/runner-cleanup.sh already garbage-collects (avoids unbounded
+    growth in a separate, unmanaged location)."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "/_work/_tool" in src
+    assert "RUNNER_TOOL_CACHE_ROOT" in src
+
+
+def test_tool_cache_root_override_is_per_runner() -> None:
+    """An explicit RUNNER_TOOL_CACHE_ROOT must still be namespaced per runner
+    (root/<runner_name>) so two runners on one host never collide."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "${RUNNER_TOOL_CACHE_ROOT%/}/${runner_name}" in src


### PR DESCRIPTION
## Why

Multiple machines in the fleet have been hit by recurring `actions/setup-python` corruption on self-hosted runners. The signatures (observed on `d-sorg-local-ControlTower-nvme-*` and `actions-runners-nvme/runner-*`, but not unique to them):

1. `rm: cannot remove '.../.shared-tool-cache/Python/3.11.x/x64/lib/python3.11': Directory not empty`
2. `python: command not found` (exit 127) immediately after `setup-python`
3. `ModuleNotFoundError: No module named 'http'` inside the `setup-python` action

### Root cause

On hosts that run several runners against **one shared** `.shared-tool-cache`, concurrent jobs race on that cache while `setup-python` extracts Python. One job's clean/extract interleaves with another's, leaving a half-written Python tree. Crucially, **making the clean step more robust cannot fix this** — it's a delete-vs-write race on a shared resource. The only durable fix is to stop sharing.

## What

**1. Per-runner tool-cache isolation (the fix).** `deploy/migrate-runner-units.sh` already writes a per-unit systemd drop-in (`KillMode=mixed`, hooks, `RUNNER_NAME=…`). It now also exports a **private** `RUNNER_TOOL_CACHE` per runner:

- Default: `<WorkingDirectory>/_work/_tool` — the runner-local toolcache that `deploy/runner-cleanup.sh` *already* garbage-collects (`TOOL_CACHE_DAYS`), so private caches stay bounded.
- Override: set `RUNNER_TOOL_CACHE_ROOT` to place caches under a custom root; still namespaced per runner (`<root>/<runner_name>`) so two runners never collide.

Each runner extracts Python into its own cache → no shared state → no race. `RUNNER_TOOL_CACHE` is the variable the actions toolkit reads at runtime, so `setup-python` honors it with no workflow changes in any consumer repo.

**2. Fleet observability.** `deploy/runner-corruption-scan.sh` gains a third Prometheus signal, `kind="python_toolcache"`, counting incomplete tool-cache trees — a `Python/<version>/<arch>` directory missing the toolkit's `<arch>.complete` marker (exactly the partial-extraction residue). After rollout this should trend to zero; a non-zero value flags a runner still corrupting.

## Rollout

Flows through the existing deploy path: `setup.sh` → `install-runner-maintenance.sh` → `migrate-runner-units.sh` (idempotent). Changes take effect on next runner restart — `deploy/heal-host.sh` during a quiet window, or `sudo systemctl restart 'actions.runner.*.service'`. No new units or timers.

The pre-existing shared `.shared-tool-cache/Python` trees become orphaned once runners restart with private caches; they can be removed by the operator at leisure (or left for normal age-based cleanup).

## Companion change

The destructive `rm -rf .shared-tool-cache/Python` force-clean that *triggered* the race lives in consumer-repo workflows; it's being removed in parallel (e.g. D-sorganization/UpstreamDrift#6686, which redirects each job's `RUNNER_TOOL_CACHE` to `RUNNER_TEMP`). This PR fixes it fleet-wide at the runner layer so every repo benefits without per-workflow edits.

## Test plan
- [x] `bash -n` clean on both edited scripts
- [x] `deploy/runner-corruption-scan.sh` runtime smoke: complete tree → 0, missing `.complete` marker → counted
- [x] New tests in `tests/deploy/test_runner_corruption_scan.py` (3 cases: all-complete, incomplete-counted, absent-cache) and `tests/deploy/test_runner_toolcache_isolation.py` (drop-in contract + `bash -n`)
- [x] Generated drop-in renders as valid systemd (`Environment=RUNNER_TOOL_CACHE=…`)
- [x] `ruff check` + `ruff format --check` clean; full pre-push suite green
- [ ] Operator: roll out via `heal-host.sh`, then watch `runner_corruption_residue_count{kind="python_toolcache"}` → 0 fleet-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)