### PR TITLE
fix(routing): remove duplicate /api/system and /api/fleet/status registrations (#940)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,23 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.86
+**Spec Version:** 2.5.87
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.87):** Removed the duplicate `GET /api/system` and
+  `GET /api/fleet/status` route registrations in `backend/metrics.py`
+  (architecture/correctness, issue #940). Because the metrics router is included
+  before `routers.system` and `routers.fleet`, FastAPI's first-match-wins routing
+  served the metrics copies and shadowed the maintained implementations — silently
+  killing the `FleetEventPoller` wiring in `routers/fleet.py` that feeds
+  `/api/events` (issue #863), and re-registering `/api/system` over
+  `routers/system.py`. The canonical handlers now own those paths and
+  `metrics.py` no longer lazy-imports from `backend.server` (circular import
+  removed). The unique `GET /api/disk/pool-pressure` route is unchanged. A new
+  route-uniqueness invariant (`tests/api/test_route_uniqueness.py`) fails on any
+  duplicate `(method, path)` pair except the explicitly-tracked god-module twins
+  pending issue #941.
 - **2026-06-12 (2.5.86):** Closed unauthenticated remote admin via the dev-login
   endpoint (security, issue #921). `GET /api/auth/dev-login` — which mints an
   admin session for the first human principal — is now gated on BOTH a loopback

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -5,15 +5,12 @@ Extracted from server.py as part of issue #159 god-module-refactor-2026q2.
 
 from __future__ import annotations
 
-import datetime as _dt_mod
 from pathlib import Path
 
 import psutil  # noqa: F401
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
 
 router = APIRouter(tags=["metrics"])
-UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
-datetime = _dt_mod.datetime
 
 
 def _resolve_windows_host_disk_path(configured_path: str | Path | None = None) -> Path | None:
@@ -36,111 +33,16 @@ def _resolve_windows_host_disk_path(configured_path: str | Path | None = None) -
     return None
 
 
-@router.get("/api/system")
-async def get_system_metrics():
-    """Real-time system resource metrics."""
-    from routers.system import get_system_metrics as _canonical_system_metrics  # noqa: PLC0415
-
-    return await _canonical_system_metrics()
-
-
-@router.get("/api/fleet/status")
-async def get_fleet_status(request: Request, exclude_pools: bool = False):
-    """Get full system metrics state for all machines in the fleet network."""
-    # Lazy import to avoid circular dependency with server.py
-    from dashboard_config import PORT  # noqa: PLC0415
-    from server import (  # noqa: PLC0415
-        FLEET_NODES,
-        _classify_node_offline,
-        _resource_offline_reason,
-        _should_proxy_fleet_to_hub,
-        proxy_to_hub,
-    )
-
-    if _should_proxy_fleet_to_hub(request):
-        return await proxy_to_hub(request)
-
-    responses = {}
-    local_metrics = await get_system_metrics()
-    local_metrics["_role"] = "hub"
-
-    if PORT == 8322:
-        local_pool_name = "ControlTower-HDD"
-        peer_pool_name = "ControlTower-NVMe"
-        peer_port = 8321
-    else:
-        local_pool_name = "ControlTower-NVMe"
-        peer_pool_name = "ControlTower-HDD"
-        peer_port = 8322
-
-    responses[local_pool_name] = local_metrics
-
-    async def fetch_node(name, url):
-        import httpx  # noqa: PLC0415
-
-        try:
-            async with httpx.AsyncClient() as client:
-                target = f"{url}/api/system"
-                resp = await client.get(target, timeout=5)
-                if resp.status_code == 200:
-                    data = resp.json()
-                    data["_role"] = "node"
-                    resource_reason = _resource_offline_reason(data)
-                    if resource_reason:
-                        data.update(resource_reason)
-                    return name, data
-                reason = _classify_node_offline(status_code=resp.status_code)
-                return name, {
-                    "status": "offline",
-                    "error": reason["offline_detail"],
-                    **reason,
-                }
-        except Exception as e:  # noqa: BLE001
-            reason = _classify_node_offline(e)
-            return name, {
-                "status": "offline",
-                "error": reason["offline_detail"],
-                **reason,
-            }
-
-    if FLEET_NODES:
-        import asyncio  # noqa: PLC0415
-
-        results = await asyncio.gather(*[fetch_node(n, u) for n, u in FLEET_NODES.items()])
-        for name, data in results:
-            responses[name] = data
-
-    if not exclude_pools:
-        import logging  # noqa: PLC0415
-
-        import httpx  # noqa: PLC0415
-
-        logger = logging.getLogger("dashboard.metrics")
-        peer_url = f"http://localhost:{peer_port}/api/fleet/status?exclude_pools=true"
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(peer_url, timeout=5)
-                if resp.status_code == 200:
-                    peer_data = resp.json()
-                    for k, v in peer_data.items():
-                        responses[k] = v
-                else:
-                    reason = _classify_node_offline(status_code=resp.status_code)
-                    responses[peer_pool_name] = {
-                        "status": "offline",
-                        "error": reason["offline_detail"],
-                        **reason,
-                    }
-        except Exception as e:  # noqa: BLE001
-            logger.warning("Failed to query peer pool on port %d: %s", peer_port, e)
-            reason = _classify_node_offline(e)
-            responses[peer_pool_name] = {
-                "status": "offline",
-                "error": reason["offline_detail"],
-                **reason,
-            }
-
-    return responses
+# NOTE (issue #940): the GET /api/system and GET /api/fleet/status routes that
+# previously lived here were duplicate registrations. Because this router is
+# included before routers.system and routers.fleet in server.py, FastAPI's
+# first-match-wins routing served these copies and shadowed the maintained
+# implementations — silently killing the FleetEventPoller wiring that feeds
+# /api/events (issue #863) and re-registering /api/system over routers.system.
+# The canonical implementations now live in:
+#   - GET /api/system        -> backend/routers/system.py
+#   - GET /api/fleet/status  -> backend/routers/fleet.py (records fleet events)
+# Do not re-add them here. A route-uniqueness invariant test enforces this.
 
 
 @router.get("/api/disk/pool-pressure")

--- a/tests/api/test_route_uniqueness.py
+++ b/tests/api/test_route_uniqueness.py
@@ -1,0 +1,131 @@
+"""Route-table invariants (issue #940).
+
+Two routers must never register the same (method, path) pair. FastAPI resolves
+the first match wins, so a duplicate silently shadows the maintained handler.
+Before #940, backend/metrics.py registered GET /api/system and
+GET /api/fleet/status a second time; because the metrics router was included
+before routers.system and routers.fleet, the metrics copies were served and the
+maintained fleet.py implementation (which feeds the /api/events poller, #863)
+was dead code.
+
+These tests assert:
+- No duplicate (method, path) pair exists anywhere in the assembled app.
+- GET /api/fleet/status resolves to the routers.fleet implementation (the one
+  that records fleet events), not the metrics.py copy.
+- backend/metrics.py no longer imports from backend.server (the circular
+  lazy-import that only existed to support the duplicate fleet-status handler).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+import server  # noqa: E402
+from starlette.routing import Route  # noqa: E402
+
+
+def _method_path_pairs() -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for route in server.app.routes:
+        if isinstance(route, Route) and route.methods:
+            for method in route.methods:
+                if method in {"HEAD", "OPTIONS"}:
+                    continue
+                pairs.append((method, route.path))
+    return pairs
+
+
+# Pre-existing duplicate registrations that are out of scope for #940 (they are
+# server.py-god-module / diagnostics.py twins tracked by #941). The diagnostics.py
+# (#360) copies are registered LAST and are therefore shadowed dead code; the
+# winning copies live in routers.runner_audit and server.py. Untangling them
+# means reworking the diagnostics.configure() DI contract, which belongs to #941.
+# This allowlist is intentionally exhaustive: the invariant below fails on ANY
+# duplicate NOT listed here, so a new shadow (the #940 regression class) is caught
+# immediately. When #941 removes these, delete the corresponding entries.
+_KNOWN_DUPLICATES_PENDING_941: set[tuple[str, str]] = {
+    ("GET", "/api/runner-routing-audit"),
+    ("POST", "/api/runner-routing-audit/refresh"),
+    ("POST", "/api/launchers/generate"),
+}
+
+
+def test_no_duplicate_method_path_pairs() -> None:
+    """No (method, path) pair may be registered more than once, except the
+    explicitly-tracked #941 god-module twins."""
+    counts = Counter(_method_path_pairs())
+    duplicates = {pair for pair, n in counts.items() if n > 1}
+    unexpected = duplicates - _KNOWN_DUPLICATES_PENDING_941
+    assert not unexpected, f"Unexpected duplicate route registrations (the #940 regression class): {sorted(unexpected)}"
+
+
+def test_metrics_duplicates_are_gone() -> None:
+    """The specific #940 duplicates (/api/system, /api/fleet/status from
+    metrics.py) must no longer be double-registered."""
+    counts = Counter(_method_path_pairs())
+    assert counts[("GET", "/api/system")] == 1
+    assert counts[("GET", "/api/fleet/status")] == 1
+
+
+def test_known_941_duplicates_do_not_grow() -> None:
+    """Guard the allowlist: every entry must still actually be duplicated, so a
+    stale allowlist entry (e.g. once #941 lands) surfaces and gets pruned."""
+    counts = Counter(_method_path_pairs())
+    stale = {pair for pair in _KNOWN_DUPLICATES_PENDING_941 if counts[pair] <= 1}
+    assert not stale, f"Allowlisted pairs are no longer duplicated; prune them: {sorted(stale)}"
+
+
+def test_fleet_status_resolves_to_fleet_router() -> None:
+    """GET /api/fleet/status must resolve to routers.fleet.get_fleet_status,
+    the implementation that records fleet events (#863)."""
+    import routers.fleet as fleet_router
+
+    target = None
+    for route in server.app.routes:
+        if isinstance(route, Route) and route.path == "/api/fleet/status" and "GET" in (route.methods or set()):
+            target = route
+            break
+
+    assert target is not None, "GET /api/fleet/status must be registered"
+    assert target.endpoint is fleet_router.get_fleet_status, (
+        "GET /api/fleet/status must resolve to routers.fleet.get_fleet_status, "
+        f"not {target.endpoint.__module__}.{target.endpoint.__qualname__}"
+    )
+
+
+def test_system_resolves_to_system_router() -> None:
+    """GET /api/system must resolve to routers.system, not the metrics copy."""
+    import routers.system as system_router
+
+    target = None
+    for route in server.app.routes:
+        if isinstance(route, Route) and route.path == "/api/system" and "GET" in (route.methods or set()):
+            target = route
+            break
+
+    assert target is not None, "GET /api/system must be registered"
+    assert target.endpoint.__module__ == system_router.__name__, (
+        f"GET /api/system must resolve to routers.system, not {target.endpoint.__module__}"
+    )
+
+
+def test_metrics_does_not_import_from_server() -> None:
+    """metrics.py must not import from backend.server (no circular dependency)."""
+    src = (_BACKEND / "metrics.py").read_text(encoding="utf-8")
+    assert "from server import" not in src, "metrics.py must not import from server"
+    assert "import server" not in src, "metrics.py must not import server"
+
+
+def test_metrics_still_serves_pool_pressure() -> None:
+    """The unique /api/disk/pool-pressure route in metrics.py must survive."""
+    paths = {path for _method, path in _method_path_pairs()}
+    assert "/api/disk/pool-pressure" in paths

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,9 +1,11 @@
 """Tests for backend/metrics.py — issue #386.
 
-metrics.py is a thin FastAPI router that delegates to server.py internals via
-lazy imports (to avoid circular dependencies). We test only what can be
-exercised without spinning up a full server: the router object itself and any
-module-level constants / helpers.
+metrics.py is a thin FastAPI router. As of issue #940 it owns only the unique
+``/api/disk/pool-pressure`` route; the previously-duplicated ``/api/system`` and
+``/api/fleet/status`` handlers were removed because they shadowed the maintained
+implementations in routers.system / routers.fleet (first-match-wins routing).
+We test only what can be exercised without spinning up a full server: the router
+object itself and any module-level helpers.
 """
 
 from __future__ import annotations
@@ -16,9 +18,17 @@ def test_router_is_apiRouter() -> None:
     assert isinstance(m.router, APIRouter)
 
 
-def test_router_has_system_route() -> None:
+def test_router_owns_pool_pressure_route() -> None:
     paths = [r.path for r in m.router.routes]  # type: ignore[attr-defined]
-    assert "/api/system" in paths
+    assert "/api/disk/pool-pressure" in paths
+
+
+def test_router_no_longer_registers_shadowing_routes() -> None:
+    """#940: metrics.py must not re-register /api/system or /api/fleet/status,
+    which are owned by routers.system and routers.fleet respectively."""
+    paths = [r.path for r in m.router.routes]  # type: ignore[attr-defined]
+    assert "/api/system" not in paths
+    assert "/api/fleet/status" not in paths
 
 
 def test_resolve_windows_host_disk_path_prefers_configured_existing_path(tmp_path) -> None:

--- a/tests/test_metrics_module.py
+++ b/tests/test_metrics_module.py
@@ -19,11 +19,15 @@ def test_metrics_module_importable() -> None:
 
 
 def test_metrics_router_has_expected_routes() -> None:
+    """#940: metrics.py owns only the unique /api/disk/pool-pressure route. The
+    previously-duplicated /api/system and /api/fleet/status handlers were removed
+    because they shadowed the maintained routers.system / routers.fleet copies."""
     import metrics  # noqa: PLC0415
 
     paths = {r.path for r in metrics.router.routes}  # type: ignore[attr-defined]
-    assert "/api/system" in paths, "metrics router must expose /api/system"
-    assert "/api/fleet/status" in paths, "metrics router must expose /api/fleet/status"
+    assert "/api/disk/pool-pressure" in paths, "metrics router must expose /api/disk/pool-pressure"
+    assert "/api/system" not in paths, "/api/system is owned by routers.system, not metrics (#940)"
+    assert "/api/fleet/status" not in paths, "/api/fleet/status is owned by routers.fleet, not metrics (#940)"
 
 
 def test_metrics_router_not_inline_in_server() -> None:
@@ -40,15 +44,11 @@ def test_server_registers_metrics_router() -> None:
     assert "include_router(_metrics_router.router)" in server_src
 
 
-def test_metrics_imports_psutil_directly() -> None:
-    """metrics.py must delegate /api/system to the canonical system router."""
+def test_metrics_does_not_import_from_server() -> None:
+    """#940: metrics.py must not import from backend.server. The only reason it
+    ever did was the duplicate /api/fleet/status handler (now removed), which
+    forced a lazy circular import."""
     metrics_src = (_BACKEND_DIR / "metrics.py").read_text(encoding="utf-8")
-    assert "from routers.system import get_system_metrics" in metrics_src
-    assert (
-        "from server import"
-        not in metrics_src.split('@router.get("/api/system")', 1)[1].split(
-            '@router.get("/api/fleet/status")',
-            1,
-        )[0]
-    )
+    assert "from server import" not in metrics_src, "metrics.py must not import from server (#940)"
+    assert "import server" not in metrics_src, "metrics.py must not import server (#940)"
     assert "psutil," not in metrics_src

--- a/tests/test_today_deploy_hardening.py
+++ b/tests/test_today_deploy_hardening.py
@@ -352,9 +352,16 @@ def test_health_gh_api_timeout_is_realistic() -> None:
 
 
 def test_metrics_imports_psutil_directly_not_through_server() -> None:
-    """metrics.py must not depend on server.py re-exporting psutil."""
+    """metrics.py must not depend on server.py for anything.
+
+    Originally this guarded against pulling psutil through a `from server import`
+    block. As of issue #940 the duplicate /api/system and /api/fleet/status
+    handlers (the only code that referenced server internals) were removed, so
+    metrics.py must have no server import at all.
+    """
     src = _read(_BACKEND / "metrics.py")
-    assert "from routers.system import get_system_metrics" in src
+    assert "from server import" not in src, "metrics.py must not import from server (#940)"
+    assert "import server" not in src, "metrics.py must not import server (#940)"
     # The bad pattern was "from server import (... psutil, ...)" — make
     # sure psutil never appears in such a multi-line import block.
     assert "psutil," not in src


### PR DESCRIPTION
## Summary

Closes #940 (P0 architecture/correctness). `backend/metrics.py` registered `GET /api/system` and `GET /api/fleet/status` a **second** time. Because the metrics router is included before `routers.system` and `routers.fleet` in `server.py`, FastAPI's first-match-wins routing served the metrics copies and **shadowed** the maintained implementations:

- The maintained `routers/fleet.py` handler — the one that calls `_record_fleet_events()` to feed the `FleetEventPoller` behind `/api/events` (#863) — was dead code, so the event feed was silently killed.
- `routers/system.py`'s `/api/system` was likewise shadowed.
- The dead metrics fleet-status handler also forced a lazy circular import from `backend.server`.

## Changes

- **`backend/metrics.py`** — delete the two duplicate handlers; the canonical handlers in `routers/fleet.py` (records fleet events) and `routers/system.py` now own those paths. The unique `GET /api/disk/pool-pressure` route is unchanged. Removed the now-orphaned `from server import ...` lazy import (circular dependency gone) and the dead `datetime`/`UTC` module aliases / `Request` import.
- **`tests/api/test_route_uniqueness.py`** (new) — asserts no duplicate `(method, path)` pair exists anywhere in the assembled app; that `/api/fleet/status` resolves to `routers.fleet.get_fleet_status` and `/api/system` to `routers.system`; that `metrics.py` has no `server` import; and that pool-pressure survives.
- Updated `tests/test_metrics.py`, `tests/test_metrics_module.py`, `tests/test_today_deploy_hardening.py` — these encoded the old (buggy) duplicate-route behavior; they now assert the corrected ownership.
- **SPEC.md** — 2.5.87 changelog entry.

## Scope note (the route-uniqueness allowlist)

The new invariant fails on **any** duplicate `(method, path)` pair except three pre-existing god-module twins that belong to **#941**:
`GET /api/runner-routing-audit`, `POST /api/runner-routing-audit/refresh`, `POST /api/launchers/generate` (diagnostics.py copies, registered last → already shadowed dead code; untangling them means reworking the `diagnostics.configure()` DI contract, which is #941's scope). The allowlist is exhaustive and self-pruning (a guard test fails if an entry is no longer actually duplicated), so the #940 regression class — a new shadowing route — is caught immediately.

## Acceptance criteria

- [x] metrics.py duplicate `/api/system` and `/api/fleet/status` routes deleted
- [x] `routers/fleet.py` is the canonical fleet status implementation (feeds FleetEventPoller / #863)
- [x] Route-table test asserts no unexpected duplicate `(method, path)` pairs
- [x] `metrics.py` has no imports from `backend.server`

Full backend suite green locally; ruff + ruff format + mypy + bandit clean (verified by the pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)