### PR TITLE
fix(security): authenticate the agent-launcher control surface (#920)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,19 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.83
+**Spec Version:** 2.5.84
 **Application Version:** 4.8.0 (see `VERSION`)
-**Last Updated:** 2026-06-10T00:00:00-07:00
+**Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.84):** Authenticated the agent-launcher control surface
+  (security, issue #920). Every `/api/agent-launcher/*` route now requires an
+  authenticated principal; the mutating routes (`PUT /config`, `POST /start`,
+  `POST /stop`, `POST /run-once`) additionally require the privileged
+  `system.control` scope. Previously these routes — which spawn code-executing
+  agent processes and write attacker-controllable JSON into the operator's home
+  directory — were completely unauthenticated, so any LAN/Tailscale peer
+  reaching the dashboard port could launch or reconfigure agents (RCE-adjacent).
+  Unauthenticated requests now return 401 and under-scoped principals get 403.
 - **2026-06-10 (2.5.83):** Corrected queue-diagnosis target classification for
   fleet jobs whose GitHub job metadata contains only custom `d-sorg-fleet*`
   labels. These jobs are now counted as self-hosted fleet work instead of

--- a/backend/agent_launcher_router.py
+++ b/backend/agent_launcher_router.py
@@ -34,10 +34,18 @@ import subprocess
 import threading
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
+from identity import Principal, require_principal, require_scope
 from pydantic import BaseModel, Field
 
 log = logging.getLogger("dashboard.agent_launcher")
+
+# Issue #920: the agent-launcher control surface spawns code-executing agent
+# processes and writes attacker-controllable JSON into the operator's home
+# directory. Every route must be authenticated; mutating routes additionally
+# require the privileged ``system.control`` scope. Read routes require only an
+# authenticated principal.
+_CONTROL_SCOPE = "system.control"
 router = APIRouter(prefix="/api/agent-launcher", tags=["agent-launcher"])
 
 # Bound concurrent launcher spawns to prevent fork-bomb when multiple dashboard
@@ -240,7 +248,7 @@ def _read_lock(agent_name: str) -> dict | None:
 
 
 @router.get("/status", response_model=StatusResponse)
-def get_status() -> StatusResponse:
+def get_status(_principal: Principal = Depends(require_principal)) -> StatusResponse:  # noqa: B008
     """Quick status read. Pure file I/O — no subprocess. Safe to poll
     every few seconds from the dashboard."""
     cfg = _read_config_dict_safe()
@@ -288,11 +296,12 @@ def _read_config_dict_safe() -> dict:
 # ---------------------------------------------------------------------------
 # Config — read returns normalized v2; write validates via launcher CLI
 # ---------------------------------------------------------------------------
-@router.get("/config")
-def get_config() -> dict:
-    """Return the normalized v2 user config. Delegates to the launcher's
-    ``--validate-config`` so the response matches whatever the scheduler
-    will see."""
+def _validated_config() -> dict:
+    """Return the normalized v2 user config from the launcher.
+
+    Extracted so internal callers (e.g. ``run_once``) can read the validated
+    config without going through the authenticated route dependency.
+    """
     rc, stdout, stderr = _run_cli("--validate-config")
     if rc != 0:
         raise HTTPException(
@@ -305,8 +314,19 @@ def get_config() -> dict:
         raise HTTPException(status_code=500, detail=f"launcher returned invalid JSON: {exc}") from exc
 
 
+@router.get("/config")
+def get_config(_principal: Principal = Depends(require_principal)) -> dict:  # noqa: B008
+    """Return the normalized v2 user config. Delegates to the launcher's
+    ``--validate-config`` so the response matches whatever the scheduler
+    will see."""
+    return _validated_config()
+
+
 @router.put("/config", response_model=SimpleResponse)
-async def put_config(request: Request) -> SimpleResponse:
+async def put_config(
+    request: Request,
+    _principal: Principal = Depends(require_scope(_CONTROL_SCOPE)),  # noqa: B008
+) -> SimpleResponse:
     """Replace the user config. Validates by writing to a temp file and
     invoking the launcher's ``--validate-config --config <tmp>``; only
     promotes to the real config path if validation passes (atomic
@@ -346,7 +366,7 @@ async def put_config(request: Request) -> SimpleResponse:
 # Repos — live WSL inventory
 # ---------------------------------------------------------------------------
 @router.get("/repos", response_model=ReposResponse)
-def get_repos() -> ReposResponse:
+def get_repos(_principal: Principal = Depends(require_principal)) -> ReposResponse:  # noqa: B008
     rc, stdout, stderr = _run_cli("--list-repos", timeout=45.0)
     if rc != 0:
         raise HTTPException(
@@ -378,7 +398,9 @@ def _cli_path() -> Path:
 
 
 @router.post("/start", response_model=SimpleResponse)
-def start_scheduler() -> SimpleResponse:
+def start_scheduler(
+    _principal: Principal = Depends(require_scope(_CONTROL_SCOPE)),  # noqa: B008
+) -> SimpleResponse:
     pid_info = _read_pidfile()
     if pid_info and _is_pid_alive(int(pid_info.get("pid", -1))):
         return SimpleResponse(ok=True, detail=f"already running (pid {pid_info['pid']})")
@@ -420,7 +442,9 @@ def start_scheduler() -> SimpleResponse:
 
 
 @router.post("/stop", response_model=SimpleResponse)
-def stop_scheduler() -> SimpleResponse:
+def stop_scheduler(
+    _principal: Principal = Depends(require_scope(_CONTROL_SCOPE)),  # noqa: B008
+) -> SimpleResponse:
     rc, stdout, stderr = _run_cli("--stop")
     if rc == 4:
         return SimpleResponse(ok=False, detail="no running scheduler found")
@@ -430,10 +454,13 @@ def stop_scheduler() -> SimpleResponse:
 
 
 @router.post("/run-once", response_model=SimpleResponse)
-def run_once(req: RunOnceRequest) -> SimpleResponse:
+def run_once(
+    req: RunOnceRequest,
+    _principal: Principal = Depends(require_scope(_CONTROL_SCOPE)),  # noqa: B008
+) -> SimpleResponse:
     """Spawn one window for one agent now (does not affect the scheduler)."""
     # Validate the agent exists first by reading the (validated) config.
-    cfg = get_config()
+    cfg = _validated_config()
     if req.agent not in cfg.get("agents", {}):
         known = list(cfg.get("agents", {}))
         raise HTTPException(

--- a/tests/api/test_agent_launcher_auth_perimeter.py
+++ b/tests/api/test_agent_launcher_auth_perimeter.py
@@ -1,0 +1,110 @@
+"""Auth-perimeter regression tests for the agent-launcher router (issue #920).
+
+The agent-launcher control surface spawns code-executing agent processes and
+writes attacker-controllable JSON into the operator's home directory. Before
+this fix every route was unauthenticated, so any LAN/Tailscale peer reaching
+the dashboard port could start/stop/configure agents (RCE-adjacent).
+
+These tests assert:
+- Unauthenticated calls to every route return 401.
+- An authenticated principal lacking ``system.control`` gets 403 on mutating
+  routes (config PUT, start, stop, run-once).
+- A properly scoped principal still passes the auth gate.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_BACKEND = str(Path(__file__).resolve().parents[2] / "backend")
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+import agent_launcher_router as alr  # noqa: E402
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 11), reason="requires Python 3.11+")
+
+
+# Routes that mutate state / spawn processes — require system.control.
+_MUTATING = [
+    ("put", "/api/agent-launcher/config", {"agents": {}}),
+    ("post", "/api/agent-launcher/start", None),
+    ("post", "/api/agent-launcher/stop", None),
+    ("post", "/api/agent-launcher/run-once", {"agent": "x"}),
+]
+
+# Read routes — require an authenticated principal (any role).
+_READ = [
+    ("get", "/api/agent-launcher/status"),
+    ("get", "/api/agent-launcher/config"),
+    ("get", "/api/agent-launcher/repos"),
+]
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    from starlette.middleware.sessions import SessionMiddleware  # noqa: PLC0415
+
+    app = FastAPI()
+    # Production mounts SessionMiddleware; require_principal consults
+    # request.session, so the test app must mirror that to reach the 401 path
+    # rather than tripping Starlette's "SessionMiddleware must be installed".
+    app.add_middleware(SessionMiddleware, secret_key="test-perimeter")  # noqa: S106  # pragma: allowlist secret
+    app.include_router(alr.router)
+    return app
+
+
+def _call(client: TestClient, method: str, url: str, json_body=None):
+    return getattr(client, method)(url, json=json_body) if json_body is not None else getattr(client, method)(url)
+
+
+@pytest.mark.parametrize(("method", "url", "body"), _MUTATING)
+def test_mutating_routes_reject_unauthenticated(app: FastAPI, method: str, url: str, body) -> None:
+    client = TestClient(app)
+    resp = _call(client, method, url, body)
+    assert resp.status_code == 401, f"{method.upper()} {url} should require auth, got {resp.status_code}"
+
+
+@pytest.mark.parametrize(("method", "url"), _READ)
+def test_read_routes_reject_unauthenticated(app: FastAPI, method: str, url: str) -> None:
+    client = TestClient(app)
+    resp = _call(client, method, url)
+    assert resp.status_code == 401, f"{method.upper()} {url} should require auth, got {resp.status_code}"
+
+
+@pytest.mark.parametrize(("method", "url", "body"), _MUTATING)
+def test_mutating_routes_reject_insufficient_scope(app: FastAPI, method: str, url: str, body) -> None:
+    """A viewer principal (no system.control scope) gets 403 on mutating routes."""
+    from identity import Principal, require_principal  # noqa: PLC0415
+
+    app.dependency_overrides[require_principal] = lambda: Principal(
+        id="viewer", type="bot", name="Viewer", roles=["viewer"]
+    )
+    try:
+        client = TestClient(app)
+        resp = _call(client, method, url, body)
+        assert resp.status_code == 403, f"{method.upper()} {url} should require system.control, got {resp.status_code}"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_status_allows_authenticated_principal(app: FastAPI, monkeypatch, tmp_path) -> None:
+    """A read route succeeds for any authenticated principal."""
+    from identity import Principal, require_principal  # noqa: PLC0415
+
+    monkeypatch.setattr(alr, "_runtime_root", lambda: tmp_path)
+    monkeypatch.setattr(alr, "_is_pid_alive", lambda pid: False)
+    app.dependency_overrides[require_principal] = lambda: Principal(
+        id="viewer", type="bot", name="Viewer", roles=["viewer"]
+    )
+    try:
+        client = TestClient(app)
+        resp = client.get("/api/agent-launcher/status")
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_agent_launcher_router.py
+++ b/tests/test_agent_launcher_router.py
@@ -39,7 +39,20 @@ def app(runtime):
 
 @pytest.fixture
 def client(app):
-    return TestClient(app)
+    """Authenticated client (admin principal) for the functional tests.
+
+    Issue #920: all agent-launcher routes now require authentication. The
+    behavioural tests exercise the launcher logic, not the auth gate, so we
+    inject an admin principal. The auth gate itself is covered by
+    ``test_agent_launcher_auth_perimeter.py`` using an unauthenticated client.
+    """
+    from identity import Principal, require_principal  # noqa: PLC0415
+
+    app.dependency_overrides[require_principal] = lambda: Principal(
+        id="test-admin", type="bot", name="Test Admin", roles=["admin"]
+    )
+    yield TestClient(app)
+    app.dependency_overrides.clear()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## P0 security — unauthenticated agent-launcher (RCE-adjacent)

Every `/api/agent-launcher/*` route was unauthenticated. `POST /start` and
`/run-once` spawn code-executing agent processes via subprocess; `PUT /config`
writes attacker-controlled JSON into the operator's home directory. With the
server bound to 0.0.0.0, any LAN/Tailscale peer reaching the dashboard port had
a code-execution control plane.

### Fix
- Read routes (`/status`, `/config`, `/repos`) now require `require_principal`.
- Mutating routes (`PUT /config`, `POST /start`, `POST /stop`, `POST /run-once`)
  require `require_scope("system.control")`.
- `get_config`'s CLI read extracted to `_validated_config()` so `run_once` reuses
  it without the route dependency.

### Verification (tests/api/test_agent_launcher_auth_perimeter.py)
- Unauthenticated calls to all 7 routes → 401.
- Viewer principal (no `system.control`) → 403 on all 4 mutating routes.
- Authenticated principal still passes.

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)