### PR TITLE
fix(security): reject signature-less dispatch envelopes (#919)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,20 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.83
+**Spec Version:** 2.5.84
 **Application Version:** 4.8.0 (see `VERSION`)
-**Last Updated:** 2026-06-10T00:00:00-07:00
+**Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.84):** Closed the dispatch HMAC signature-gate bypass
+  (security, issue #919). `CommandEnvelope.from_dict` no longer runs the
+  auto-signing path used for locally minted envelopes: an inbound wire body is
+  reconstructed verbatim and a new `signature_authentic` flag records whether a
+  non-empty signature was actually present. `validate_envelope_crypto` now
+  rejects any envelope whose signature was absent on the wire
+  (`"envelope signature missing"`), so `POST /api/fleet/dispatch/submit` returns
+  400 for signature-less or empty-signature envelopes instead of the server
+  minting a valid signature on the caller's behalf. Locally minted,
+  server-originated envelopes still auto-sign and round-trip unchanged.
 - **2026-06-10 (2.5.83):** Corrected queue-diagnosis target classification for
   fleet jobs whose GitHub job metadata contains only custom `d-sorg-fleet*`
   labels. These jobs are now counted as self-hosted fleet work instead of

--- a/backend/dispatch/envelope.py
+++ b/backend/dispatch/envelope.py
@@ -88,6 +88,13 @@ class CommandEnvelope:
     principal: str = ""
     on_behalf_of: str = ""
     correlation_id: str = ""
+    # Issue #919: True when this envelope's signature is trustworthy as to its
+    # origin — i.e. it was either minted locally by ``__post_init__`` (a
+    # server-originated envelope) OR carried a non-empty signature when parsed
+    # from the wire by ``from_dict``. It is False ONLY for a wire envelope that
+    # arrived with no signature, which must never have one minted on the
+    # caller's behalf. ``validate_envelope_crypto`` rejects such envelopes.
+    signature_authentic: bool = field(default=False, compare=False)
 
     def __post_init__(self) -> None:
         if not self.signature:
@@ -108,6 +115,10 @@ class CommandEnvelope:
                 _hash_payload(self.payload),
             )
             object.__setattr__(self, "signature", sig)
+        # A locally minted envelope (or one constructed with an explicit
+        # signature) is authentic by construction — we never reach the
+        # wire-parsing path for it.
+        object.__setattr__(self, "signature_authentic", bool(self.signature))
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
@@ -117,25 +128,36 @@ class CommandEnvelope:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CommandEnvelope:
+        """Reconstruct an envelope from an untrusted wire body.
+
+        Issue #919: inbound parsing must NEVER auto-sign. An attacker who omits
+        the signature must not have one minted on their behalf. We therefore
+        build the instance without ever entering ``__post_init__``'s signing
+        branch by constructing through ``object.__new__`` and recording the
+        wire signature verbatim. ``signature_authentic`` captures whether a
+        non-empty signature was actually present so downstream crypto
+        validation can fail-loud on absence.
+        """
         confirmation_data = data.get("confirmation")
         confirmation = DispatchConfirmation.from_dict(confirmation_data) if confirmation_data is not None else None
