### PR TITLE
feat(queue): detect unroutable queued runs in the stale-queue reaper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Queue reaper unroutable-job detection (`backend/queue_cleanup.py`): a new
+  `unroutable-label` stale reason flags queued runs whose `runs-on` labels are
+  carried by no online runner (e.g. a removed/renamed tier such as
+  `d-sorg-fleet-16core`). These previously sat queued indefinitely and were
+  invisible to the reaper. Marked `safe_to_cancel` since they can never start;
+  fails safe when the runner inventory or job metadata is unavailable.
 - `backend/pyproject.toml` and `backend/uv.lock` for reproducible backend dependency resolution.
 - Root-level `uv.lock` for reproducible project dependency resolution.
 - `useTimeAgo` hook (`frontend/src/hooks/useTimeAgo.ts`) and `<TimeAgo>` primitive

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,21 @@
 # SPEC.md â€” D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.43
-**Application Version:** 4.1.3 (see `VERSION`)
-**Last Updated:** 2026-05-29T00:00:00-07:00
+**Spec Version:** 2.5.45
+**Application Version:** 4.2.2 (see `VERSION`)
+**Last Updated:** 2026-05-30T00:00:00-07:00
 **Status:** Active
 
+- **2026-05-30 (2.5.45):** Queue reaper now detects **unroutable** queued runs.
+  `backend/queue_cleanup.py` adds `StaleReason.UNROUTABLE_LABEL` plus
+  `is_routable()`, `fetch_online_runner_label_sets()`, and
+  `required_labels_for_run()`. `find_stale_runs` fetches the online-runner label
+  inventory once per scan; `_queued_stale_for_repo` flags any queued run past the
+  age gate whose `runs-on` labels are a superset of no online runner's labels
+  (e.g. a removed/renamed tier like `d-sorg-fleet-16core`). These are
+  `safe_to_cancel=True` because they will never start regardless of age. The
+  check fails safe: an empty/unavailable runner inventory (transient API error)
+  or missing job metadata never flags a run, so no false-positive cancellations.
+  12 new unit tests in `tests/test_queue_cleanup_unroutable.py`.
 - **2026-05-29 (2.5.44):** Keep the WSL distro resident between keepalive probes
   so the idle runner fleet stays online. A WSL2 distro is torn down a few seconds
   after the last active `wsl.exe` session ends; in-distro systemd services

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.2.1
+4.2.2

--- a/backend/queue_cleanup.py
+++ b/backend/queue_cleanup.py
@@ -25,6 +25,7 @@ import asyncio
 import datetime as _dt
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from datetime import timedelta
 from enum import StrEnum
@@ -59,6 +60,11 @@ class StaleReason(StrEnum):
     STALE_FEATURE_BRANCH = "stale-feature-branch"
     OFFLINE_RUNNER_OR_LAG = "offline-runner-or-lag"
     STALE_MAIN_BRANCH = "stale-main-branch-queue"
+    # A queued job whose required runs-on labels are not carried by ANY online
+    # runner. Unlike the age/branch reasons, these will never start no matter
+    # how long they wait (e.g. a removed/renamed runner label), so they are
+    # always safe to cancel once past the age gate. See is_routable().
+    UNROUTABLE_LABEL = "unroutable-label"
     UNKNOWN = "unknown"
 
 
@@ -78,6 +84,22 @@ def classify_stale_run(branch: str, age_minutes: int) -> tuple[str, bool]:
         return StaleReason.ABANDONED_AGENT.value, True
     else:
         return StaleReason.STALE_FEATURE_BRANCH.value, True
+
+
+def is_routable(required_labels: Iterable[str], online_label_sets: list[frozenset[str]]) -> bool:
+    """Return True if some online runner can satisfy *required_labels*.
+
+    A GitHub Actions job runs only on a runner whose label set is a SUPERSET of
+    the job's `runs-on` labels. So the job is routable iff at least one online
+    runner's labels ⊇ the required set.
+
+    Empty *required_labels* (job metadata not yet populated) returns True — we
+    do not have enough information to declare it stuck, so we never cancel it.
+    """
+    required = frozenset(label for label in required_labels if label)
+    if not required:
+        return True
+    return any(required <= labels for labels in online_label_sets)
 
 
 @dataclass
