### PR TITLE
fix(security): gate dev-login on loopback + opt-in and honor DASHBOARD_HOST bind (#921)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,14 @@ GITHUB_ORG=D-sorganization
 DASHBOARD_PORT=8321
 DISPLAY_NAME=
 RUNNER_DASHBOARD_REPO_ROOT=
+# Bind interface for uvicorn. Defaults to 0.0.0.0 (all interfaces). Set to
+# 127.0.0.1 to bind loopback-only (recommended on WSL-mirrored / Tailscale hosts).
+DASHBOARD_HOST=
+# Opt-in to the loopback-only dev-login admin shortcut (issue #921). Leave UNSET
+# in any networked/production deployment. When "1" AND the request originates
+# from loopback, GET /api/auth/dev-login mints a local admin session; otherwise
+# the endpoint returns 404.
+DASHBOARD_DEV_LOGIN=
 
 # Runner limits
 NUM_RUNNERS=12

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -319,7 +319,7 @@
         "filename": "tests\\api\\test_dev_login_persistence.py",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 66
       }
     ],
     "tests\\api\\test_linear_taxonomy_map.py": [
@@ -576,5 +576,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-27T03:22:55Z"
+  "generated_at": "2026-06-12T19:56:41Z"
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,18 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.85
+**Spec Version:** 2.5.86
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.86):** Closed unauthenticated remote admin via the dev-login
+  endpoint (security, issue #921). `GET /api/auth/dev-login` — which mints an
+  admin session for the first human principal — is now gated on BOTH a loopback
+  transport peer AND an explicit `DASHBOARD_DEV_LOGIN=1` opt-in; any request
+  failing either gate gets a `404` (indistinguishable from "not present" to a
+  remote scanner). The `__main__` uvicorn bind now uses `dashboard_config.HOST`
+  (honoring `DASHBOARD_HOST`) instead of a hardcoded `0.0.0.0`; the default
+  still resolves to `0.0.0.0` so existing deployments are unchanged.
 - **2026-06-12 (2.5.85):** Closed the dispatch HMAC signature-gate bypass
   (security, issue #919). `CommandEnvelope.from_dict` no longer runs the
   auto-signing path used for locally minted envelopes: an inbound wire body is

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -8,7 +8,12 @@ import httpx
 import session_management as sm
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
-from identity import Principal, identity_manager, require_principal
+from identity import (
+    Principal,
+    _is_loopback_request,
+    identity_manager,
+    require_principal,
+)
 from middleware import check_auth_rate_limit
 from pydantic import BaseModel
 
@@ -20,6 +25,15 @@ GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
 GITHUB_ORG = os.environ.get("GITHUB_ORG", os.environ.get("REQUIRED_GITHUB_ORG", ""))
 REQUIRED_GITHUB_ORG = GITHUB_ORG
 _OAUTH_STATE_TTL_SECONDS = 10 * 60
+
+
+def _dev_login_enabled() -> bool:
+    """Dev-login is opt-in via an explicit env flag (issue #921).
+
+    Read at call time (not import time) so tests and operators can toggle it
+    without re-importing the module.
+    """
+    return os.environ.get("DASHBOARD_DEV_LOGIN") == "1"
 
 
 def _clear_oauth_state(request: Request) -> None:
@@ -131,10 +145,21 @@ async def github_callback(request: Request, code: str, state: str):
 
 @router.get("/dev-login")
 async def dev_login(request: Request):
-    """Development login when OAuth is not configured."""
+    """Development login when OAuth is not configured.
+
+    Hardened per issue #921: this endpoint mints an admin session for the first
+    human principal, so it must never be reachable from the network. It is gated
+    on BOTH a loopback transport peer AND an explicit ``DASHBOARD_DEV_LOGIN=1``
+    opt-in. Any request failing either gate gets a 404 so the endpoint is
+    indistinguishable from "not present" to a remote scanner.
+    """
     check_auth_rate_limit(request)  # issue #320: 5 attempts / 5 min per IP
     if GITHUB_CLIENT_ID:
         raise HTTPException(status_code=400, detail="Dev login disabled when OAuth is configured")
+
+    # Fail closed for any non-loopback peer or when the opt-in flag is unset.
+    if not (_dev_login_enabled() and _is_loopback_request(request)):
+        raise HTTPException(status_code=404, detail="Not Found")
 
     # Just grab the first human principal
     for p in identity_manager.principals.values():

--- a/backend/server.py
+++ b/backend/server.py
@@ -2727,7 +2727,10 @@ if __name__ == "__main__":
     _uvicorn_target: object = "server:app" if _uvicorn_cfg["workers"] > 1 else app
     uvicorn.run(
         _uvicorn_target,  # type: ignore[arg-type]
-        host="0.0.0.0",  # B104: intentionally binding to all interfaces; listed in bandit.yaml
+        # Issue #921: honor the operator-resolved bind host (DASHBOARD_HOST) instead
+        # of a hardcoded 0.0.0.0. Defaults to 0.0.0.0 when DASHBOARD_HOST is unset,
+        # preserving historical behavior while letting operators bind loopback-only.
+        host=dashboard_config.HOST,  # noqa: S104 — default resolves to 0.0.0.0; see dashboard_config._resolve_bind_host
         port=PORT,
         log_level="warning",  # FastAPI handles its own logging
         workers=_uvicorn_cfg["workers"],

--- a/tests/api/test_dev_login_gate.py
+++ b/tests/api/test_dev_login_gate.py
@@ -1,0 +1,136 @@
+"""Dev-login perimeter hardening tests (issue #921).
+
+The /api/auth/dev-login endpoint mints an admin session for the first human
+principal. Before #921 it was reachable by any network peer whenever OAuth was
+unconfigured (the out-of-the-box default), combined with a hardcoded 0.0.0.0
+bind — i.e. unauthenticated remote admin.
+
+Acceptance criteria verified here:
+- Non-loopback request to GET /api/auth/dev-login returns 404 (even with the
+  opt-in flag set).
+- Loopback request WITHOUT DASHBOARD_DEV_LOGIN=1 is rejected (404).
+- Loopback request WITH DASHBOARD_DEV_LOGIN=1 still works for local dev.
+- The server __main__ bind honors dashboard_config.HOST rather than a hardcoded
+  0.0.0.0.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+_BACKEND_DIR = Path(__file__).parent.parent.parent / "backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit() -> None:
+    """Clear the shared per-IP auth rate-limit store (issue #320) between tests."""
+    import middleware
+
+    middleware._auth_rate_store.clear()
+
+
+def _make_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    """Minimal app wired to the auth router with a temp identity store."""
+    import session_management as sm
+    from identity import IdentityManager
+    from routers import auth as auth_module
+
+    sessions_path = tmp_path / "sessions.json"
+    sessions_path.write_text("[]")
+    monkeypatch.setattr(sm, "_SESSIONS_PATH", sessions_path)
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    mgr = IdentityManager(config_dir=config_dir)
+    monkeypatch.setattr(auth_module, "identity_manager", mgr)
+    monkeypatch.setattr(auth_module, "GITHUB_CLIENT_ID", "")
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-key")  # pragma: allowlist secret
+    app.include_router(auth_module.router)
+    return app
+
+
+def _client(app: FastAPI, host: str) -> TestClient:
+    """TestClient whose transport peer address is ``host``."""
+    return TestClient(app, follow_redirects=False, client=(host, 12345))
+
+
+# ── Non-loopback is always rejected, even with the opt-in flag ────────────────
+
+
+def test_non_loopback_dev_login_returns_404_even_with_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_DEV_LOGIN", "1")
+    app = _make_app(tmp_path, monkeypatch)
+    resp = _client(app, "192.168.1.50").get("/api/auth/dev-login")
+    assert resp.status_code == 404
+
+
+def test_non_loopback_dev_login_returns_404_without_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DASHBOARD_DEV_LOGIN", raising=False)
+    app = _make_app(tmp_path, monkeypatch)
+    resp = _client(app, "10.0.0.7").get("/api/auth/dev-login")
+    assert resp.status_code == 404
+
+
+# ── Loopback without the opt-in flag is rejected ──────────────────────────────
+
+
+def test_loopback_dev_login_without_flag_returns_404(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DASHBOARD_DEV_LOGIN", raising=False)
+    app = _make_app(tmp_path, monkeypatch)
+    resp = _client(app, "127.0.0.1").get("/api/auth/dev-login")
+    assert resp.status_code == 404
+
+
+# ── Loopback with the opt-in flag still works for local development ───────────
+
+
+def test_loopback_dev_login_with_flag_succeeds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_DEV_LOGIN", "1")
+    app = _make_app(tmp_path, monkeypatch)
+    resp = _client(app, "127.0.0.1").get("/api/auth/dev-login")
+    assert resp.status_code in (200, 302, 307)
+    # A session principal cookie should now be set.
+    assert resp.cookies or "set-cookie" in {k.lower() for k in resp.headers}
+
+
+def test_loopback_ipv6_dev_login_with_flag_succeeds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DASHBOARD_DEV_LOGIN", "1")
+    app = _make_app(tmp_path, monkeypatch)
+    resp = _client(app, "::1").get("/api/auth/dev-login")
+    assert resp.status_code in (200, 302, 307)
+
+
+# ── Server bind honors dashboard_config.HOST (issue #921) ─────────────────────
+
+
+def test_server_main_binds_resolved_host_not_hardcoded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`python backend/server.py` must pass dashboard_config.HOST to uvicorn.run,
+    and DASHBOARD_HOST must be honored."""
+    import importlib
+
+    import dashboard_config
+
+    monkeypatch.setenv("DASHBOARD_HOST", "127.0.0.1")
+    importlib.reload(dashboard_config)
+    assert dashboard_config.HOST == "127.0.0.1"
+
+    src = (_BACKEND_DIR / "server.py").read_text(encoding="utf-8")
+    # The uvicorn.run call must reference the resolved host, not a literal bind-all.
+    assert "host=dashboard_config.HOST" in src
+    assert 'host="0.0.0.0"' not in src
+
+    monkeypatch.delenv("DASHBOARD_HOST", raising=False)
+    importlib.reload(dashboard_config)
+    assert dashboard_config.HOST == "0.0.0.0"  # default preserved

--- a/tests/api/test_dev_login_persistence.py
+++ b/tests/api/test_dev_login_persistence.py
@@ -28,6 +28,20 @@ if str(_BACKEND_DIR) not in sys.path:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _enable_dev_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dev-login is opt-in (issue #921). TestClient connects from loopback, so
+    enabling the flag is sufficient to exercise the persistence behaviour.
+
+    Also clears the per-IP auth rate-limit store (issue #320) so repeated
+    loopback dev-login calls across tests don't trip the shared 5/5min limiter.
+    """
+    monkeypatch.setenv("DASHBOARD_DEV_LOGIN", "1")
+    import middleware
+
+    middleware._auth_rate_store.clear()
+
+
 def _make_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     """Build a minimal FastAPI app wired to a temp config dir."""
     import session_management as sm
@@ -66,7 +80,7 @@ def test_dev_login_persists_principal_to_yaml(
     """Calling /api/auth/dev-login when no human principal exists must write
     dev-user to principals.yml atomically."""
     app = _make_app(tmp_path, monkeypatch)
-    client = TestClient(app, follow_redirects=False)
+    client = TestClient(app, follow_redirects=False, client=("127.0.0.1", 12345))
 
     response = client.get("/api/auth/dev-login")
     assert response.status_code in (200, 302, 307)
@@ -95,7 +109,7 @@ def test_dev_login_session_survives_restart(
 
     # --- First boot ---
     app1 = _make_app(tmp_path, monkeypatch)
-    client1 = TestClient(app1, follow_redirects=False)
+    client1 = TestClient(app1, follow_redirects=False, client=("127.0.0.1", 12345))
     client1.get("/api/auth/dev-login")
 
     principals_yml = tmp_path / "config" / "principals.yml"
@@ -143,7 +157,7 @@ def test_dev_login_cookie_works_after_restart(
     app1.add_middleware(SessionMiddleware, secret_key="test-secret-key")
     app1.include_router(auth_module.router)
 
-    client1 = TestClient(app1, follow_redirects=False)
+    client1 = TestClient(app1, follow_redirects=False, client=("127.0.0.1", 12345))
     resp = client1.get("/api/auth/dev-login")
     # Cookie is set in client1's jar
     assert resp.status_code in (200, 302, 307)
@@ -167,7 +181,7 @@ def test_dev_login_idempotent_no_duplicate_entries(
 ) -> None:
     """Calling dev-login twice must not create duplicate principals in the YAML."""
     app = _make_app(tmp_path, monkeypatch)
-    client = TestClient(app, follow_redirects=False)
+    client = TestClient(app, follow_redirects=False, client=("127.0.0.1", 12345))
 
     client.get("/api/auth/dev-login")
     client.get("/api/auth/dev-login")


### PR DESCRIPTION
## Summary

Closes #921 (P0 security). `GET /api/auth/dev-login` mints an admin session for the first human principal. Previously it was reachable by **any network peer** whenever OAuth was unconfigured (the out-of-the-box default — `.env.example` ships an empty `GITHUB_CLIENT_ID`), and `backend/server.py` hardcoded a `0.0.0.0` uvicorn bind. Together that is unauthenticated remote admin.

## Changes

- **`backend/routers/auth.py`** — `dev_login` now fails closed: returns **404** unless the request comes from a **loopback peer** AND **`DASHBOARD_DEV_LOGIN=1`** is set. 404 (not 403) so the endpoint is indistinguishable from "not present" to a remote scanner. Reuses the IP-checked `_is_loopback_request` from `identity.py` (same primitive as the #315 loopback bypass).
- **`backend/server.py`** — `__main__` `uvicorn.run` now binds `dashboard_config.HOST` (honoring `DASHBOARD_HOST`) instead of a hardcoded `0.0.0.0`. Default still resolves to `0.0.0.0`, so existing deployments are unchanged.
- **`.env.example`** — documents `DASHBOARD_HOST` and `DASHBOARD_DEV_LOGIN`.
- **SPEC.md** — 2.5.86 changelog entry.

## Tests (TDD)

New `tests/api/test_dev_login_gate.py`:
- non-loopback -> 404 (with and without the flag)
- loopback without flag -> 404
- loopback + flag -> success (IPv4 `127.0.0.1` and IPv6 `::1`)
- asserts the server bind references `dashboard_config.HOST` and `DASHBOARD_HOST` is honored

Existing `tests/api/test_dev_login_persistence.py` updated to opt in (`DASHBOARD_DEV_LOGIN=1`) and connect from a loopback peer; clears the shared auth rate-limit store between tests.

All 32 auth-perimeter / loopback / dev-login tests pass locally; ruff + ruff format + mypy clean on changed files.

## Acceptance criteria

- [x] Non-loopback request to `GET /api/auth/dev-login` returns 404/403
- [x] Loopback request without `DASHBOARD_DEV_LOGIN=1` is rejected
- [x] Loopback request with `DASHBOARD_DEV_LOGIN=1` still works for local dev
- [x] `python backend/server.py` binds the host resolved by `dashboard_config`; `DASHBOARD_HOST` honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)