### PR TITLE
fix(security): validate HUB_FLEET_TOKEN on the hub via require_fleet_peer (#922)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,21 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.88
+**Spec Version:** 2.5.89
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.89):** Enforced intra-fleet authentication on the hub
+  (security, issue #922). Added the `require_fleet_peer` dependency
+  (`backend/identity.py`): a hub-reachable fleet route is accepted only when the
+  caller presents a valid principal OR `Authorization: Bearer <HUB_FLEET_TOKEN>`
+  matching the hub's configured token via `hmac.compare_digest` (constant-time).
+  Applied to `GET /api/fleet/status`. Policy: fleet reads are token-gated when
+  `HUB_FLEET_TOKEN` is set (unauthenticated callers get `401`) and tailnet-public
+  when it is unset (backward-compatible no-op for single-node deployments).
+  `docs/runbooks/hub-credentials.md` now describes the enforced behavior instead
+  of claiming validation that did not exist. The structural "all `/api/*` routes
+  authenticated" follow-up is tracked by #924.
 - **2026-06-12 (2.5.88):** Collapsed the two divergent `proxy_to_hub`
   implementations into one (security, issue #923, re-opens #347). `backend/server.py`
   previously defined its own `proxy_to_hub` that forwarded ALL caller headers to

--- a/backend/identity.py
+++ b/backend/identity.py
@@ -1,4 +1,5 @@
 # ruff: noqa: B008
+import hmac
 import ipaddress
 import logging
 import os
@@ -324,3 +325,66 @@ def require_scope(required_scope: str):
         )
 
     return checker
+
+
+def _resolve_principal_optional(request: Request, header_token: str | None) -> Principal | None:
+    """Resolve a principal from a Bearer token or session WITHOUT raising.
+
+    Mirrors the credential resolution in ``require_principal`` but returns
+    ``None`` instead of a 401 when no valid credential is present. Used by
+    ``require_fleet_peer`` so the fleet-token path can be tried as a fallback.
+    """
+    if header_token and header_token.startswith("Bearer "):
+        raw_token = header_token.replace("Bearer ", "")
+        prin = identity_manager.verify_token(raw_token)
+        if prin:
+            return prin
+
+    if hasattr(request, "session"):
+        principal_id = request.session.get("principal_id")
+        session_id = request.session.get("session_id")
+        if principal_id and principal_id in identity_manager.principals:
+            if session_id and not sm.touch_session(session_id):
+                return None
+            return identity_manager.principals[principal_id]
+    return None
+
+
+def require_fleet_peer(
+    request: Request,
+    header_token: str | None = Depends(auth_header),
+) -> str:
+    """Authenticate an intra-fleet caller for hub-reachable fleet routes (#922).
+
+    A request is accepted when EITHER:
+      - it carries valid operator credentials (a principal resolved from a
+        service token or session), OR
+      - it presents ``Authorization: Bearer <HUB_FLEET_TOKEN>`` matching the
+        hub's configured ``HUB_FLEET_TOKEN`` (constant-time compare).
+
+    Policy decision (documented in docs/runbooks/hub-credentials.md): when
+    ``HUB_FLEET_TOKEN`` is UNSET on this node, fleet reads are tailnet-public —
+    the dependency is a no-op so single-node and token-less deployments keep
+    working. When the token IS set, the fleet trust boundary is enforced and
+    an unauthenticated caller gets 401.
+
+    Returns a short principal/peer label for logging; never the token itself.
+    """
+    hub_token = os.environ.get("HUB_FLEET_TOKEN", "")
+
+    # A valid operator principal is always accepted.
+    principal = _resolve_principal_optional(request, header_token)
+    if principal is not None:
+        return f"principal:{principal.id}"
+
+    # No token configured → fleet reads are tailnet-public (backward compatible).
+    if not hub_token:
+        return "anonymous:tailnet"
+
+    # Token configured → require a constant-time match of the fleet bearer token.
+    if header_token and header_token.startswith("Bearer "):
+        presented = header_token[len("Bearer ") :]
+        if hmac.compare_digest(presented, hub_token):
+            return "fleet-peer"
+
+    raise HTTPException(status_code=401, detail="Fleet authentication required")

--- a/backend/routers/fleet.py
+++ b/backend/routers/fleet.py
@@ -15,12 +15,13 @@ from dashboard_config import (
     ORG,
     HttpTimeout,
 )
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fleet_events import (  # issue #863 — record runner/disk transitions
     FleetEventPoller,
     nodes_from_fleet_status,
 )
 from gh_utils import gh_api_admin
+from identity import require_fleet_peer  # issue #922 — intra-fleet auth gate
 from proxy_utils import proxy_to_hub, should_proxy_fleet_to_hub
 from routers.runners import run_runner_svc, runner_num_from_id, runner_svc_path
 from runner_inventory import fetch_org_runners
@@ -117,9 +118,14 @@ async def _fleet_control_local(action: str) -> dict:
 # Runner control routes are defined in routers/runners.py
 
 
-@router.get("/api/fleet/status")
+@router.get("/api/fleet/status", dependencies=[Depends(require_fleet_peer)])
 async def get_fleet_status(request: Request, exclude_pools: bool = False):
-    """Get full system metrics state for all machines in the fleet network."""
+    """Get full system metrics state for all machines in the fleet network.
+
+    Gated by require_fleet_peer (#922): when HUB_FLEET_TOKEN is set on this node,
+    callers must present a valid principal or the fleet bearer token; otherwise
+    (no token configured) fleet reads remain tailnet-public.
+    """
     if should_proxy_fleet_to_hub(request):
         return await proxy_to_hub(request)
 

--- a/docs/runbooks/hub-credentials.md
+++ b/docs/runbooks/hub-credentials.md
@@ -3,7 +3,7 @@
 ## Overview
 
 `HUB_FLEET_TOKEN` is the intra-fleet bearer token used by spoke nodes when
-proxying requests to the hub node.  It replaces forwarding the caller's own
+proxying requests to the hub node. It replaces forwarding the caller's own
 `Authorization` / `Cookie` / `X-API-Key` headers (issue #347).
 
 ## Setting the token
@@ -21,8 +21,28 @@ echo "HUB_FLEET_TOKEN=${HUB_FLEET_TOKEN}" >> ~/.config/runner-dashboard/runner-d
 sudo systemctl restart runner-dashboard
 ```
 
-The hub must validate inbound `Authorization: Bearer <HUB_FLEET_TOKEN>` headers
-on routes that accept spoke traffic.
+## Enforcement (issue #922)
+
+The hub validates inbound `Authorization: Bearer <HUB_FLEET_TOKEN>` on
+hub-reachable fleet-read routes via the `require_fleet_peer` dependency
+(`backend/identity.py`). A request to a gated route is accepted when **either**:
+
+- it carries valid operator credentials (a principal resolved from a service
+  token or session), **or**
+- it presents `Authorization: Bearer <HUB_FLEET_TOKEN>` matching the hub's
+  configured token, compared with `hmac.compare_digest` (constant-time).
+
+**Policy — fleet reads are token-gated only when a token is configured.**
+When `HUB_FLEET_TOKEN` is **set** on the hub, an unauthenticated caller to a
+gated fleet route receives `401`. When it is **unset** (single-node and
+token-less deployments), fleet reads are tailnet-public and the dependency is a
+no-op — preserving backward compatibility. To enforce the fleet trust boundary,
+set `HUB_FLEET_TOKEN` on the hub (and on every spoke, so their proxied calls
+carry it).
+
+> Currently gated: `GET /api/fleet/status`. Additional hub-reachable read routes
+> are being brought under the same dependency; see issue #924 for the structural
+> "all `/api/*` routes authenticated" follow-up.
 
 ## Rotation procedure
 

--- a/tests/api/test_fleet_peer_auth.py
+++ b/tests/api/test_fleet_peer_auth.py
@@ -1,0 +1,150 @@
+"""Intra-fleet authentication tests for hub-reachable fleet routes (issue #922).
+
+Before #922 the HUB_FLEET_TOKEN existed only in documentation and as a header
+spokes sent into the void — the hub never validated it, and proxied fleet-read
+routes had no auth dependency at all, so the fleet trust boundary did not exist
+in code.
+
+`require_fleet_peer` enforces: when HUB_FLEET_TOKEN is set, a caller must present
+either a valid principal OR `Authorization: Bearer <HUB_FLEET_TOKEN>` (constant-
+time compare); when the token is unset, fleet reads stay tailnet-public.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+os.environ.setdefault("DASHBOARD_API_KEY", "test-key")
+
+from fastapi import HTTPException  # noqa: E402
+from identity import Principal, require_fleet_peer  # noqa: E402
+
+
+def _request(*, session: dict | None = None) -> MagicMock:
+    req = MagicMock()
+    req.session = session if session is not None else {}
+    return req
+
+
+# ── No token configured → tailnet-public (no-op) ─────────────────────────────
+
+
+def test_no_token_configured_allows_anonymous(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HUB_FLEET_TOKEN", raising=False)
+    label = require_fleet_peer(_request(), header_token=None)
+    assert label == "anonymous:tailnet"
+
+
+# ── Token configured → unauthenticated caller rejected ───────────────────────
+
+
+def test_token_configured_rejects_missing_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "the-fleet-token")  # pragma: allowlist secret
+    with pytest.raises(HTTPException) as exc:
+        require_fleet_peer(_request(), header_token=None)
+    assert exc.value.status_code == 401
+
+
+def test_token_configured_rejects_wrong_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "the-fleet-token")  # pragma: allowlist secret
+    with pytest.raises(HTTPException) as exc:
+        require_fleet_peer(_request(), header_token="Bearer wrong-token")
+    assert exc.value.status_code == 401
+
+
+# ── Token configured → correct fleet token accepted ──────────────────────────
+
+
+def test_token_configured_accepts_matching_fleet_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "the-fleet-token")  # pragma: allowlist secret
+    label = require_fleet_peer(_request(), header_token="Bearer the-fleet-token")
+    assert label == "fleet-peer"
+
+
+# ── A valid principal is always accepted (even with token set) ───────────────
+
+
+def test_valid_principal_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "the-fleet-token")  # pragma: allowlist secret
+    import identity
+
+    prin = Principal(id="alice", type="human", name="Alice", roles=["operator"])
+    monkeypatch.setitem(identity.identity_manager.principals, "alice", prin)
+    monkeypatch.setattr(identity.sm, "touch_session", lambda sid: True)
+
+    req = _request(session={"principal_id": "alice", "session_id": "sess1"})
+    label = require_fleet_peer(req, header_token=None)
+    assert label == "principal:alice"
+
+
+def test_valid_service_token_principal_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "the-fleet-token")  # pragma: allowlist secret
+    import identity
+
+    prin = Principal(id="bot", type="bot", name="Bot", roles=["bot"])
+    monkeypatch.setattr(identity.identity_manager, "verify_token", lambda raw: prin if raw == "svc-tok" else None)
+
+    label = require_fleet_peer(_request(), header_token="Bearer svc-tok")
+    assert label == "principal:bot"
+
+
+# ── Uses constant-time comparison (hmac.compare_digest) ──────────────────────
+
+
+def test_uses_constant_time_comparison() -> None:
+    """The implementation must use hmac.compare_digest, not == (timing-safe)."""
+    src = (_BACKEND / "identity.py").read_text(encoding="utf-8")
+    assert "hmac.compare_digest" in src, "fleet token comparison must use hmac.compare_digest (#922)"
+
+
+# ── HTTP-level: the /api/fleet/status route is gated ─────────────────────────
+
+
+def test_fleet_status_route_returns_401_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: with HUB_FLEET_TOKEN set, GET /api/fleet/status without
+    credentials returns 401."""
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "the-fleet-token")  # pragma: allowlist secret
+    # Force local serving (not proxy) so the gate is what we exercise.
+    monkeypatch.setenv("MACHINE_ROLE", "hub")
+
+    import routers.fleet as fleet_mod
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from starlette.middleware.sessions import SessionMiddleware
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-key")  # pragma: allowlist secret
+    app.include_router(fleet_mod.router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/api/fleet/status")
+    assert resp.status_code == 401
+
+
+def test_fleet_status_route_accepts_fleet_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUB_FLEET_TOKEN", "the-fleet-token")  # pragma: allowlist secret
+    monkeypatch.setenv("MACHINE_ROLE", "hub")
+
+    import routers.fleet as fleet_mod
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from starlette.middleware.sessions import SessionMiddleware
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-key")  # pragma: allowlist secret
+    app.include_router(fleet_mod.router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/api/fleet/status", headers={"Authorization": "Bearer the-fleet-token"})
+    # Not 401/403 — the auth gate passed (handler may still 5xx on gh calls in
+    # this minimal harness, but the perimeter is what we assert).
+    assert resp.status_code not in (401, 403)


### PR DESCRIPTION
## Summary

Closes #922 (P0 security). The intra-fleet `HUB_FLEET_TOKEN` existed only in documentation and as a header spokes injected into the void — the hub never validated it, and the proxied fleet-read routes had no auth dependency at all, so the fleet trust boundary did not exist in code. `identity.verify_token` only matches tokens minted into `config/tokens.yml`, so the env token would never authenticate anything.

## Changes

- **`backend/identity.py`** — new `require_fleet_peer` dependency. A hub-reachable fleet route is accepted only when the caller presents a **valid principal** (service token or session) **OR** `Authorization: Bearer <HUB_FLEET_TOKEN>` matching the hub's configured token via **`hmac.compare_digest`** (constant-time, no timing leak). Adds a non-raising `_resolve_principal_optional` helper so the token path can be tried as a fallback.
- **`backend/routers/fleet.py`** — gate `GET /api/fleet/status` with `Depends(require_fleet_peer)`.
- **`docs/runbooks/hub-credentials.md`** — documents the **enforced** behavior (the runbook previously claimed validation that did not exist).
- **SPEC.md** — 2.5.89.

## Policy decision (documented)

Fleet reads are **token-gated when `HUB_FLEET_TOKEN` is set** (unauthenticated callers get `401`) and **tailnet-public when it is unset** (backward-compatible no-op for single-node / token-less deployments). To enforce the fleet trust boundary, operators set `HUB_FLEET_TOKEN` on the hub and every spoke. The structural "every `/api/*` route authenticated" follow-up (extending this gate to the remaining proxied read routes across queue/repos/runners/etc.) is tracked by **#924**.

## Tests (TDD)

`tests/api/test_fleet_peer_auth.py`:
- no token configured → anonymous allowed (tailnet-public)
- token set + no credentials → 401; token set + wrong token → 401
- token set + correct fleet token → accepted
- valid principal (session) and valid service-token principal always accepted
- asserts `hmac.compare_digest` is used (timing-safe)
- HTTP-level: `GET /api/fleet/status` returns 401 without the token and is accepted with it

## Acceptance criteria

- [x] With `HUB_FLEET_TOKEN` set, a proxied fleet route called without the token (and without a principal) returns 401
- [x] A spoke request bearing the correct token succeeds
- [x] `hmac.compare_digest` is used (no timing-unsafe equality)
- [x] The runbook accurately describes the enforced behavior

Full backend suite green locally; ruff + ruff format + mypy + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)