@@ -146,6 +168,52 @@ async def _gh_json(*args: str, default=None, timeout: int = 30):
 
 
 # ---------------------------------------------------------------------------
+# Runner-label routability
+# ---------------------------------------------------------------------------
+
+
+async def fetch_online_runner_label_sets(org: str) -> list[frozenset[str]]:
+    """Return one label set per ONLINE org runner.
+
+    Used to decide whether a queued job can ever be picked up. On failure (API
+    error, no runners visible) returns [] — callers treat an empty inventory as
+    "routability unknown" and skip cancellation, so a transient API hiccup never
+    causes a false-positive cancel.
+    """
+    data = await _gh_json(
+        "api",
+        f"/orgs/{org}/actions/runners?per_page=100",
+        default=None,
+        timeout=30,
+    )
+    if not data or "runners" not in data:
+        return []
+    sets: list[frozenset[str]] = []
+    for runner in data["runners"]:
+        if runner.get("status") == "online":
+            sets.append(frozenset(label["name"] for label in runner.get("labels", []) if label.get("name")))
+    return sets
+
+
+async def required_labels_for_run(org: str, repo: str, run_id: int) -> list[str]:
+    """Return the runs-on labels of a run's first still-queued job (or its first
+    job if none are queued). Empty when job metadata is not yet populated."""
+    data = await _gh_json(
+        "api",
+        f"/repos/{org}/{repo}/actions/runs/{run_id}/jobs",
+        default=None,
+        timeout=20,
+    )
+    if not data or "jobs" not in data:
+        return []
+    jobs = data["jobs"]
+    for job in jobs:
+        if job.get("status") == "queued":
+            return list(job.get("labels") or [])
+    return list(jobs[0].get("labels") or []) if jobs else []
+
+
+# ---------------------------------------------------------------------------
 # Repo discovery
 # ---------------------------------------------------------------------------
 
@@ -202,8 +270,11 @@ async def _queued_stale_for_repo(
     org: str,
     repo: str,
     min_age: timedelta,
+    online_label_sets: list[frozenset[str]] | None = None,
 ) -> list[StaleRun]:
     now = _get_now()
