### PR TITLE
fix(integration): proxy Maxwell pipeline-control to /api/control, not /api/v1/control (#952)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,20 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.89
+**Spec Version:** 2.5.90
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.90):** Fixed the dead Maxwell pipeline-control proxy path
+  (integration, issue #952). `POST /api/maxwell/pipeline-control/{action}`
+  proxied to `/api/v1/control/{action}`, which Maxwell-Daemon does not expose —
+  every pause/resume/abort from the dashboard 404'd. The proxy now targets MD's
+  real route `POST /api/control/{action}`, and `MaxwellControlResponse` carries
+  MD's `{action, applied_at, previous_state}` shape (with `action` required so a
+  mismatched payload fails loudly; legacy `status`/`message` kept optional for
+  backward compatibility). `docs/contracts/maxwell.md` updated to match. Part of
+  the RD↔MD contract epic (#964); the MD side already serves port 8080 /
+  contract 2.0.0.
 - **2026-06-12 (2.5.89):** Enforced intra-fleet authentication on the hub
   (security, issue #922). Added the `require_fleet_peer` dependency
   (`backend/identity.py`): a hub-reachable fleet route is accepted only when the

--- a/backend/maxwell_contract.py
+++ b/backend/maxwell_contract.py
@@ -193,9 +193,20 @@ class MaxwellCostResponse(BaseModel):
 
 
 class MaxwellControlResponse(BaseModel):
-    """Consumer view of Maxwell-Daemon's /api/v1/control/{action} response."""
+    """Consumer view of Maxwell-Daemon's ``POST /api/control/{action}`` response.
+
+    MD's ``ControlResponse`` (maxwell_daemon/api/contract.py) is
+    ``{action, applied_at, previous_state}``. We mirror those fields and keep
+    ``action`` required so a mismatched payload fails loudly (DbC) instead of
+    silently defaulting (issue #952). The legacy ``status``/``message`` fields are
+    retained as optional for backward compatibility with the dashboard tab and
+    older MD builds, but are no longer the contract's source of truth.
+    """
 
     action: str
+    applied_at: str | None = Field(default=None)
+    previous_state: str | None = Field(default=None)
+    # Legacy/optional — the Maxwell tab and older MD builds may still read these.
     status: str = Field(default="ok")
     message: str | None = Field(default=None)
 

--- a/backend/routers/maxwell.py
+++ b/backend/routers/maxwell.py
@@ -401,7 +401,10 @@ async def maxwell_pipeline_control(
     """
     if action not in ("pause", "resume", "abort"):
         raise HTTPException(status_code=422, detail="action must be pause, resume, or abort")
-    path = f"/api/v1/control/{action}"
+    # Maxwell-Daemon exposes POST /api/control/{action} (not /api/v1/control);
+    # see maxwell_daemon/api/routes/dispatch.py. Proxying to the v1 path 404'd
+    # every pause/resume/abort (issue #952).
+    path = f"/api/control/{action}"
     raw_body = await request.json()
 
     # Validate caller-supplied confirmation_token (DbC, issue #349)

--- a/docs/contracts/maxwell.md
+++ b/docs/contracts/maxwell.md
@@ -24,12 +24,12 @@ This contract is implemented in `backend/maxwell_contract.py`.
 
 Proxy of Maxwell-Daemon `/api/version`.
 
-| Field          | Type         | Notes                          |
-|----------------|--------------|--------------------------------|
-| `version`      | `string`     | Semantic version, default `"unknown"` |
-| `build`        | `string?`    | CI build label or hash         |
-| `environment`  | `string?`    | e.g. `"production"`            |
-| `started_at`   | `string?`    | ISO 8601 daemon start time     |
+| Field         | Type      | Notes                                 |
+| ------------- | --------- | ------------------------------------- |
+| `version`     | `string`  | Semantic version, default `"unknown"` |
+| `build`       | `string?` | CI build label or hash                |
+| `environment` | `string?` | e.g. `"production"`                   |
+| `started_at`  | `string?` | ISO 8601 daemon start time            |
 
 ---
 
@@ -37,16 +37,16 @@ Proxy of Maxwell-Daemon `/api/version`.
 
 Proxy of Maxwell-Daemon `/api/status`.
 
-| Field             | Type       | Notes                           |
-|-------------------|------------|---------------------------------|
-| `state`           | `string`   | `"idle"`, `"running"`, …        |
-| `active_tasks`    | `int`      | Currently executing             |
-| `queued_tasks`    | `int`      | Waiting in queue                |
-| `completed_tasks` | `int?`     |                                 |
-| `failed_tasks`    | `int?`     |                                 |
-| `uptime_seconds`  | `float?`   |                                 |
-| `last_activity`   | `string?`  | ISO 8601                        |
-| `paused`          | `bool`     |                                 |
+| Field             | Type      | Notes                    |
+| ----------------- | --------- | ------------------------ |
+| `state`           | `string`  | `"idle"`, `"running"`, … |
+| `active_tasks`    | `int`     | Currently executing      |
+| `queued_tasks`    | `int`     | Waiting in queue         |
+| `completed_tasks` | `int?`    |                          |
+| `failed_tasks`    | `int?`    |                          |
+| `uptime_seconds`  | `float?`  |                          |
+| `last_activity`   | `string?` | ISO 8601                 |
+| `paused`          | `bool`    |                          |
 
 ---
 
@@ -54,24 +54,24 @@ Proxy of Maxwell-Daemon `/api/status`.
 
 Proxy of Maxwell-Daemon `/api/tasks`.
 
-| Field    | Type            | Notes                       |
-|----------|-----------------|-----------------------------|
-| `tasks`  | `TaskItem[]`    | See task item schema below  |
-| `cursor` | `string?`       | Opaque pagination cursor    |
-| `total`  | `int?`          |                             |
+| Field    | Type         | Notes                      |
+| -------- | ------------ | -------------------------- |
+| `tasks`  | `TaskItem[]` | See task item schema below |
+| `cursor` | `string?`    | Opaque pagination cursor   |
+| `total`  | `int?`       |                            |
 
 **TaskItem**:
 
-| Field          | Type       | Notes                     |
-|----------------|------------|---------------------------|
-| `id`           | `string`   | UUID                      |
-| `status`       | `string`   |                           |
-| `created_at`   | `string?`  | ISO 8601                  |
-| `updated_at`   | `string?`  | ISO 8601                  |
-| `type`         | `string?`  |                           |
-| `priority`     | `int?`     |                           |
-| `tags`         | `string[]` |                           |
-| `error`        | `string?`  |                           |
+| Field        | Type       | Notes    |
+| ------------ | ---------- | -------- |
+| `id`         | `string`   | UUID     |
+| `status`     | `string`   |          |
+| `created_at` | `string?`  | ISO 8601 |
+| `updated_at` | `string?`  | ISO 8601 |
+| `type`       | `string?`  |          |
+| `priority`   | `int?`     |          |
+| `tags`       | `string[]` |          |
+| `error`      | `string?`  |          |
 
 ---
 
@@ -81,11 +81,11 @@ Proxy of Maxwell-Daemon `/api/tasks/{id}`.
 
 Same as TaskItem plus:
 
-| Field            | Type       | Notes              |
-|------------------|------------|--------------------|
-| `started_at`     | `string?`  | ISO 8601           |
-| `completed_at`   | `string?`  | ISO 8601           |
-| `result_summary` | `string?`  | Truncated summary  |
+| Field            | Type      | Notes             |
+| ---------------- | --------- | ----------------- |
+| `started_at`     | `string?` | ISO 8601          |
+| `completed_at`   | `string?` | ISO 8601          |
+| `result_summary` | `string?` | Truncated summary |
 
 ---
 
@@ -93,25 +93,28 @@ Same as TaskItem plus:
 
 Proxy of Maxwell-Daemon `POST /api/v1/tasks`.
 
-| Field             | Type       | Notes                        |
-|-------------------|------------|------------------------------|
-| `task_id`         | `string`   | Returned as `id` by Maxwell  |
-| `status`          | `string`   | Typically `"queued"`         |
-| `idempotency_key` | `string?`  |                              |
-| `created_at`      | `string?`  |                              |
-| `message`         | `string?`  |                              |
+| Field             | Type      | Notes                       |
+| ----------------- | --------- | --------------------------- |
+| `task_id`         | `string`  | Returned as `id` by Maxwell |
+| `status`          | `string`  | Typically `"queued"`        |
+| `idempotency_key` | `string?` |                             |
+| `created_at`      | `string?` |                             |
+| `message`         | `string?` |                             |
 
 ---
 
 ### `POST /api/maxwell/pipeline-control/{action}`
 
-Proxy of Maxwell-Daemon `POST /api/v1/control/{action}`.
+Proxy of Maxwell-Daemon `POST /api/control/{action}` (issue #952; the daemon has
+no `/api/v1/control/*` route).
 
-| Field     | Type      | Notes                        |
-|-----------|-----------|------------------------------|
-| `action`  | `string`  | `pause`, `resume`, `abort`   |
-| `status`  | `string`  | Default `"ok"`               |
-| `message` | `string?` |                              |
+| Field            | Type      | Notes                                     |
+| ---------------- | --------- | ----------------------------------------- |
+| `action`         | `string`  | `pause`, `resume`, `abort` (required)     |
+| `applied_at`     | `string?` | MD timestamp when the control was applied |
+| `previous_state` | `string?` | MD pipeline state before this action      |
+| `status`         | `string`  | Legacy/optional, default `"ok"`           |
+| `message`        | `string?` | Legacy/optional                           |
 
 ---
 
@@ -119,19 +122,19 @@ Proxy of Maxwell-Daemon `POST /api/v1/control/{action}`.
 
 Proxy of Maxwell-Daemon `/api/v1/backends`.
 
-| Field       | Type             | Notes                     |
-|-------------|------------------|---------------------------|
-| `backends`  | `BackendItem[]`  |                           |
+| Field      | Type            | Notes |
+| ---------- | --------------- | ----- |
+| `backends` | `BackendItem[]` |       |
 
 **BackendItem**:
 
-| Field     | Type      | Notes                              |
-|-----------|-----------|------------------------------------|
-| `name`    | `string`  | Display name, e.g. `"Anthropic"`  |
-| `type`    | `string`  |                                    |
-| `enabled` | `bool`    |                                    |
-| `model`   | `string?` |                                    |
-| `status`  | `string?` |                                    |
+| Field     | Type      | Notes                            |
+| --------- | --------- | -------------------------------- |
+| `name`    | `string`  | Display name, e.g. `"Anthropic"` |
+| `type`    | `string`  |                                  |
+| `enabled` | `bool`    |                                  |
+| `model`   | `string?` |                                  |
+| `status`  | `string?` |                                  |
 
 > ⚠️ **`api_key`, `connection_string`, and similar fields are NEVER forwarded.**
 
@@ -141,22 +144,22 @@ Proxy of Maxwell-Daemon `/api/v1/backends`.
 
 Proxy of Maxwell-Daemon `/api/v1/workers`.
 
-| Field       | Type            |
-|-------------|-----------------|
-| `workers`   | `WorkerItem[]`  |
-| `total`     | `int?`          |
+| Field     | Type           |
+| --------- | -------------- |
+| `workers` | `WorkerItem[]` |
+| `total`   | `int?`         |
 
 **WorkerItem**:
 
-| Field               | Type      |
-|---------------------|-----------|
-| `id`                | `string`  |
-| `status`            | `string`  |
-| `current_task_id`   | `string?` |
-| `tasks_completed`   | `int?`    |
-| `tasks_failed`      | `int?`    |
-| `started_at`        | `string?` |
-| `last_activity`     | `string?` |
+| Field             | Type      |
+| ----------------- | --------- |
+| `id`              | `string`  |
+| `status`          | `string`  |
+| `current_task_id` | `string?` |
+| `tasks_completed` | `int?`    |
+| `tasks_failed`    | `int?`    |
+| `started_at`      | `string?` |
+| `last_activity`   | `string?` |
 
 ---
 
@@ -164,13 +167,13 @@ Proxy of Maxwell-Daemon `/api/v1/workers`.
 
 Proxy of Maxwell-Daemon `/api/v1/cost`.
 
-| Field        | Type              |
-|--------------|-------------------|
-| `total_usd`  | `float?`          |
-| `window`     | `string?`         |
-| `by_model`   | `dict[str,float]?`|
-| `by_backend` | `dict[str,float]?`|
-| `currency`   | `string`          |
+| Field        | Type               |
+| ------------ | ------------------ |
+| `total_usd`  | `float?`           |
+| `window`     | `string?`          |
+| `by_model`   | `dict[str,float]?` |
+| `by_backend` | `dict[str,float]?` |
+| `currency`   | `string`           |
 
 ---
 

--- a/tests/test_maxwell_proxy.py
+++ b/tests/test_maxwell_proxy.py
@@ -258,6 +258,41 @@ async def test_maxwell_pipeline_control_daemon_unreachable_returns_503(client) -
     assert resp.json()["detail"] == "maxwell connection error"
 
 
+@pytest.mark.asyncio
+async def test_maxwell_pipeline_control_proxies_to_non_v1_path(client) -> None:
+    """Issue #952: the proxy must target MD's real route POST /api/control/{action},
+    NOT the nonexistent /api/v1/control/{action} (which 404'd every control)."""
+    payload = {"action": "pause", "applied_at": "2026-06-12T00:00:00Z", "previous_state": "running"}
+    mock_cm = _make_mock_client(post_return=_mock_httpx_response(payload))
+    with patch("httpx.AsyncClient", return_value=mock_cm):
+        resp = await client.post(
+            "/api/maxwell/pipeline-control/pause",
+            json={"confirmation_token": "test-token"},
+        )
+    assert resp.status_code == 200
+    called_url = mock_cm.__aenter__.return_value.post.call_args.args[0]
+    assert called_url.endswith("/api/control/pause"), f"expected /api/control/pause, got {called_url}"
+    assert "/api/v1/control/" not in called_url
+
+
+@pytest.mark.asyncio
+async def test_maxwell_pipeline_control_returns_md_response_shape(client) -> None:
+    """Issue #952: the proxy surfaces MD's {action, applied_at, previous_state}
+    instead of silently defaulting to {action, status:'ok'}."""
+    payload = {"action": "abort", "applied_at": "2026-06-12T01:02:03Z", "previous_state": "paused"}
+    mock_cm = _make_mock_client(post_return=_mock_httpx_response(payload))
+    with patch("httpx.AsyncClient", return_value=mock_cm):
+        resp = await client.post(
+            "/api/maxwell/pipeline-control/abort",
+            json={"confirmation_token": "test-token"},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["action"] == "abort"
+    assert data["applied_at"] == "2026-06-12T01:02:03Z"
+    assert data["previous_state"] == "paused"
+
+
 # ─── POST /api/maxwell/dispatch ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #952 (P0, RD<->MD integration). `POST /api/maxwell/pipeline-control/{action}` proxied to `/api/v1/control/{action}`, which Maxwell-Daemon does NOT expose — its only control route is `POST /api/control/{action}` (`maxwell_daemon/api/routes/dispatch.py`). Every pause/resume/abort from the dashboard's Maxwell tab 404'd, so pipeline control never worked against the daemon as shipped. The failure was invisible in RD's tests because they validate hand-written fixtures.

Additionally the response shapes disagreed: MD returns `{action, applied_at, previous_state}` while RD validated `{action, status, message}` (all defaulted), so even a successful response surfaced as a defaulted `status: "ok"` with no real data.

## Changes

- `backend/routers/maxwell.py` — proxy path `/api/v1/control/{action}` -> `/api/control/{action}`.
- `backend/maxwell_contract.py` — `MaxwellControlResponse` now carries MD's `{action, applied_at, previous_state}`; `action` stays required so a mismatched payload fails loudly (DbC) instead of defaulting. Legacy `status`/`message` kept optional for backward compatibility.
- `docs/contracts/maxwell.md` — documents the corrected path and response shape.
- `tests/test_maxwell_proxy.py` — asserts the proxied URL is `/api/control/{action}` (not `/api/v1/control`), and that `applied_at`/`previous_state` round-trip.
- SPEC.md — 2.5.90.

## Acceptance criteria

- [x] Proxy path changed to `/api/control/{action}`
- [x] `MaxwellControlResponse` carries `applied_at` and `previous_state`; `action` required (fails loudly)
- [x] `docs/contracts/maxwell.md` updated

## Coordination

Part of the RD<->MD contract epic #964. The Maxwell_Daemon side already serves port 8080 / contract 2.0.0 (per the MD driver). Remaining contract-alignment items (#956, #955, #958, #960, #959) are separate issues in that epic and need continued cross-repo coordination.

Full backend suite green (pre-push hook); ruff + ruff format + mypy + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
