### PR TITLE
fix(stats): stop /api/stats publishing false zeros under partial GitHub failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Overview summary (`/api/stats`) showed false zeros for open PRs, queue depth,
+  and machines under partial GitHub failure. The PR/issue search, queue
+  fan-out, and fleet probe shared one timeout budget, so a slow search or
+  secondary rate-limit zeroed them all at once (while the toolstrip's
+  `/api/queue` stayed correct). Now each source is budgeted independently, the
+  queue is reused from its own resilient cache, and failed fields fall back to a
+  `stats:stale` last-known-good snapshot instead of zero (`backend/routers/repos_stats.py`).
 - Per-runner Python tool-cache isolation (`deploy/migrate-runner-units.sh`):
   every `actions.runner.*.service` drop-in now exports a private
   `RUNNER_TOOL_CACHE` (default `<WorkingDirectory>/_work/_tool`, overridable via

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,22 @@
-# SPEC.md â€” D-sorganization Runner Dashboard
+# SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.45
-**Application Version:** 4.2.2 (see `VERSION`)
+**Spec Version:** 2.5.46
+**Application Version:** 4.2.3 (see `VERSION`)
 **Last Updated:** 2026-05-30T00:00:00-07:00
 **Status:** Active
 
+- **2026-05-30 (2.5.46):** `/api/stats` (Overview summary) no longer publishes
+  false zeros under partial GitHub failure. Previously the org PR/issue search,
+  the 24-repo queue fan-out, and the fleet probe shared one timeout budget, so a
+  slow search or secondary rate-limit timed out the whole bundle and zeroed PRs,
+  queue, and machine counts together — even while the standalone `/api/queue`
+  (toolstrip) stayed correct. `backend/routers/repos_stats.py` now: (1) reuses
+  the resilient `/api/queue` cache instead of re-fanning-out, (2) budgets
+  runners, workflow-runs, PR search, issue search, and fleet **independently**,
+  (3) backfills any failed field from a `stats:stale` last-known-good snapshot
+  (24h TTL) that is only written on a fully-healthy compute, and (4) adds a
+  `stale` flag to the payload. 4 new tests in
+  `tests/test_stats_summary_resilience.py`.
 - **2026-05-30 (2.5.45):** Queue reaper now detects **unroutable** queued runs.
   `backend/queue_cleanup.py` adds `StaleReason.UNROUTABLE_LABEL` plus
   `is_routable()`, `fetch_online_runner_label_sets()`, and

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.2.2
+4.2.3

--- a/backend/routers/repos_stats.py
+++ b/backend/routers/repos_stats.py
@@ -22,6 +22,16 @@ router = APIRouter(tags=["repos"])
 
 _STATS_FANOUT_TIMEOUT_S = 6.0
 _STATS_REPO_SAMPLE_LIMIT = 12
+# Last-known-good snapshot of a fully-healthy /api/stats. Only written when the
+# computation is NOT degraded, so a transient rate-limit/timeout window can fall
+# back to real numbers instead of publishing zeros. 24h is generous: fleet
+# topology and open PR/issue counts change slowly, and a fresh healthy compute
+# overwrites it the moment GitHub recovers.
+_STATS_STALE_KEY = "stats:stale"
+_STATS_STALE_TTL = 60.0 * 60.0 * 24.0
+# Reuse a recent /api/queue result (which has its own last-known-good fallback)
+# instead of re-running the 24-repo queue fan-out inside the stats budget.
+_STATS_QUEUE_REUSE_TTL = 120.0
 
 
 def _state() -> Any:
@@ -54,6 +64,11 @@ async def get_stats(request: Request) -> Any:
     if cached is not None:
         return cached
 
+    # Last-known-good snapshot — used to backfill any field whose live fetch
+    # fails this cycle, so a partial GitHub outage degrades one number instead
+    # of zeroing the whole summary.
+    last_good = cache_get(_STATS_STALE_KEY, _STATS_STALE_TTL) or {}
+
     degraded_reasons: list[str] = []
 
     async def _with_budget(label: str, coro: Any, fallback: Any, timeout_s: float = _STATS_FANOUT_TIMEOUT_S) -> Any:
@@ -66,11 +81,13 @@ async def get_stats(request: Request) -> Any:
             degraded_reasons.append(f"{label}_error:{type(exc).__name__}")
             return fallback
 
+    # --- Runners (independent; fall back to last-known-good counts) -----------
     runners_data = cache_get("runners", 25.0)
     if runners_data is None:
-        runners_data = await _with_budget("runners", gh_api_admin(f"/orgs/{org}/actions/runners"), {"runners": []})
-        cache_set("runners", runners_data)
-    runners = runners_data.get("runners", [])
+        runners_data = await _with_budget("runners", gh_api_admin(f"/orgs/{org}/actions/runners"), None)
+        if isinstance(runners_data, dict):
+            cache_set("runners", runners_data)
+    runners = runners_data.get("runners", []) if isinstance(runners_data, dict) else None
 
     repos = await _with_budget("recent_repos", get_recent_org_repos(limit=30), [])
 
@@ -87,16 +104,16 @@ async def get_stats(request: Request) -> Any:
             return []
 
     async def _github_search_total_local(query: str) -> int:
+        """Return the search total, RAISING on failure so the caller's budget
+        records a degraded reason and backfills last-known-good (rather than
+        silently reporting 0, which is indistinguishable from a real empty)."""
         code, stdout, _ = await run_cmd(
             ["gh", "api", f"search/issues?q={query}&per_page=1"],
             timeout=15,
         )
         if code != 0:
-            return 0
-        try:
-            return int(json.loads(stdout).get("total_count", 0))
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return 0
+            raise RuntimeError(f"gh search exited {code}")
+        return int(json.loads(stdout).get("total_count", 0))
 
     sampled_repos = repos[:_STATS_REPO_SAMPLE_LIMIT]
     all_runs_nested = await _with_budget(
@@ -108,47 +125,86 @@ async def get_stats(request: Request) -> Any:
     runs.sort(key=lambda r: r.get("created_at", ""), reverse=True)
     runs = runs[:100]
 
-    online = sum(1 for r in runners if r["status"] == "online")
-    busy = sum(1 for r in runners if r.get("busy"))
     completed = [r for r in runs if r.get("conclusion")]
     successes = sum(1 for r in completed if r["conclusion"] == "success")
     failures = sum(1 for r in completed if r["conclusion"] == "failure")
 
-    org_open_issues, org_open_prs, queue_data, fleet_data = await _with_budget(
-        "summary_fanout",
-        asyncio.gather(
-            _github_search_total_local(f"org:{org}+is:open+is:issue"),
-            _github_search_total_local(f"org:{org}+is:open+is:pr"),
-            queue_impl(),
-            get_fleet_nodes_impl(),
-        ),
-        (0, 0, {}, {}),
-    )
+    # --- Queue: reuse the resilient /api/queue cache (which already serves
+    # last-known-good on failure). Only re-run the fan-out if no recent cache
+    # exists, and on its own budget so it can't starve the rest of the summary.
+    queue_data = cache_get("queue", _STATS_QUEUE_REUSE_TTL)
+    if queue_data is None:
+        queue_data = await _with_budget("queue", queue_impl(), None, timeout_s=8.0)
+
+    # --- Org PR / issue counts: independent budgets so a slow search API call
+    # cannot zero the queue and machine numbers alongside it.
+    issues_total = await _with_budget("issues_search", _github_search_total_local(f"org:{org}+is:open+is:issue"), None)
+    prs_total = await _with_budget("prs_search", _github_search_total_local(f"org:{org}+is:open+is:pr"), None)
+
+    # --- Fleet machines (independent) ----------------------------------------
+    fleet_data = await _with_budget("fleet", get_fleet_nodes_impl(), None)
+
+    # --- Assemble, backfilling any failed field from last-known-good ----------
+    if runners is None:
+        runners_total = last_good.get("runners_total", 0)
+        runners_online = last_good.get("runners_online", 0)
+        runners_busy = last_good.get("runners_busy", 0)
+        runners_idle = last_good.get("runners_idle", 0)
+        runners_offline = last_good.get("runners_offline", 0)
+    else:
+        runners_online = sum(1 for r in runners if r.get("status") == "online")
+        runners_busy = sum(1 for r in runners if r.get("busy"))
+        runners_total = len(runners)
+        runners_idle = max(0, runners_online - runners_busy)
+        runners_offline = max(0, runners_total - runners_online)
+
+    if isinstance(queue_data, dict):
+        in_progress = queue_data.get("in_progress_count", 0)
+        queued = queue_data.get("queued_count", 0)
+        queue_total = queue_data.get("total", 0)
+    else:
+        in_progress = last_good.get("in_progress", 0)
+        queued = last_good.get("queued", 0)
+        queue_total = last_good.get("queue_total", 0)
+
+    org_open_issues = issues_total if issues_total is not None else last_good.get("org_open_issues", 0)
+    org_open_prs = prs_total if prs_total is not None else last_good.get("org_open_prs", 0)
+
+    if isinstance(fleet_data, dict):
+        machines_total = fleet_data.get("count", 0)
+        machines_online = fleet_data.get("online_count", 0)
+    else:
+        machines_total = last_good.get("machines_total", 0)
+        machines_online = last_good.get("machines_online", 0)
 
     result = {
-        "runners_total": len(runners),
-        "runners_online": online,
-        "runners_busy": busy,
-        "runners_idle": max(0, online - busy),
-        "runners_offline": max(0, len(runners) - online),
+        "runners_total": runners_total,
+        "runners_online": runners_online,
+        "runners_busy": runners_busy,
+        "runners_idle": runners_idle,
+        "runners_offline": runners_offline,
         "runs_total": len(runs),
         "runs_success": successes,
         "runs_failure": failures,
         "runs_completed": len(completed),
         "success_rate": round(successes / len(completed) * 100) if completed else 0,
-        "in_progress": queue_data.get("in_progress_count", 0),
-        "queued": queue_data.get("queued_count", 0),
-        "queue_total": queue_data.get("total", 0),
+        "in_progress": in_progress,
+        "queued": queued,
+        "queue_total": queue_total,
         "org_open_issues": org_open_issues,
         "org_open_prs": org_open_prs,
-        "machines_total": fleet_data.get("count", 0),
-        "machines_online": fleet_data.get("online_count", 0),
-        "machines_offline": max(0, fleet_data.get("count", 0) - fleet_data.get("online_count", 0)),
+        "machines_total": machines_total,
+        "machines_online": machines_online,
+        "machines_offline": max(0, machines_total - machines_online),
         "repos_sampled": len(sampled_repos),
         "degraded": bool(degraded_reasons),
         "degraded_reasons": degraded_reasons,
+        "stale": bool(degraded_reasons),
     }
     cache_set("stats", result)
+    # Only persist a fully-healthy result as the last-known-good snapshot.
+    if not degraded_reasons:
+        cache_set(_STATS_STALE_KEY, result)
     return result
 
 

--- a/tests/test_stats_summary_resilience.py
+++ b/tests/test_stats_summary_resilience.py
@@ -1,0 +1,161 @@
+"""Regression coverage for /api/stats partial-failure resilience.
+
+The Overview summary previously bundled the org PR/issue search, the queue
+fan-out, and the fleet probe under a single timeout. A slow search (or a
+secondary rate-limit) timed out the whole bundle and published ZEROS for PRs,
+queue, and machines at once — even though the standalone /api/queue endpoint
+was fine. These tests pin the fixed behavior: each source is budgeted
+independently, the queue is reused from its own resilient cache, and any failed
+field falls back to the last-known-good snapshot instead of zero.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from starlette.requests import Request
+
+_BACKEND_DIR = Path(__file__).parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND_DIR))
+
+
+def _request(path: str = "/api/stats") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "query_string": b"local=1",
+            "headers": [],
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+        }
+    )
+
+
+async def _default_run_cmd(args, timeout: int = 15):  # type: ignore[no-untyped-def]
+    return 0, '{"workflow_runs":[]}', ""
+
+
+async def _default_gh_admin(_path: str):  # type: ignore[no-untyped-def]
+    return {"runners": [{"status": "online", "busy": True}, {"status": "online", "busy": False}]}
+
+
+async def _default_recent(*, limit: int):  # type: ignore[no-untyped-def]
+    return [{"name": "Repository_Management"}]
+
+
+async def _default_queue():  # type: ignore[no-untyped-def]
+    return {"in_progress_count": 1, "queued_count": 2, "total": 3}
+
+
+async def _default_fleet():  # type: ignore[no-untyped-def]
+    return {"count": 4, "online_count": 3}
+
+
+def _wire(cache, **overrides):  # type: ignore[no-untyped-def]
+    from routers import repos
+
+    repos.set_dependencies(
+        cache_get=lambda k, _ttl: cache.get(k),
+        cache_set=lambda k, v: cache.__setitem__(k, v),
+        cache_delete=lambda k: cache.pop(k, None),
+        run_cmd=overrides.get("run_cmd", _default_run_cmd),
+        gh_api_admin=overrides.get("gh_api_admin", _default_gh_admin),
+        get_recent_org_repos=overrides.get("recent", _default_recent),
+        get_fleet_nodes_impl=overrides.get("fleet", _default_fleet),
+        queue_impl=overrides.get("queue_impl", _default_queue),
+        pr_inventory=SimpleNamespace(),
+        issue_inventory=SimpleNamespace(),
+        linear_router=SimpleNamespace(),
+        linear_inventory=SimpleNamespace(),
+        unified_issue_inventory=SimpleNamespace(),
+        lease_synchronizer=SimpleNamespace(),
+        usage_monitoring=SimpleNamespace(),
+        org="D-sorganization",
+    )
+
+
+async def _search_fails_run_cmd(args, timeout: int = 15):  # type: ignore[no-untyped-def]
+    if "search/issues" in " ".join(args):
+        return 1, "", "secondary rate limit"
+    return 0, '{"workflow_runs":[]}', ""
+
+
+def test_queue_numbers_survive_search_failure() -> None:
+    """The exact reported symptom: searches fail but the queue (served from its
+    own cache) must still show real numbers, not zero."""
+    cache = {"queue": {"in_progress_count": 3, "queued_count": 3, "total": 6}}
+    _wire(cache, run_cmd=_search_fails_run_cmd)
+
+    from routers import repos_stats
+
+    payload = asyncio.run(repos_stats.get_stats(_request()))
+    assert payload["queued"] == 3
+    assert payload["in_progress"] == 3
+    assert payload["queue_total"] == 6
+    assert payload["degraded"] is True
+    assert any("search" in r for r in payload["degraded_reasons"])
+
+
+def test_failed_fields_fall_back_to_last_known_good() -> None:
+    last_good = {
+        "org_open_prs": 42,
+        "org_open_issues": 50,
+        "in_progress": 1,
+        "queued": 1,
+        "queue_total": 2,
+        "machines_total": 3,
+        "machines_online": 3,
+    }
+    cache = {"stats:stale": last_good}
+    _wire(cache, run_cmd=_search_fails_run_cmd)
+
+    from routers import repos_stats
+
+    payload = asyncio.run(repos_stats.get_stats(_request()))
+    assert payload["org_open_prs"] == 42
+    assert payload["org_open_issues"] == 50
+    assert payload["degraded"] is True
+
+
+def test_healthy_compute_persists_last_known_good() -> None:
+    cache: dict[str, object] = {}
+
+    async def run_cmd(args, timeout: int = 15):  # type: ignore[no-untyped-def]
+        cmd = " ".join(args)
+        if "search/issues" in cmd:
+            total = 42 if "is:pr" in cmd else 50
+            return 0, f'{{"total_count":{total}}}', ""
+        return 0, '{"workflow_runs":[]}', ""
+
+    _wire(cache, run_cmd=run_cmd)
+
+    from routers import repos_stats
+
+    payload = asyncio.run(repos_stats.get_stats(_request()))
+    assert payload["degraded"] is False
+    assert payload["org_open_prs"] == 42
+    assert payload["org_open_issues"] == 50
+    assert payload["queued"] == 2
+    assert payload["queue_total"] == 3
+    assert payload["runners_online"] == 2
+    # A fully-healthy result is persisted as the last-known-good snapshot.
+    assert cache.get("stats:stale") is not None
+    assert cache["stats:stale"]["org_open_prs"] == 42  # type: ignore[index]
+
+
+def test_degraded_result_is_not_persisted_as_last_known_good() -> None:
+    cache: dict[str, object] = {}
+    _wire(cache, run_cmd=_search_fails_run_cmd)
+
+    from routers import repos_stats
+
+    payload = asyncio.run(repos_stats.get_stats(_request()))
+    assert payload["degraded"] is True
+    # Degraded zeros must never overwrite/populate the last-known-good snapshot.
+    assert "stats:stale" not in cache


### PR DESCRIPTION
## Symptom

The Overview summary tab shows **0 open PRs and 0 queue items**, while the top toolstrip shows the queue correctly.

## Root cause

The toolstrip reads `/api/queue` (which has a last-known-good cache fallback and stays correct). The Overview summary reads `/api/stats`, which bundled three unrelated GitHub calls — the org **PR/issue search**, the full **24-repo queue fan-out**, and the **fleet peer-probe** — under a single 6s timeout with one `(0,0,{},{})` fallback:

```python
org_open_issues, org_open_prs, queue_data, fleet_data = await _with_budget(
    "summary_fanout",
    asyncio.gather(search_issues(), search_prs(), queue_impl(), get_fleet_nodes_impl()),
    (0, 0, {}, {}),
)
```

When the search API is slow or the dashboard's token hits a **secondary** rate-limit, the whole bundle times out and zeros PRs + queue + machines **together**, then caches those zeros for 30s. Live confirmation: REST quota is healthy and the searches return real numbers (**42 PRs, 49 issues**, <1s) from a shell — it's the bundling + secondary limit, and the bug is on current `main`.

## Fix

`backend/routers/repos_stats.py`:
- **Reuse** the resilient `/api/queue` cache (`cache_get("queue", …)`) instead of re-running the 24-repo fan-out inside the stats budget.
- **Independent budgets** for runners, workflow-runs, PR search, issue search, and fleet — one slow source can no longer zero the others.
- **Last-known-good backfill**: any field whose live fetch fails this cycle is filled from a `stats:stale` snapshot (24h TTL) that is written **only on a fully-healthy compute**, so degraded zeros never overwrite good data.
- Adds a `stale` flag to the payload for the UI.

## Test plan
- [x] 4 new tests in `tests/test_stats_summary_resilience.py`: queue numbers survive a search failure (the exact symptom), failed fields fall back to last-known-good, healthy compute persists the snapshot, degraded result is **not** persisted.
- [x] Existing `test_dashboard_degraded_endpoints.py` still passes.
- [x] ruff / mypy / bandit / full pytest green (pre-push).
- [ ] **Redeploy needed:** the running dashboard is a stale build (4.1.4) serving cached degraded zeros — restart after merge to pick up the fix and clear the cache.

Note: the `runners_error:RateLimitedError` (secondary/abuse limit from the dashboard's own polling volume) is a separate, related concern worth a back-off follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)