+    if online_label_sets is None:
+        online_label_sets = await fetch_online_runner_label_sets(org)
 
     # Fetch queued and in_progress runs
     queued_data = await _gh_json(
@@ -241,7 +312,52 @@ async def _queued_stale_for_repo(
     pr_groups: dict[tuple[str, int], list[dict]] = {}
     non_pr_runs: list[dict] = []
 
+    # Pre-pass: queued runs whose required runs-on labels match NO online runner
+    # will never start — regardless of branch or age — so flag them as
+    # unroutable and exclude them from the branch/PR classification below to
+    # avoid double-counting. Skipped entirely when the online-runner inventory
+    # is unavailable (empty), so a transient API failure cannot trigger a cancel.
+    unroutable_ids: set[int] = set()
+    if online_label_sets:
+        for run in unique_runs:
+            if run.get("status") != "queued":
+                continue
+            raw_ts = run.get("created_at", "")
+            try:
+                created = _dt.datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                continue
+            age = now - created
+            if age < min_age:
+                continue
+            run_id = run.get("id", 0)
+            required = await required_labels_for_run(org, repo, run_id)
+            if required and not is_routable(required, online_label_sets):
+                stale.append(
+                    StaleRun(
+                        repo=repo,
+                        run_id=run_id,
+                        workflow=run.get("name", "?"),
+                        branch=run.get("head_branch", "?") or "?",
+                        created_at=raw_ts,
+                        age_minutes=int(age.total_seconds() / 60),
+                        reason=StaleReason.UNROUTABLE_LABEL.value,
+                        reason_detail=(
+                            f"queued job requires runs-on labels {sorted(set(required))} "
+                            "but no online runner can satisfy them"
+                        ),
+                        safe_to_cancel=True,
+                        url=f"https://github.com/{org}/{repo}/actions/runs/{run_id}",
+                        html_url=run.get("html_url", ""),
+                        event=run.get("event", ""),
+                        head_sha=run.get("head_sha", ""),
+                    )
+                )
+                unroutable_ids.add(run_id)
+
     for run in unique_runs:
+        if run.get("id", 0) in unroutable_ids:
+            continue
         raw_ts = run.get("created_at", "")
         try:
             created = _dt.datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
@@ -502,12 +618,16 @@ async def find_stale_runs(
     without hammering the GitHub API.  Sorted oldest-first so the worst
     offenders appear at the top.
     """
+    # Fetch the online-runner label inventory ONCE for the whole scan so every
+    # repo shares it (used to flag jobs requesting labels no runner advertises).
+    online_label_sets = await fetch_online_runner_label_sets(org)
+
     if repo:
         from security import validate_repo_slug
 
         validated_repo = validate_repo_slug(repo)
         min_age = timedelta(minutes=min_age_minutes)
-        flat = await _queued_stale_for_repo(org, validated_repo, min_age)
+        flat = await _queued_stale_for_repo(org, validated_repo, min_age, online_label_sets)
     else:
         repos = await list_all_repos(org)
         min_age = timedelta(minutes=min_age_minutes)
@@ -515,7 +635,7 @@ async def find_stale_runs(
 
         async def bounded(r: str) -> list[StaleRun]:
             async with sem:
-                return await _queued_stale_for_repo(org, r, min_age)
+                return await _queued_stale_for_repo(org, r, min_age, online_label_sets)
 
         nested = await asyncio.gather(*[bounded(r) for r in repos])
         flat = [run for runs in nested for run in runs]

--- a/tests/test_queue_cleanup_semaphore.py
+++ b/tests/test_queue_cleanup_semaphore.py
@@ -39,7 +39,7 @@ def test_semaphore_actually_limits_concurrency() -> None:
     in_flight = 0
     peak = 0
 
-    async def fake_query(_org: str, _repo: str, _min_age):  # type: ignore[no-untyped-def]
+    async def fake_query(_org: str, _repo: str, _min_age, _online=None):  # type: ignore[no-untyped-def]
         nonlocal in_flight, peak
         in_flight += 1
         peak = max(peak, in_flight)
@@ -50,17 +50,23 @@ def test_semaphore_actually_limits_concurrency() -> None:
     async def fake_list_repos(_org: str) -> list[str]:
         return repos
 
+    async def fake_label_sets(_org: str) -> list[frozenset[str]]:
+        return []
+
     async def run() -> None:
         # Patch the module-level helpers used inside find_stale_runs.
         orig_list = queue_cleanup.list_all_repos
         orig_query = queue_cleanup._queued_stale_for_repo
+        orig_labels = queue_cleanup.fetch_online_runner_label_sets
         queue_cleanup.list_all_repos = fake_list_repos  # type: ignore[assignment]
         queue_cleanup._queued_stale_for_repo = fake_query  # type: ignore[assignment]
+        queue_cleanup.fetch_online_runner_label_sets = fake_label_sets  # type: ignore[assignment]
         try:
             await queue_cleanup.find_stale_runs("dummy-org", min_age_minutes=60)
         finally:
             queue_cleanup.list_all_repos = orig_list  # type: ignore[assignment]
             queue_cleanup._queued_stale_for_repo = orig_query  # type: ignore[assignment]
+            queue_cleanup.fetch_online_runner_label_sets = orig_labels  # type: ignore[assignment]
 
     asyncio.run(run())
 

--- a/tests/test_queue_cleanup_unroutable.py
+++ b/tests/test_queue_cleanup_unroutable.py
@@ -1,0 +1,192 @@
+"""Tests for unroutable-label detection in backend/queue_cleanup.py.
+
+A queued job runs only on a runner whose label set is a superset of the job's
+`runs-on` labels. When a workflow requests a label that no *online* runner
+advertises (a removed/renamed runner tier), the run sits queued forever. The
+reaper now detects these and marks them `unroutable-label`, safe to cancel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+
+import queue_cleanup as qc
+
+
+def _iso_ago(minutes: int) -> str:
+    return (qc._get_now() - _dt.timedelta(minutes=minutes)).isoformat()
+
+
+def _make_gh_json(queued_runs, jobs_by_run):
+    async def fake(*args, **_kwargs):
+        path = args[1] if len(args) > 1 else ""
+        if "status=queued" in path:
+            return {"workflow_runs": queued_runs}
+        if "status=in_progress" in path:
+            return {"workflow_runs": []}
+        if "/jobs" in path:
+            run_id = int(path.split("/actions/runs/")[1].split("/jobs")[0])
+            return {"jobs": jobs_by_run.get(run_id, [])}
+        return {}
+
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# is_routable (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_is_routable_true_when_a_runner_superset_matches() -> None:
+    assert qc.is_routable(["d-sorg-fleet"], [frozenset({"self-hosted", "d-sorg-fleet"})]) is True
+
+
+def test_is_routable_requires_all_labels_on_one_runner() -> None:
+    # Job needs BOTH labels; the runner has only one -> not routable.
+    online = [frozenset({"self-hosted"}), frozenset({"d-sorg-fleet"})]
+    assert qc.is_routable(["self-hosted", "d-sorg-fleet"], online) is False
+
+
+def test_is_routable_false_when_label_on_no_runner() -> None:
+    assert qc.is_routable(["d-sorg-fleet-16core"], [frozenset({"d-sorg-fleet"})]) is False
+
+
+def test_is_routable_empty_required_is_true() -> None:
+    # Missing job metadata must never be treated as stuck.
+    assert qc.is_routable([], [frozenset()]) is True
+
+
+def test_is_routable_false_when_no_online_runners() -> None:
+    assert qc.is_routable(["d-sorg-fleet"], []) is False
+
+
+# ---------------------------------------------------------------------------
+# fetch_online_runner_label_sets / required_labels_for_run
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_online_runner_label_sets_filters_offline(monkeypatch) -> None:
+    async def fake(*_args, **_kwargs):
+        return {
+            "runners": [
+                {"status": "online", "labels": [{"name": "self-hosted"}, {"name": "d-sorg-fleet"}]},
+                {"status": "offline", "labels": [{"name": "d-sorg-fleet-14core"}]},
+            ]
+        }
+
+    monkeypatch.setattr(qc, "_gh_json", fake)
+    sets = asyncio.run(qc.fetch_online_runner_label_sets("org"))
+    assert sets == [frozenset({"self-hosted", "d-sorg-fleet"})]
+
+
+def test_fetch_online_runner_label_sets_failure_returns_empty(monkeypatch) -> None:
+    async def fake(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(qc, "_gh_json", fake)
+    assert asyncio.run(qc.fetch_online_runner_label_sets("org")) == []
+
+
+def test_required_labels_prefers_queued_job(monkeypatch) -> None:
+    async def fake(*_args, **_kwargs):
+        return {
+            "jobs": [
+                {"status": "completed", "labels": ["d-sorg-fleet-docker"]},
+                {"status": "queued", "labels": ["d-sorg-fleet-8core"]},
+            ]
+        }
+
+    monkeypatch.setattr(qc, "_gh_json", fake)
+    assert asyncio.run(qc.required_labels_for_run("org", "repo", 1)) == ["d-sorg-fleet-8core"]
+
+
+# ---------------------------------------------------------------------------
+# _queued_stale_for_repo integration
+# ---------------------------------------------------------------------------
+
+
+def test_dead_label_queued_run_flagged_unroutable(monkeypatch) -> None:
+    runs = [
+        {
+            "id": 111,
+            "name": "CI",
+            "head_branch": "feature/x",
+            "status": "queued",
+            "created_at": _iso_ago(120),
+            "event": "schedule",
+        }
+    ]
+    jobs = {111: [{"status": "queued", "labels": ["d-sorg-fleet-16core"]}]}
+    monkeypatch.setattr(qc, "_gh_json", _make_gh_json(runs, jobs))
+
+    out = asyncio.run(
+        qc._queued_stale_for_repo("org", "repo", _dt.timedelta(minutes=60), [frozenset({"d-sorg-fleet"})])
+    )
+    unroutable = [r for r in out if r.reason == qc.StaleReason.UNROUTABLE_LABEL.value]
+    assert len(unroutable) == 1
+    assert unroutable[0].run_id == 111
+    assert unroutable[0].safe_to_cancel is True
+    assert "d-sorg-fleet-16core" in unroutable[0].reason_detail
+    # The run must not be double-classified under a branch/age reason.
+    assert sum(1 for r in out if r.run_id == 111) == 1
+
+
+def test_routable_queued_run_not_flagged_unroutable(monkeypatch) -> None:
+    runs = [
+        {
+            "id": 222,
+            "name": "CI",
+            "head_branch": "feature/y",
+            "status": "queued",
+            "created_at": _iso_ago(120),
+            "event": "schedule",
+        }
+    ]
+    jobs = {222: [{"status": "queued", "labels": ["d-sorg-fleet"]}]}
+    monkeypatch.setattr(qc, "_gh_json", _make_gh_json(runs, jobs))
+
+    out = asyncio.run(
+        qc._queued_stale_for_repo("org", "repo", _dt.timedelta(minutes=60), [frozenset({"d-sorg-fleet"})])
+    )
+    assert all(r.reason != qc.StaleReason.UNROUTABLE_LABEL.value for r in out)
+
+
+def test_empty_inventory_never_flags_unroutable(monkeypatch) -> None:
+    # When the online-runner inventory is unavailable, a transient API failure
+    # must not cause false-positive cancellations.
+    runs = [
+        {
+            "id": 333,
+            "name": "CI",
+            "head_branch": "feature/z",
+            "status": "queued",
+            "created_at": _iso_ago(120),
+            "event": "schedule",
+        }
+    ]
+    jobs = {333: [{"status": "queued", "labels": ["d-sorg-fleet-16core"]}]}
+    monkeypatch.setattr(qc, "_gh_json", _make_gh_json(runs, jobs))
+
+    out = asyncio.run(qc._queued_stale_for_repo("org", "repo", _dt.timedelta(minutes=60), []))
+    assert all(r.reason != qc.StaleReason.UNROUTABLE_LABEL.value for r in out)
+
+
+def test_young_unroutable_run_below_age_gate_is_ignored(monkeypatch) -> None:
+    runs = [
+        {
+            "id": 444,
+            "name": "CI",
+            "head_branch": "feature/w",
+            "status": "queued",
+            "created_at": _iso_ago(5),
+            "event": "schedule",
+        }
+    ]
+    jobs = {444: [{"status": "queued", "labels": ["d-sorg-fleet-16core"]}]}
+    monkeypatch.setattr(qc, "_gh_json", _make_gh_json(runs, jobs))
+
+    out = asyncio.run(
+        qc._queued_stale_for_repo("org", "repo", _dt.timedelta(minutes=60), [frozenset({"d-sorg-fleet"})])
+    )
+    assert out == []


### PR DESCRIPTION
## Why

Jobs across the fleet sat **queued for 5–11 hours** while PRs blocked on them, because their `runs-on` requested capability labels that no online runner advertises (removed/renamed tiers like `d-sorg-fleet-8core`/`-16core`, or `-14core` whose only host — Oglaptop — is offline). A job runs only on a runner whose label set is a *superset* of its required labels, so these never start — and the reaper had no way to see them (it only knew about age/branch/PR-supersession reasons). They accumulated silently.

## What

Add unroutable-label detection to `backend/queue_cleanup.py`:

- **`StaleReason.UNROUTABLE_LABEL`** — a new reason for queued runs that can never be picked up.
- **`is_routable(required, online_label_sets)`** — pure predicate: routable iff some online runner's labels ⊇ the job's required labels.
- **`fetch_online_runner_label_sets(org)`** — one label-set per online org runner.
- **`required_labels_for_run(org, repo, run_id)`** — the `runs-on` labels of the run's queued job.
- `find_stale_runs` fetches the runner inventory **once per scan** and threads it to each repo scan; `_queued_stale_for_repo` flags aged queued runs that match no online runner as `unroutable-label`, `safe_to_cancel=True`.

### Fails safe
- Empty/unavailable runner inventory (transient API error) → **no** runs flagged.
- Missing job metadata (labels not yet populated) → treated as routable, never cancelled.
- Age-gated: only runs past `min_age_minutes` (default 60) are considered, so a job briefly waiting on a busy runner is never touched.

The reaper script (`scripts/reap_queued_jobs.py`) needs no change — the new reason flows through `/api/queue/stale` and can be targeted with `--reason-filter unroutable-label`.

## Test plan
- [x] 12 new unit tests in `tests/test_queue_cleanup_unroutable.py` (pure routability, inventory fetch, label extraction, end-to-end flag/skip, fail-safe on empty inventory, age-gate)
- [x] Updated `test_queue_cleanup_semaphore.py` double for the new signature
- [x] Full queue suite + pre-push (ruff, mypy, bandit, pytest) green
- [x] SPEC.md (2.5.45) + VERSION (4.2.2) + CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)