-        envelope = cls(
-            action=_required_string(data, "action"),
-            source=_required_string(data, "source"),
-            target=_required_string(data, "target"),
-            requested_by=_required_string(data, "requested_by"),
-            reason=str(data.get("reason", "")),
-            payload=_ensure_dict(data.get("payload")),
-            confirmation=confirmation,
-            envelope_id=str(data.get("envelope_id", uuid4().hex)),
-            schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
-            envelope_version=int(data.get("envelope_version", ENVELOPE_VERSION)),
-            issued_at=str(data.get("issued_at", utc_now_iso())),
-            signature=str(data.get("signature", "")),
-            principal=str(data.get("principal", "")),
-            on_behalf_of=str(data.get("on_behalf_of", "")),
-            correlation_id=str(data.get("correlation_id", "")),
-        )
+        wire_signature = str(data.get("signature", ""))
+        envelope = object.__new__(cls)
+        object.__setattr__(envelope, "action", _required_string(data, "action"))
+        object.__setattr__(envelope, "source", _required_string(data, "source"))
+        object.__setattr__(envelope, "target", _required_string(data, "target"))
+        object.__setattr__(envelope, "requested_by", _required_string(data, "requested_by"))
+        object.__setattr__(envelope, "reason", str(data.get("reason", "")))
+        object.__setattr__(envelope, "payload", _ensure_dict(data.get("payload")))
+        object.__setattr__(envelope, "confirmation", confirmation)
+        object.__setattr__(envelope, "envelope_id", str(data.get("envelope_id", uuid4().hex)))
+        object.__setattr__(envelope, "schema_version", str(data.get("schema_version", SCHEMA_VERSION)))
+        object.__setattr__(envelope, "envelope_version", int(data.get("envelope_version", ENVELOPE_VERSION)))
+        object.__setattr__(envelope, "issued_at", str(data.get("issued_at", utc_now_iso())))
+        object.__setattr__(envelope, "signature", wire_signature)
+        object.__setattr__(envelope, "principal", str(data.get("principal", "")))
+        object.__setattr__(envelope, "on_behalf_of", str(data.get("on_behalf_of", "")))
+        object.__setattr__(envelope, "correlation_id", str(data.get("correlation_id", "")))
+        object.__setattr__(envelope, "signature_authentic", bool(wire_signature))
         return envelope
 
     def verify_signature(self) -> bool:

--- a/backend/dispatch/validate.py
+++ b/backend/dispatch/validate.py
@@ -41,6 +41,13 @@ def validate_envelope_crypto(envelope: object) -> CryptoValidationResult:
     - Timestamp is fresh (issued_at within ±5 minutes)
     - Confirmation timestamp is fresh if confirmation is present (approved_at within ±5 minutes)
     """
+    # Issue #919: an envelope parsed from the wire that arrived WITHOUT a
+    # signature must be rejected outright. The server must never mint a
+    # signature on the caller's behalf during parsing. ``signature_authentic``
+    # is False only for a wire envelope whose signature field was empty.
+    if not getattr(envelope, "signature_authentic", False):
+        return CryptoValidationResult(valid=False, reason="envelope signature missing")
+
     if not envelope.signature:  # type: ignore[attr-defined]
         return CryptoValidationResult(valid=False, reason="envelope signature missing")
 

--- a/tests/api/test_dispatch_signature_gate.py
+++ b/tests/api/test_dispatch_signature_gate.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #919 — dispatch HMAC signature gate.
+
+An attacker who POSTs a signature-less (or empty-signature) envelope to
+``/api/fleet/dispatch/submit`` must be rejected. The server must never mint a
+signature on the caller's behalf during inbound parsing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_BACKEND = str(Path(__file__).resolve().parents[2] / "backend")
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 11), reason="dispatch_contract requires Python 3.11+")
+
+_SECRET = "test-dispatch-secret-919"  # pragma: allowlist secret
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("DISPATCH_SIGNING_SECRET", _SECRET)
+    from routers import dispatch  # noqa: PLC0415
+
+    app = FastAPI()
+    app.include_router(dispatch.router)
+    return TestClient(app)
+
+
+def _valid_envelope_dict() -> dict:
+    """A correctly signed, allowlisted envelope minted locally."""
+    import dispatch_contract  # noqa: PLC0415
+
+    action = next(iter(dispatch_contract.ALLOWLISTED_ACTIONS.values()))
+    env = dispatch_contract.build_envelope(
+        action=action.name,
+        source="hub",
+        target="node-1",
+        requested_by="operator",
+    )
+    return env.to_dict()
+
+
+def test_from_dict_never_mints_signature() -> None:
+    """Issue #919: parsing a wire body with no signature must not auto-sign."""
+    os.environ["DISPATCH_SIGNING_SECRET"] = _SECRET
+    import dispatch_contract  # noqa: PLC0415
+
+    data = _valid_envelope_dict()
+    data["signature"] = ""
+
+    parsed = dispatch_contract.CommandEnvelope.from_dict(data)
+
+    assert parsed.signature == "", "from_dict must leave an absent wire signature empty"
+    assert parsed.signature_authentic is False
+    crypto = dispatch_contract.validate_envelope_crypto(parsed)
+    assert crypto.valid is False
+    assert "signature missing" in crypto.reason
+
+
+def test_from_dict_preserves_wire_signature_verbatim() -> None:
+    """A provided wire signature is preserved exactly, never re-minted."""
+    os.environ["DISPATCH_SIGNING_SECRET"] = _SECRET
+    import dispatch_contract  # noqa: PLC0415
+
+    data = _valid_envelope_dict()
+    data["signature"] = "f" * 64  # attacker-supplied garbage
+
+    parsed = dispatch_contract.CommandEnvelope.from_dict(data)
+
+    assert parsed.signature == "f" * 64
+    # Garbage signature is authentic-as-present but fails verification.
+    assert parsed.signature_authentic is True
+    crypto = dispatch_contract.validate_envelope_crypto(parsed)
+    assert crypto.valid is False
+    assert "invalid" in crypto.reason
+
+
+def test_submit_rejects_missing_signature(client: TestClient) -> None:
+    """POST with the signature field omitted entirely is rejected (not 2xx)."""
+    data = _valid_envelope_dict()
+    data.pop("signature", None)
+
+    resp = client.post("/api/fleet/dispatch/submit", json=data)
+
+    assert resp.status_code in (400, 401, 403), resp.text
+    assert "signature missing" in resp.text
+
+
+def test_submit_rejects_empty_signature(client: TestClient) -> None:
+    """POST with an empty-string signature is rejected."""
+    data = _valid_envelope_dict()
+    data["signature"] = ""
+
+    resp = client.post("/api/fleet/dispatch/submit", json=data)
+
+    assert resp.status_code in (400, 401, 403), resp.text
+    assert "signature missing" in resp.text
+
+
+def test_submit_rejects_wrong_signature(client: TestClient) -> None:
+    """POST with an incorrect signature is rejected."""
+    data = _valid_envelope_dict()
+    data["signature"] = "a" * 64
+
+    resp = client.post("/api/fleet/dispatch/submit", json=data)
+
+    assert resp.status_code in (400, 401, 403), resp.text
+    assert "invalid" in resp.text
+
+
+def test_submit_accepts_correctly_signed_envelope(client: TestClient) -> None:
+    """A locally minted, correctly signed envelope still round-trips."""
+    data = _valid_envelope_dict()
+
+    resp = client.post("/api/fleet/dispatch/submit", json=data)
+
+    # Accepted at the crypto gate. Non-privileged allowlisted action should
+    # pass validation and return the prototype command.
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["action"] == data["action"]


### PR DESCRIPTION
## P0 security — dispatch HMAC signature-gate bypass

`CommandEnvelope.from_dict` reconstructed inbound envelopes via the normal
constructor, whose `__post_init__` auto-signs whenever `signature` is empty. An
attacker POSTing a signature-less envelope to `/api/fleet/dispatch/submit` thus
had a valid signature **minted on their behalf** during parsing — the HMAC gate
provided zero authentication.

### Fix
- `from_dict` now reconstructs the wire envelope via `object.__new__` (never the
  signing path) and records a new `signature_authentic` flag: `True` only when a
  non-empty signature was present on the wire, or when the envelope was minted
  locally (server-originated).
- `validate_envelope_crypto` rejects any envelope whose signature was absent on
  the wire (`"envelope signature missing"`).

### Verification (tests/api/test_dispatch_signature_gate.py)
- `POST /api/fleet/dispatch/submit` with missing/empty signature → 400, body
  "signature missing".
- Wrong signature → 400 "invalid".
- `from_dict` provably never mints a signature (wire signature preserved verbatim).
- Correctly signed local envelope still round-trips (200).

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)