### PR TITLE
fix(security): collapse divergent proxy_to_hub copies; stop forwarding operator credentials to the hub (#923)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,21 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.87
+**Spec Version:** 2.5.88
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.88):** Collapsed the two divergent `proxy_to_hub`
+  implementations into one (security, issue #923, re-opens #347). `backend/server.py`
+  previously defined its own `proxy_to_hub` that forwarded ALL caller headers to
+  the hub except `host`/`content-length` — laundering operator session cookies,
+  `Authorization`, `X-API-Key`, and `X-CSRF-Token` upstream — and that copy was the
+  one dependency-injected into the deployment / orchestration / orchestration-node
+  routers. The server-side body is deleted; `server.proxy_to_hub` and
+  `server._should_proxy_fleet_to_hub` are now thin re-exports of the single
+  header-stripping implementation in `proxy_utils`, which strips the sensitive
+  headers and injects the intra-fleet `HUB_FLEET_TOKEN`. A regression test asserts
+  that for every hub-proxying route no operator credential reaches the hub.
 - **2026-06-12 (2.5.87):** Removed the duplicate `GET /api/system` and
   `GET /api/fleet/status` route registrations in `backend/metrics.py`
   (architecture/correctness, issue #940). Because the metrics router is included

--- a/backend/server.py
+++ b/backend/server.py
@@ -81,6 +81,7 @@ import orchestration_audit as orchestration_audit  # noqa: E402
 import orchestrator_api as _orchestrator_api  # noqa: E402  # Conductor integration (issue #1282)
 import pr_inventory as pr_inventory  # noqa: E402
 import prometheus_metrics as _prometheus_metrics_router  # noqa: E402
+import proxy_utils as _proxy_utils  # noqa: E402  # single hub-proxy implementation (issue #923)
 import push as _push_router  # noqa: E402
 import quota_enforcement as quota_enforcement  # noqa: E402
 import unified_issue_inventory as unified_issue_inventory  # noqa: E402
@@ -854,58 +855,15 @@ if HUB_URL:
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 
-async def proxy_to_hub(request: Request):
-    """Proxy request to the designated HUB_URL for hub-spoke topology."""
-    if not HUB_URL:
-        raise HTTPException(status_code=502, detail="HUB_URL not configured")
-    from proxy_utils import _translate_upstream_response, mark_hub_unreachable, reset_hub_circuit
-
-    async with httpx.AsyncClient(timeout=HttpTimeout.PROXY_TO_HUB_S) as client:
-        url = f"{HUB_URL}{request.url.path}"
-        if request.url.query:
-            url = f"{url}?{request.url.query}"
-        try:
-            req = client.build_request(
-                request.method,
-                url,
-                headers={k: v for k, v in request.headers.items() if k.lower() not in ("host", "content-length")},
-                content=await request.body(),
-            )
-            resp = await client.send(req)
-            reset_hub_circuit()  # hub answered → close the breaker
-            return _translate_upstream_response(resp, "Hub proxy")
-        except httpx.TimeoutException as e:
-            log.warning("Hub proxy timeout for %s: %s", request.url.path, e)
-            mark_hub_unreachable()  # open breaker → serve local until hub recovers
-            raise HTTPException(status_code=504, detail="Hub timeout") from e
-        except httpx.ConnectError as e:
-            log.warning("Hub proxy connect error for %s: %s", request.url.path, e)
-            mark_hub_unreachable()  # open breaker → serve local until hub recovers
-            raise HTTPException(status_code=503, detail="Hub connection error") from e
-        except HTTPException:
-            raise
-        except Exception as e:  # noqa: BLE001
-            log.warning("Hub proxy error for %s: %s", request.url.path, e)
-            raise HTTPException(status_code=502, detail="Hub proxy error") from e
-
-
-def _should_proxy_fleet_to_hub(request: Request) -> bool:
-    """Return True when this node should use the hub's fleet-wide view.
-
-    Local health, system metrics, watchdog, and runner schedule endpoints stay
-    local. Fleet-wide endpoints can proxy to the hub, while hub fan-out calls
-    can add ``?local=1`` to force a node-local action and avoid proxy loops.
-
-    If the hub circuit breaker is open (hub recently unreachable), we serve local
-    data instead of proxying, so a dead hub never blanks the dashboard.
-    """
-    from proxy_utils import hub_in_cooldown
-
-    if MACHINE_ROLE != "node" or not HUB_URL or hub_in_cooldown():
-        return False
-    local_value = request.query_params.get("local", "").lower()
-    scope_value = request.query_params.get("scope", "").lower()
-    return local_value not in {"1", "true", "yes", "local"} and scope_value != "local"
+# Hub proxying lives in a SINGLE implementation: proxy_utils.proxy_to_hub, which
+# strips sensitive caller headers (Authorization/Cookie/X-API-Key/X-CSRF-Token)
+# and injects the intra-fleet HUB_FLEET_TOKEN instead. The previous server.py copy
+# (issue #923) forwarded ALL caller headers verbatim except host/content-length,
+# laundering operator credentials to the hub — a regression of the #347 class. It
+# is deleted; these names are thin re-exports so existing call sites and DI wiring
+# keep working without a second divergent implementation.
+proxy_to_hub = _proxy_utils.proxy_to_hub
+_should_proxy_fleet_to_hub = _proxy_utils.should_proxy_fleet_to_hub
 
 
 async def run_cmd(

--- a/tests/api/test_proxy_credential_stripping.py
+++ b/tests/api/test_proxy_credential_stripping.py
@@ -1,0 +1,173 @@
+"""Hub-proxy credential-stripping regression tests (issue #923, re-opens #347).
+
+There used to be TWO proxy_to_hub implementations:
+  - proxy_utils.proxy_to_hub — strips Authorization/Cookie/X-API-Key/X-CSRF-Token
+    and injects the intra-fleet HUB_FLEET_TOKEN.
+  - server.proxy_to_hub — forwarded ALL caller headers except host/content-length,
+    laundering operator credentials to the hub. This dead-named twin was the one
+    dependency-injected into the deployment / orchestration routers.
+
+This module asserts:
+  - There is exactly one proxy implementation: server.proxy_to_hub IS
+    proxy_utils.proxy_to_hub (and the shouldproxy predicate likewise), so every
+    DI consumer (deployment, orchestration, orchestration_node_routes, fleet)
+    uses the header-stripping version.
+  - The header builder strips every sensitive header and injects HUB_FLEET_TOKEN.
+  - An end-to-end proxy call against a fake upstream never leaks
+    Authorization/Cookie/X-API-Key/X-CSRF-Token, and carries the fleet token.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+import proxy_utils  # noqa: E402
+
+_SENSITIVE = ("authorization", "cookie", "x-api-key", "x-csrf-token")
+
+
+# ── Exactly one implementation (server re-exports proxy_utils) ────────────────
+
+
+def test_server_proxy_to_hub_is_proxy_utils_implementation() -> None:
+    import server  # noqa: PLC0415
+
+    assert server.proxy_to_hub is proxy_utils.proxy_to_hub, (
+        "server.proxy_to_hub must be the header-stripping proxy_utils implementation (#923)"
+    )
+    assert server._should_proxy_fleet_to_hub is proxy_utils.should_proxy_fleet_to_hub
+
+
+def test_no_second_proxy_definition_in_server_source() -> None:
+    """server.py must not define its own proxy_to_hub body (only the re-export)."""
+    src = (_BACKEND / "server.py").read_text(encoding="utf-8")
+    assert "async def proxy_to_hub" not in src, "server.py must not define a second proxy_to_hub (#923)"
+    # The credential-leaking signature must be gone.
+    assert 'if k.lower() not in ("host", "content-length")' not in src
+
+
+def test_di_consumers_receive_stripping_proxy() -> None:
+    """The deployment / orchestration routers must be wired with the
+    header-stripping proxy (verified via the configured callables)."""
+    import server  # noqa: PLC0415
+    from routers import deployment, orchestration, orchestration_node_routes
+
+    for mod in (deployment, orchestration, orchestration_node_routes):
+        assert mod._proxy_to_hub is proxy_utils.proxy_to_hub, (
+            f"{mod.__name__} must use proxy_utils.proxy_to_hub, not a credential-forwarding copy"
+        )
+    # And the server-level names resolve to the same object.
+    assert server.proxy_to_hub is proxy_utils.proxy_to_hub
+
+
+# ── Header builder strips secrets and injects the fleet token ─────────────────
+
+
+def _request_with_headers(headers: dict[str, str]) -> MagicMock:
+    req = MagicMock()
+    req.headers.items = lambda: list(headers.items())
+    return req
+
+
+def test_safe_forward_headers_strips_all_sensitive_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "fleet-secret-token")  # pragma: allowlist secret
+    req = _request_with_headers(
+        {
+            "Authorization": "Bearer operator-session",
+            "Cookie": "dashboard_session=abc",
+            "X-API-Key": "operator-key",
+            "X-CSRF-Token": "csrf123",
+            "X-Request-Id": "keepme",
+            "Accept": "application/json",
+        }
+    )
+    forwarded = proxy_utils._safe_forward_headers(req)
+    lowered = {k.lower(): v for k, v in forwarded.items()}
+
+    # The fleet token replaces Authorization; no operator credential survives.
+    assert lowered.get("authorization") == "Bearer fleet-secret-token"
+    assert "cookie" not in lowered
+    assert "x-api-key" not in lowered
+    assert "x-csrf-token" not in lowered
+    # Non-sensitive headers pass through.
+    assert lowered.get("x-request-id") == "keepme"
+    assert lowered.get("accept") == "application/json"
+
+
+def test_safe_forward_headers_no_token_drops_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no HUB_FLEET_TOKEN configured, the caller's Authorization must still
+    be stripped (never forwarded), and no Authorization is injected."""
+    monkeypatch.delenv("HUB_FLEET_TOKEN", raising=False)
+    req = _request_with_headers({"Authorization": "Bearer operator-session", "Cookie": "x=y"})
+    forwarded = proxy_utils._safe_forward_headers(req)
+    lowered = {k.lower(): v for k, v in forwarded.items()}
+    assert "authorization" not in lowered
+    assert "cookie" not in lowered
+
+
+# ── End-to-end: a real proxy_to_hub call never leaks credentials ──────────────
+
+
+@pytest.mark.asyncio
+async def test_proxy_to_hub_does_not_leak_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "fleet-secret-token")  # pragma: allowlist secret
+    monkeypatch.setattr(proxy_utils, "HUB_URL", "http://hub.internal")
+
+    captured: dict[str, dict[str, str]] = {}
+
+    class _FakeResponse:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+
+        def json(self) -> dict:
+            return {"ok": True}
+
+    class _FakeClient:
+        def __init__(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+            pass
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *a) -> None:  # noqa: ANN002
+            return None
+
+        def build_request(self, method, url, headers, content):  # noqa: ANN001
+            captured["headers"] = dict(headers)
+            return MagicMock()
+
+        async def send(self, req):  # noqa: ANN001
+            return _FakeResponse()
+
+    req = MagicMock()
+    req.url.path = "/api/fleet/status"
+    req.url.query = ""
+    req.method = "GET"
+    req.body = AsyncMock(return_value=b"")
+    req.headers.items = lambda: [
+        ("Authorization", "Bearer operator-session"),
+        ("Cookie", "dashboard_session=abc"),
+        ("X-API-Key", "operator-key"),
+        ("X-CSRF-Token", "csrf123"),
+    ]
+
+    with patch.object(proxy_utils.httpx, "AsyncClient", _FakeClient):
+        result = await proxy_utils.proxy_to_hub(req)
+
+    assert result == {"ok": True}
+    sent = {k.lower(): v for k, v in captured["headers"].items()}
+    # The only Authorization is the fleet token; no operator credential leaked.
+    assert sent.get("authorization") == "Bearer fleet-secret-token"
+    for h in ("cookie", "x-api-key", "x-csrf-token"):
+        assert h not in sent, f"{h} must never reach the hub (#347/#923)"


### PR DESCRIPTION
## Summary

Closes #923 (P0 security, re-opens the #347 credential-laundering class). There were **two** divergent `proxy_to_hub` implementations:

- `proxy_utils.proxy_to_hub` — strips `Authorization`/`Cookie`/`X-API-Key`/`X-CSRF-Token` and injects the intra-fleet `HUB_FLEET_TOKEN`.
- `server.proxy_to_hub` — forwarded **all** caller headers except `host`/`content-length`. This is the copy that was dependency-injected into the deployment / orchestration / orchestration-node routers, so on every deployment/orchestration proxy call the operator's session cookie, `Authorization`, `X-API-Key`, and `X-CSRF-Token` were forwarded verbatim to the hub.

## Changes

- **`backend/server.py`** — delete the `proxy_to_hub` body and the duplicate `_should_proxy_fleet_to_hub`. `server.proxy_to_hub` and `server._should_proxy_fleet_to_hub` are now thin re-exports of the single header-stripping `proxy_utils` implementation (imported as `_proxy_utils`). One implementation, no divergent twin — every DI consumer now uses the stripping proxy.
- **`tests/api/test_proxy_credential_stripping.py`** (new) — asserts `server.proxy_to_hub IS proxy_utils.proxy_to_hub`; that no second proxy body remains in `server.py`; that the deployment/orchestration/node DI consumers (`_proxy_to_hub`) are the stripping implementation; that the header builder strips every sensitive header and injects the fleet token; and an end-to-end proxy call against a fake upstream leaks no operator credential while carrying `HUB_FLEET_TOKEN`.
- **SPEC.md** — 2.5.88.

## Acceptance criteria

- [x] Repo contains exactly one `proxy_to_hub` implementation (the header-stripping one in `proxy_utils`)
- [x] A test fakes the upstream and asserts, for the hub-proxying routes, that `Authorization`/`Cookie`/`X-API-Key`/`X-CSRF-Token` are absent upstream and `HUB_FLEET_TOKEN` is injected
- [x] Regression history references #347

Full backend suite green (verified by the pre-push hook); ruff + ruff format + mypy + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)