### PR TITLE
fix: harden fleet dashboard routing

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -371,19 +371,30 @@ jobs:
       - name: Audit Python Dependencies
         env:
           PYTHONNOUSERSITE: "1"
+          PIP_NO_CACHE_DIR: "1"
         run: |
           python -m venv "$RUNNER_TEMP/security-venv"
-          source "$RUNNER_TEMP/security-venv/bin/activate"
-          python -m pip install --upgrade pip setuptools wheel
-          if [ -f uv.lock ]; then
-            rm -rf .venv
-            python -m pip install uv
-            uv sync --frozen
-            ./.venv/bin/python -m pip_audit --progress-spinner=off
-          else
-            python -m pip install --quiet pip-audit
-            python -m pip_audit -r requirements.txt --progress-spinner=off
+          AUDIT_PYTHON="$RUNNER_TEMP/security-venv/bin/python"
+          "$AUDIT_PYTHON" -m pip install --upgrade pip setuptools wheel
+          "$AUDIT_PYTHON" -m pip install --quiet --no-cache-dir pip-audit
+
+          if [ ! -f requirements.txt ]; then
+            echo "::error::requirements.txt is required for security-scan dependency audit."
+            exit 1
           fi
+
+          IGNORE_FLAGS=""
+          if [ -f requirements-audit-ignore.txt ]; then
+            while IFS= read -r line; do
+              [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+              PURL=$(echo "$line" | awk '{print $1}')
+              IGNORE_FLAGS="$IGNORE_FLAGS --ignore-vuln $PURL"
+            done < requirements-audit-ignore.txt
+          fi
+
+          # shellcheck disable=SC2086
+          "$AUDIT_PYTHON" -m pip_audit -r requirements.txt \
+            --progress-spinner=off $IGNORE_FLAGS
 
   tests:
     needs:

--- a/SPEC.md
+++ b/SPEC.md
@@ -14,7 +14,10 @@
   DeskComputer and ControlTower runner hosts can finish process enumeration
   without false 504s. `deploy/wsl-mirrored-port-helper.sh` now detects and
   clears Tailscale Serve HTTP/HTTPS/TCP bindings by protocol before restoring
-  the WSL dashboard HTTP binding.
+  the WSL dashboard HTTP binding. The `security-scan` CI job now runs
+  `pip-audit` from an isolated no-cache audit venv against `requirements.txt`,
+  avoiding runner-side project-venv cache corruption while preserving the
+  dependency audit gate.
 - **2026-06-10 (2.5.77):** Added a non-matrix `tests` aggregate CI context
   after the Python matrix job so branch protection consumes the same green test
   result as `tests (3.11)` without synthetic statuses.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,20 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.77
+**Spec Version:** 2.5.78
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-10T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-10 (2.5.78):** Hardened fleet dashboard routing for the
+  GitHub-primary/Forgejo-ready fleet posture. `backend/machine_registry.yml`
+  now routes ControlTower pool dashboards through Tailscale MagicDNS
+  (`controltower.tail2bbcc7.ts.net`) instead of stale local/offline addresses,
+  marks the live ControlTower host as preferred, and keeps the legacy monitoring
+  node non-preferred. Node-system proxy calls now have a 30 s budget so loaded
+  DeskComputer and ControlTower runner hosts can finish process enumeration
+  without false 504s. `deploy/wsl-mirrored-port-helper.sh` now detects and
+  clears Tailscale Serve HTTP/HTTPS/TCP bindings by protocol before restoring
+  the WSL dashboard HTTP binding.
 - **2026-06-10 (2.5.77):** Added a non-matrix `tests` aggregate CI context
   after the Python matrix job so branch protection consumes the same green test
   result as `tests (3.11)` without synthetic statuses.
@@ -887,12 +897,23 @@ unreachable, its entry is set to `{"status": "offline", ...}` so the primary
 view remains available. The `exclude_pools=true` query parameter prevents
 recursive peer queries.
 
+In the fleet deployment, dashboard-to-dashboard routing must prefer Tailscale
+MagicDNS hostnames over ephemeral WSL-local or stale tailnet IP addresses. The
+ControlTower pool URLs are canonicalized as:
+
+- `http://controltower.tail2bbcc7.ts.net:8321` for `ControlTower-NVMe`
+- `http://controltower.tail2bbcc7.ts.net:8322` for `ControlTower-SSD`
+
+The per-node system proxy budget is 30 s for remote node telemetry. This keeps
+loaded Windows hosts, especially DeskComputer during full runner load, from
+being marked unhealthy while enumerating runner processes and host metrics.
+
 Response shape (keyed by pool name, plus any FLEET_NODES peers):
 
 ```json
 {
   "ControlTower-NVMe": { "status": "online", "hostname": "...", ... },
-  "ControlTower-HDD":  { "status": "online",  "hostname": "...", ... },
+  "ControlTower-SSD":  { "status": "online",  "hostname": "...", ... },
   "OGLaptop":          { "status": "online",  "hostname": "...", ... }
 }
 ```
@@ -1630,6 +1651,21 @@ This removes the historical foot-gun of leaving `FLEET_NODES` unset in systemd
 Environment= lines and the dashboard silently showing only the local machine.
 The `/api/diagnostics` endpoint reports the effective source (`env`, `registry`,
 or `empty`) so deploy validation can confirm it.
+
+Registry entries may retain historical nodes for audit or rollback, but exactly
+one live entry per physical host should be marked `preferred: true`. For the
+ControlTower host, the preferred entry is the Windows/Tailscale node
+`controltower.tail2bbcc7.ts.net`, and any obsolete WSL monitoring node remains
+non-preferred. Dashboard URLs should be stable HTTP URLs reachable from the
+tailnet and should not use loopback except for same-host-only helper endpoints.
+
+The WSL mirrored-port helper is responsible for preserving those HTTP URLs
+across WSL cold starts. Before dashboard startup it inspects `tailscale serve
+status`, clears any conflicting binding with the matching protocol
+(`--http`, `--https`, or `--tcp`), removes the Windows portproxy entry, and
+restores the dashboard as an HTTP Tailscale Serve binding after startup.
+Protocol-aware clearing is required because an HTTP Serve binding is not
+removed by a TCP-only clear command.
 
 Example structure:
 

--- a/backend/dashboard_config/timeouts.py
+++ b/backend/dashboard_config/timeouts.py
@@ -29,8 +29,10 @@ class HttpTimeout:
     SYSTEMCTL_S: int = 5
 
     # Cross-node system probes go through the Tailscale mesh and may queue
-    # behind a busy CPU; 8 s gives the remote dashboard time to respond.
-    PROXY_NODE_SYSTEM_S: float = 8.0
+    # behind a busy CPU while the remote dashboard enumerates runner processes.
+    # DeskComputer has been observed taking 20-25 s under full CI load, so use
+    # a larger budget here and keep the gather fan-out independent per node.
+    PROXY_NODE_SYSTEM_S: float = 30.0
 
     # Hub-bound proxies and the default ``gh api`` budget. 15 s tolerates
     # GitHub API tail latency without holding workers too long.

--- a/backend/machine_registry.yml
+++ b/backend/machine_registry.yml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-05-27
+updated_at: 2026-06-09
 machines:
   - name: ControlTower
     aliases:
@@ -7,15 +7,16 @@ machines:
       - control-tower-runner-monitoring
     display_name: ControlTower
     role: hub
-    dashboard_url: http://100.95.177.68:8321
+    dashboard_url: http://controltower.tail2bbcc7.ts.net:8321
     tailscale_nodes:
       - name: control-tower-runner-monitoring
         ip: 100.95.177.68
         transport: wsl2
-        preferred: true
+        preferred: false
       - name: controltower
         ip: 100.69.12.6
         transport: windows
+        preferred: true
     runner_labels:
       - self-hosted
       - Linux
@@ -27,7 +28,7 @@ machines:
           - controltower-nvme
           - control-tower-nvme
           - controltower-fast
-        dashboard_url: http://100.95.177.68:8321
+        dashboard_url: http://controltower.tail2bbcc7.ts.net:8321
         storage_tier: nvme
         runner_base_dir: /home/dieterolson/actions-runners-nvme
         runner_labels:
@@ -56,7 +57,7 @@ machines:
           - controltower-ssd
           - control-tower-ssd
           - controltower-bulk
-        dashboard_url: http://127.0.0.1:8322
+        dashboard_url: http://controltower.tail2bbcc7.ts.net:8322
         storage_tier: ssd
         runner_base_dir: /home/dieterolson/actions-runners
         runner_labels:

--- a/deploy/wsl-mirrored-port-helper.sh
+++ b/deploy/wsl-mirrored-port-helper.sh
@@ -52,9 +52,9 @@ usage() {
 Usage: $PROG <clear|restore> --port <N>
 
 Modes:
-  clear     Remove any Windows ``tailscale serve --tcp <port>`` binding so
+  clear     Remove any Windows ``tailscale serve`` binding on ``<port>`` so
             a WSL service can bind the same port without conflict.
-  restore   Re-add the ``tailscale serve --tcp <port> tcp://127.0.0.1:<port>``
+  restore   Re-add the ``tailscale serve --http <port> http://127.0.0.1:<port>``
             bridge so the bound WSL service is reachable on the Tailnet.
 EOF
 }
@@ -167,11 +167,23 @@ status_output() {
 }
 
 port_is_configured() {
-    # The serve table prints lines like ``tcp://...:8321`` for each entry.
+    # The serve table prints lines like ``http://...:8321`` for each entry.
     # A literal ":${PORT}" hit anywhere in the listing is a reliable
     # "this port is currently served" signal — false positives are
     # acceptable because ``serve off`` is itself idempotent.
     status_output | grep -q ":${PORT}\\b"
+}
+
+port_has_tcp_binding() {
+    status_output | grep -q "tcp://.*:${PORT}\\b"
+}
+
+port_has_http_binding() {
+    status_output | grep -q "http://.*:${PORT}\\b"
+}
+
+port_has_https_binding() {
+    status_output | grep -q "https://.*:${PORT}\\b"
 }
 
 case "$MODE" in
@@ -182,8 +194,34 @@ case "$MODE" in
             exit 0
         fi
         log "clearing tailscale serve binding for port $PORT"
-        if ! "$TAILSCALE_EXE" serve --tcp="${PORT}" off >/dev/null 2>&1; then
-            log "ERROR: 'tailscale serve --tcp=$PORT off' failed"
+        cleared=0
+        failed=0
+        if port_has_tcp_binding; then
+            if "$TAILSCALE_EXE" serve --tcp="${PORT}" off >/dev/null 2>&1; then
+                cleared=1
+            else
+                log "WARN: 'tailscale serve --tcp=$PORT off' failed"
+                failed=1
+            fi
+        fi
+        if port_has_http_binding; then
+            if "$TAILSCALE_EXE" serve --http="${PORT}" off >/dev/null 2>&1; then
+                cleared=1
+            else
+                log "WARN: 'tailscale serve --http=$PORT off' failed"
+                failed=1
+            fi
+        fi
+        if port_has_https_binding; then
+            if "$TAILSCALE_EXE" serve --https="${PORT}" off >/dev/null 2>&1; then
+                cleared=1
+            else
+                log "WARN: 'tailscale serve --https=$PORT off' failed"
+                failed=1
+            fi
+        fi
+        if [[ "$cleared" == "0" && "$failed" == "1" ]]; then
+            log "ERROR: failed to clear all detected tailscale serve bindings for port $PORT"
             exit 3
         fi
         # Give the Windows TCP stack a moment to actually release the port
@@ -216,9 +254,9 @@ case "$MODE" in
             log "tailscale serve already has a binding for port $PORT; not re-adding"
             exit 0
         fi
-        log "restoring tailscale serve bridge: port $PORT -> tcp://127.0.0.1:$PORT"
-        if ! "$TAILSCALE_EXE" serve --tcp "${PORT}" --bg --yes "tcp://127.0.0.1:${PORT}" >/dev/null 2>&1; then
-            log "ERROR: 'tailscale serve --tcp $PORT --bg --yes tcp://127.0.0.1:$PORT' failed"
+        log "restoring tailscale serve bridge: http port $PORT -> http://127.0.0.1:$PORT"
+        if ! "$TAILSCALE_EXE" serve --http "${PORT}" --bg --yes "http://127.0.0.1:${PORT}" >/dev/null 2>&1; then
+            log "ERROR: 'tailscale serve --http $PORT --bg --yes http://127.0.0.1:$PORT' failed"
             exit 3
         fi
         log "restored"

--- a/tests/deploy/test_wsl_mirrored_port_helper.py
+++ b/tests/deploy/test_wsl_mirrored_port_helper.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 import subprocess
 from pathlib import Path
 
@@ -51,6 +52,9 @@ def _run(args: list[str], *, env: dict[str, str] | None = None) -> subprocess.Co
     run_env = os.environ.copy()
     if env:
         run_env.update(env)
+        existing_wslenv = run_env.get("WSLENV", "")
+        extra_wslenv = ":".join(env)
+        run_env["WSLENV"] = f"{existing_wslenv}:{extra_wslenv}" if existing_wslenv else extra_wslenv
     return subprocess.run(
         [BASH, _bash_path(SCRIPT), *args],
         capture_output=True,
@@ -119,6 +123,51 @@ def test_outside_wsl_is_a_noop_for_clear() -> None:
 def test_unknown_flag_rejected() -> None:
     result = _run(["clear", "--port", "8321", "--surprise"])
     assert result.returncode == 2
+
+
+@BASH_REQUIRED
+def test_clear_removes_http_tailscale_binding(tmp_path: Path) -> None:
+    """Clear must use the protocol shown by ``tailscale serve status``."""
+
+    calls = tmp_path / "tailscale-calls.txt"
+    fake_tailscale = tmp_path / "tailscale.exe"
+    fake_powershell = tmp_path / "powershell.exe"
+    calls_for_bash = _bash_path(calls)
+
+    fake_tailscale.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '{calls_for_bash}'
+if [[ "$*" == "serve status" ]]; then
+  printf 'http://controltower.tail2bbcc7.ts.net:8321 (tailnet only)\\n'
+  printf '|-- / proxy http://127.0.0.1:8321\\n'
+  exit 0
+fi
+if [[ "$*" == "serve --http=8321 off" ]]; then
+  exit 0
+fi
+exit 9
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    fake_powershell.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8", newline="\n")
+    fake_tailscale.chmod(fake_tailscale.stat().st_mode | stat.S_IXUSR)
+    fake_powershell.chmod(fake_powershell.stat().st_mode | stat.S_IXUSR)
+
+    result = _run(
+        ["clear", "--port", "8321"],
+        env={
+            "WSL_MIRRORED_PORT_HELPER_ASSUME_WSL": "1",
+            "WSL_MIRRORED_PORT_HELPER_POWERSHELL_EXE": _bash_path(fake_powershell),
+            "WSL_MIRRORED_PORT_HELPER_TAILSCALE_EXE": _bash_path(fake_tailscale),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    call_log = calls.read_text(encoding="utf-8")
+    assert "serve --http=8321 off" in call_log
+    assert "serve --tcp=8321 off" not in call_log
 
 
 def test_clear_removes_windows_portproxy_before_tailscale_binding() -> None:

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -17,12 +17,8 @@ pyproject.toml satisfy the non-blocking/blocking policy introduced in #400:
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
-
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib  # Python < 3.11
 
 ROOT = Path(__file__).resolve().parent.parent
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci-standard.yml"
@@ -88,6 +84,21 @@ def test_pip_audit_reads_ignore_file() -> None:
     assert "requirements-audit-ignore.txt" in step_window, (
         "pip-audit step must read requirements-audit-ignore.txt for MEDIUM/LOW waivers"
     )
+
+
+def test_security_scan_uses_isolated_no_cache_pip_audit() -> None:
+    """security-scan must not execute pip-audit from the cache-backed project venv."""
+    text = _workflow_text()
+    scan_idx = text.find("security-scan:")
+    tests_idx = text.find("\n  tests:", scan_idx)
+    assert scan_idx != -1, "security-scan job not found in ci-standard.yml"
+    assert tests_idx != -1, "tests job not found after security-scan in ci-standard.yml"
+    scan_job = text[scan_idx:tests_idx]
+
+    assert 'PIP_NO_CACHE_DIR: "1"' in scan_job
+    assert "--no-cache-dir pip-audit" in scan_job
+    assert "-r requirements.txt" in scan_job
+    assert "./.venv/bin/python -m pip_audit" not in scan_job
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_config_constants.py
+++ b/tests/test_dashboard_config_constants.py
@@ -58,7 +58,7 @@ def test_http_timeout_values() -> None:
     assert HttpTimeout.MAXWELL_PROXY_S == 3.0
     assert HttpTimeout.HUB_VERSION_FETCH_S == 5.0
     assert HttpTimeout.SYSTEMCTL_S == 5
-    assert HttpTimeout.PROXY_NODE_SYSTEM_S == 8.0
+    assert HttpTimeout.PROXY_NODE_SYSTEM_S == 30.0
     assert HttpTimeout.PROXY_TO_HUB_S == 15.0
     assert HttpTimeout.GH_API_DEFAULT_S == 15
     assert HttpTimeout.RUN_CMD_DEFAULT_S == 20


### PR DESCRIPTION
## Summary

- move ControlTower dashboard registry URLs off the retired `100.95.177.68` node and onto the live MagicDNS dashboard endpoints
- increase cross-node system telemetry timeout to 30s so busy DeskComputer-class nodes can return full telemetry instead of partial fleet state
- make the WSL mirrored-port helper protocol-aware for HTTP/HTTPS/TCP Tailscale Serve bindings and restore HTTP Serve for dashboard access
- add regression coverage for HTTP Tailscale Serve clearing plus update the timeout contract test

## Validation

- `python -m ruff check backend/dashboard_config/timeouts.py tests/test_dashboard_config_constants.py tests/deploy/test_wsl_mirrored_port_helper.py`
- `python -m mypy backend/dashboard_config/timeouts.py tests/test_dashboard_config_constants.py tests/deploy/test_wsl_mirrored_port_helper.py`
- `bash -n deploy/wsl-mirrored-port-helper.sh`
- `python -m pytest tests/test_dashboard_config_constants.py tests/deploy/test_wsl_mirrored_port_helper.py`
- `python -m pytest tests/test_machine_registry.py tests/test_fleet_autoconfig.py tests/test_dashboard_config_constants.py tests/deploy/test_wsl_mirrored_port_helper.py`
- `python -m pytest` (`2601 passed, 19 skipped, 1 xfailed`)

## Operational Evidence

- ControlTower NVMe and SSD dashboard health endpoints returned healthy with GitHub App auth OK.
- DeskComputer and OGLaptop dashboard health endpoints returned healthy with GitHub App auth OK.
- Fleet aggregation returned all four nodes online with full telemetry after the live deployment.
