### PR TITLE
fix(integration): make Maxwell read-path contract real — map daemon shapes, fail loud (#955, #956, #958)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -468,7 +468,7 @@
         "filename": "tests\\test_maxwell_contract.py",
         "hashed_secret": "10eb5a758459a052469c09f5cd56bab6036af011",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 107
       }
     ],
     "tests\\test_push_module.py": [
@@ -576,5 +576,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-12T19:56:41Z"
+  "generated_at": "2026-06-13T00:22:26Z"
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,30 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.91
+**Spec Version:** 2.5.92
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.92):** Made the Maxwell read-path contract real — the
+  `/api/version`, `/api/status`, and `/api/v1/workers` consumer models in
+  `backend/maxwell_contract.py` previously modelled an imaginary shape with zero
+  overlapping keys against the daemon, so every field silently defaulted and the
+  Maxwell tab perpetually showed "unknown / 0 tasks" and an empty worker list
+  (integration, issues #955, #956, #958). The models now validate the daemon's
+  REAL shapes: `/api/version` returns `{daemon, contract}` (both required;
+  `daemon` mirrors to `version`, `contract_compatible` computed against
+  `EXPECTED_CONTRACT_VERSION="2.0.0"`); `/api/status` returns the daemon's
+  `pipeline_state` / `active_task_id` / `gate` / `sandbox` (`pipeline_state`
+  required, mapped to `state`, `paused` derived), with task counts merged from
+  `/api/v2/status` `counts`; `/api/v1/workers` returns
+  `{worker_count, queue_depth}` (`worker_count` required, mirrored to `total`).
+  The discriminating field of each is required so contract
+  drift fails loudly (`ValidationError` surfaced as `502`) instead of defaulting.
+  `GET /api/maxwell/status` now surfaces a `contract` negotiation block
+  `{expected, daemon, compatible}` so the tab can show an incompatibility banner
+  (#956). `docs/contracts/maxwell.md` bumped from "v1" to `2.0.0` with the real
+  shapes. Existing contract/proxy tests updated off the imaginary shapes and new
+  fail-loud / mapping tests added in `tests/test_maxwell_contract.py`.
 - **2026-06-12 (2.5.91):** Added a structural authentication perimeter so every
   `/api/*` route is authenticated by default rather than opt-in per route
   (security, issues #924 and #928). A fail-closed middleware

--- a/backend/maxwell_contract.py
+++ b/backend/maxwell_contract.py
@@ -7,7 +7,14 @@ Responses from Maxwell are deserialized into these models so that:
 2. Sensitive fields (e.g., ``secret_token``, ``api_key``) are never leaked.
 3. Schema drift (Maxwell adds/renames a field) is caught at the boundary.
 
-Contract version: v1 (2026-04-30, issue #366).
+Contract version: 2.0.0 (matches Maxwell-Daemon ``CONTRACT_VERSION``; issues
+#955/#956/#958). Earlier this module modelled an imaginary "v1" shape with zero
+overlapping keys against the daemon, so every field silently defaulted and the
+Maxwell tab perpetually showed "unknown / 0 tasks". The models below validate the
+daemon's REAL response shapes (see ``maxwell_daemon/api/contract.py``) and make
+the discriminating field of each response **required**, so future drift fails
+loudly (a ``ValidationError`` the proxy surfaces as 502) instead of defaulting.
+
 Docs: docs/contracts/maxwell.md
 
 Usage::
@@ -21,7 +28,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+# The contract major version this dashboard build was written against. Surfaced
+# at the /api/version boundary so a major-version mismatch with the daemon's
+# advertised ``contract`` can be detected and shown as a degraded-mode banner
+# instead of rendering silently-defaulted data (#956).
+EXPECTED_CONTRACT_VERSION = "2.0.0"
+EXPECTED_CONTRACT_MAJOR = EXPECTED_CONTRACT_VERSION.split(".", 1)[0]
 
 # ---------------------------------------------------------------------------
 # Shared sentinel — use this for any field that must not be forwarded.
@@ -50,12 +64,34 @@ _SENSITIVE_FIELDS = frozenset(
 
 
 class MaxwellVersionResponse(BaseModel):
-    """Consumer view of Maxwell-Daemon's /api/version endpoint."""
+    """Consumer view of Maxwell-Daemon's ``GET /api/version`` endpoint (#956).
 
+    MD returns ``{daemon, contract}`` (``maxwell_daemon/api/contract.py:VersionResponse``).
+    ``daemon`` is the daemon's semantic version; ``contract`` is the surface
+    contract version used for consumer negotiation. Both are **required** so a
+    reachable-but-incompatible daemon fails loudly here instead of reporting
+    ``version="unknown"`` forever.
+
+    The derived ``version`` field preserves the dashboard-facing name the frontend
+    already reads, and ``contract_compatible`` is computed against the contract
+    version this build targets so the Maxwell tab can show an explicit
+    incompatibility banner rather than silently rendering defaulted data.
+    """
+
+    daemon: str = Field(description="Daemon semantic version (MD 'daemon' field)")
+    contract: str = Field(description="MD surface contract version, e.g. '2.0.0'")
+    # Dashboard-facing alias retained for the existing frontend (mirrors `daemon`).
     version: str = Field(default="unknown", description="Semantic version string")
-    build: str | None = Field(default=None, description="Build hash or CI label")
-    environment: str | None = Field(default=None)
-    started_at: str | None = Field(default=None)
+    contract_compatible: bool = Field(default=True)
+
+    @model_validator(mode="after")
+    def _derive(self) -> MaxwellVersionResponse:
+        # Mirror the daemon version onto the legacy `version` key the UI reads.
+        self.version = self.daemon
+        # Major-version compatibility: a mismatch is a breaking contract change.
+        daemon_major = self.contract.split(".", 1)[0]
+        self.contract_compatible = daemon_major == EXPECTED_CONTRACT_MAJOR
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -64,8 +100,26 @@ class MaxwellVersionResponse(BaseModel):
 
 
 class MaxwellStatusResponse(BaseModel):
-    """Consumer view of Maxwell-Daemon's /api/status endpoint."""
+    """Consumer view of Maxwell-Daemon's ``GET /api/status`` endpoint (#955).
 
+    MD returns ``{pipeline_state, active_task_id, gate, sandbox}``
+    (``maxwell_daemon/api/contract.py:StatusResponse``). ``pipeline_state`` is the
+    discriminating field and is **required** so a shape mismatch fails loudly
+    instead of reporting ``state="unknown"`` against a healthy daemon.
+
+    ``pipeline_state`` is mapped onto the dashboard-facing ``state`` key; ``paused``
+    is derived from it; ``active_tasks`` is derived from ``active_task_id``
+    presence. Richer task counts come from ``GET /api/v2/status`` via
+    :class:`MaxwellStatusV2Response` and are merged in by the proxy route, which
+    sets ``active_tasks``/``queued_tasks``/``completed_tasks``/``failed_tasks``
+    from the authoritative ``counts`` map when available.
+    """
+
+    pipeline_state: str = Field(description="MD pipeline state: idle/running/paused/error")
+    active_task_id: str | None = Field(default=None)
+    gate: str | None = Field(default=None, description="MD admission gate: open/closed")
+    sandbox: str | None = Field(default=None, description="enabled/disabled")
+    # Dashboard-facing derived fields (mirrors / counts).
     state: str = Field(default="unknown")
     active_tasks: int = Field(default=0, ge=0)
     queued_tasks: int = Field(default=0, ge=0)
@@ -74,6 +128,42 @@ class MaxwellStatusResponse(BaseModel):
     uptime_seconds: float | None = Field(default=None)
     last_activity: str | None = Field(default=None)
     paused: bool = Field(default=False)
+
+    @model_validator(mode="after")
+    def _derive(self) -> MaxwellStatusResponse:
+        self.state = self.pipeline_state
+        self.paused = self.pipeline_state == "paused"
+        # Baseline from /api/status; refined by merge_v2_counts() when the richer
+        # /api/v2/status payload is available.
+        self.active_tasks = 1 if self.active_task_id else 0
+        return self
+
+    def merge_v2_counts(self, v2: MaxwellStatusV2Response) -> None:
+        """Overlay authoritative task counts from ``GET /api/v2/status`` (#955).
+
+        ``StatusV2Response.counts`` is a ``{state: n}`` map. We read the standard
+        states defensively (missing keys default to 0) so a daemon that omits a
+        bucket does not crash the merge.
+        """
+        counts = v2.counts
+        self.active_tasks = int(counts.get("running", self.active_tasks))
+        self.queued_tasks = int(counts.get("queued", counts.get("pending", 0)))
+        self.completed_tasks = int(counts.get("completed", counts.get("done", 0)))
+        self.failed_tasks = int(counts.get("failed", counts.get("error", 0)))
+
+
+class MaxwellStatusV2Response(BaseModel):
+    """Consumer view of Maxwell-Daemon's ``GET /api/v2/status`` endpoint (#955).
+
+    Only the ``counts`` map is contract-relevant for the dashboard's task tallies;
+    ``counts`` is **required** so a shape change is caught loudly. The richer
+    ``running``/``retrying`` task arrays are intentionally not modelled field-by-
+    field here (they are large and unstable); they are ignored by this consumer.
+    """
+
+    counts: dict[str, int] = Field(description="Per-state task counts, e.g. {'running': 2}")
+
+    model_config = {"extra": "ignore"}
 
 
 # ---------------------------------------------------------------------------
@@ -166,10 +256,27 @@ class MaxwellWorkerItem(BaseModel):
 
 
 class MaxwellWorkersResponse(BaseModel):
-    """Consumer view of Maxwell-Daemon's /api/v1/workers endpoint."""
+    """Consumer view of Maxwell-Daemon's ``GET /api/v1/workers`` endpoint (#958).
 
+    MD returns ``{worker_count, queue_depth}`` (``maxwell_daemon/api/routes/fleet.py``)
+    — it does NOT (yet) emit per-worker items. ``worker_count`` is **required** so a
+    shape change fails loudly instead of silently rendering an empty list.
+
+    ``total`` mirrors ``worker_count`` for the existing frontend; ``queue_depth`` is
+    surfaced for the workers panel. The ``workers`` list stays empty until MD
+    enriches the endpoint with per-worker detail (tracked on the MD side).
+    """
+
+    worker_count: int = Field(ge=0, description="Number of active workers (MD field)")
+    queue_depth: int | None = Field(default=None, ge=0, description="Pending queue depth (MD field)")
+    # Dashboard-facing fields.
     workers: list[MaxwellWorkerItem] = Field(default_factory=list)
     total: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _derive(self) -> MaxwellWorkersResponse:
+        self.total = self.worker_count
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routers/maxwell.py
+++ b/backend/routers/maxwell.py
@@ -168,6 +168,23 @@ async def get_maxwell_status() -> dict:
 
     status = "running" if (service_running or http_reachable) else "stopped"
 
+    # Contract negotiation (#956): when the daemon is reachable, surface its
+    # advertised contract version and whether it is compatible with the version
+    # this dashboard build targets. Best-effort — never fails the status probe.
+    contract: dict[str, Any] = {
+        "expected": _mc.EXPECTED_CONTRACT_VERSION,
+        "daemon": None,
+        "compatible": None,
+    }
+    if http_reachable:
+        try:
+            raw_version = await _mx_get("/api/version")
+            ver = _mc.MaxwellVersionResponse.model_validate(_mc.strip_sensitive(raw_version))
+            contract["daemon"] = ver.contract
+            contract["compatible"] = ver.contract_compatible
+        except Exception as e:  # noqa: BLE001 — negotiation is advisory here
+            log.info("maxwell contract negotiation skipped: %s", str(e)[:120])
+
     return {
         "status": status,
         "binary_found": maxwell_binary is not None,
@@ -177,6 +194,7 @@ async def get_maxwell_status() -> dict:
         "http_reachable": http_reachable,
         "http_detail": http_detail,
         "dashboard_url": base_url,
+        "contract": contract,
         "deep_links": {
             "dashboard": base_url,
             "health": f"{base_url}/api/health",
@@ -217,18 +235,43 @@ async def maxwell_control(
     return {"status": action + "ed", "action": action, "approved_by": approved_by}
 
 
+async def _validated_maxwell_status() -> _mc.MaxwellStatusResponse:
+    """Fetch and validate MD ``/api/status``, merging ``/api/v2/status`` counts (#955).
+
+    ``/api/status`` is the authoritative pipeline-state source (its discriminating
+    ``pipeline_state`` field is required, so drift fails loudly as a 502). The
+    richer ``/api/v2/status`` ``counts`` map refines the task tallies; it is
+    best-effort — if it is unavailable or shape-shifted, the base status (with
+    ``active_tasks`` derived from ``active_task_id``) is still returned.
+    """
+    raw = await _mx_get("/api/status")
+    status = _mc.MaxwellStatusResponse.model_validate(_mc.strip_sensitive(raw))
+    try:
+        raw_v2 = await _mx_get("/api/v2/status")
+        v2 = _mc.MaxwellStatusV2Response.model_validate(_mc.strip_sensitive(raw_v2))
+        status.merge_v2_counts(v2)
+    except (HTTPException, ValidationError) as exc:
+        # v2 is an enrichment, not a hard dependency — log and keep base counts.
+        log.info("maxwell v2 status enrichment unavailable: %s", str(exc)[:120])
+    return status
+
+
 @router.get("/version")
 async def get_maxwell_version() -> dict:
-    """Proxy GET /api/version from Maxwell-Daemon (contract-filtered)."""
+    """Proxy GET /api/version from Maxwell-Daemon (contract-negotiated, #956).
+
+    Surfaces the daemon's real version and its advertised contract version, plus a
+    ``contract_compatible`` flag the Maxwell tab uses to show a degraded-mode
+    banner on a major-version mismatch instead of rendering defaulted data.
+    """
     raw = await _mx_get("/api/version")
     return _mc.MaxwellVersionResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
 
 
 @router.get("/daemon-status")
 async def get_maxwell_daemon_status_detail() -> dict:
-    """Proxy GET /api/status from Maxwell-Daemon (pipeline state, contract-filtered)."""
-    raw = await _mx_get("/api/status")
-    return _mc.MaxwellStatusResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
+    """Proxy GET /api/status from Maxwell-Daemon (pipeline state + counts, #955)."""
+    return (await _validated_maxwell_status()).model_dump()
 
 
 @router.get("/tasks")
@@ -465,6 +508,5 @@ async def get_maxwell_cost() -> dict:
 
 @router.get("/pipeline-state")
 async def get_maxwell_pipeline_state() -> dict:
-    """Proxy GET /api/status (pipeline state) from Maxwell-Daemon (contract-filtered)."""
-    raw = await _mx_get("/api/status")
-    return _mc.MaxwellStatusResponse.model_validate(_mc.strip_sensitive(raw)).model_dump()
+    """Proxy GET /api/status (pipeline state + counts) from Maxwell-Daemon (#955)."""
+    return (await _validated_maxwell_status()).model_dump()

--- a/docs/contracts/maxwell.md
+++ b/docs/contracts/maxwell.md
@@ -1,8 +1,16 @@
 # Maxwell-Daemon API Contract — Dashboard Consumer View
 
-**Contract version**: v1  
-**Date**: 2026-04-30  
-**Issue**: [#366](https://github.com/D-sorganization/Runner_Dashboard/issues/366)
+**Contract version**: 2.0.0 (matches Maxwell-Daemon `CONTRACT_VERSION`)  
+**Date**: 2026-06-12  
+**Issues**: [#366](https://github.com/D-sorganization/Runner_Dashboard/issues/366),
+[#955](https://github.com/D-sorganization/Runner_Dashboard/issues/955),
+[#956](https://github.com/D-sorganization/Runner_Dashboard/issues/956),
+[#958](https://github.com/D-sorganization/Runner_Dashboard/issues/958)
+
+> The `version`/`status`/`workers` shapes below now mirror the daemon's REAL
+> response shapes (`maxwell_daemon/api/contract.py`). The discriminating field of
+> each is **required**, so contract drift fails loudly (a `ValidationError` the
+> proxy surfaces as `502`) instead of silently defaulting to "unknown / empty".
 
 ---
 
@@ -22,31 +30,45 @@ This contract is implemented in `backend/maxwell_contract.py`.
 
 ### `GET /api/maxwell/version`
 
-Proxy of Maxwell-Daemon `/api/version`.
+Proxy of Maxwell-Daemon `/api/version`, which returns `{daemon, contract}`.
 
-| Field         | Type      | Notes                                 |
-| ------------- | --------- | ------------------------------------- |
-| `version`     | `string`  | Semantic version, default `"unknown"` |
-| `build`       | `string?` | CI build label or hash                |
-| `environment` | `string?` | e.g. `"production"`                   |
-| `started_at`  | `string?` | ISO 8601 daemon start time            |
+| Field                 | Type     | Notes                                                              |
+| --------------------- | -------- | ------------------------------------------------------------------ |
+| `daemon`              | `string` | **Required.** Daemon semantic version (MD `daemon` field)          |
+| `contract`            | `string` | **Required.** MD surface contract version, e.g. `"2.0.0"`          |
+| `version`             | `string` | Mirrors `daemon` for the existing frontend                         |
+| `contract_compatible` | `bool`   | `false` on a major-version mismatch vs `EXPECTED_CONTRACT_VERSION` |
+
+Version negotiation (#956): `GET /api/maxwell/status` also surfaces a
+`contract` block `{expected, daemon, compatible}` when the daemon is reachable,
+so the Maxwell tab can show a degraded-mode banner on an incompatible major
+version instead of rendering defaulted data.
 
 ---
 
 ### `GET /api/maxwell/daemon-status` · `GET /api/maxwell/pipeline-state`
 
-Proxy of Maxwell-Daemon `/api/status`.
+Proxy of Maxwell-Daemon `/api/status` (shape `{pipeline_state, active_task_id,
+gate, sandbox}`), enriched with task counts from `/api/v2/status` (`counts` map).
 
-| Field             | Type      | Notes                    |
-| ----------------- | --------- | ------------------------ |
-| `state`           | `string`  | `"idle"`, `"running"`, … |
-| `active_tasks`    | `int`     | Currently executing      |
-| `queued_tasks`    | `int`     | Waiting in queue         |
-| `completed_tasks` | `int?`    |                          |
-| `failed_tasks`    | `int?`    |                          |
-| `uptime_seconds`  | `float?`  |                          |
-| `last_activity`   | `string?` | ISO 8601                 |
-| `paused`          | `bool`    |                          |
+| Field             | Type      | Notes                                                               |
+| ----------------- | --------- | ------------------------------------------------------------------- |
+| `pipeline_state`  | `string`  | **Required.** MD field: `"idle"`/`"running"`/`"paused"`/`"error"`   |
+| `active_task_id`  | `string?` | MD field                                                            |
+| `gate`            | `string?` | MD admission gate: `"open"`/`"closed"`                              |
+| `sandbox`         | `string?` | `"enabled"`/`"disabled"`                                            |
+| `state`           | `string`  | Mirrors `pipeline_state` for the existing frontend                  |
+| `active_tasks`    | `int`     | From `/api/v2/status` `counts.running` (else 1 if a task is active) |
+| `queued_tasks`    | `int`     | From `counts.queued`/`counts.pending`                               |
+| `completed_tasks` | `int?`    | From `counts.completed`/`counts.done`                               |
+| `failed_tasks`    | `int?`    | From `counts.failed`/`counts.error`                                 |
+| `uptime_seconds`  | `float?`  |                                                                     |
+| `last_activity`   | `string?` | ISO 8601                                                            |
+| `paused`          | `bool`    | Derived: `pipeline_state == "paused"`                               |
+
+The `/api/v2/status` enrichment is best-effort: if it is unavailable or
+shape-shifted, the base `/api/status` mapping is still returned (`active_tasks`
+derived from `active_task_id`).
 
 ---
 
@@ -142,14 +164,17 @@ Proxy of Maxwell-Daemon `/api/v1/backends`.
 
 ### `GET /api/maxwell/workers`
 
-Proxy of Maxwell-Daemon `/api/v1/workers`.
+Proxy of Maxwell-Daemon `/api/v1/workers`, which returns `{worker_count,
+queue_depth}` (it does NOT yet emit per-worker items).
 
-| Field     | Type           |
-| --------- | -------------- |
-| `workers` | `WorkerItem[]` |
-| `total`   | `int?`         |
+| Field          | Type           | Notes                                                       |
+| -------------- | -------------- | ----------------------------------------------------------- |
+| `worker_count` | `int`          | **Required.** Number of active workers (MD field)           |
+| `queue_depth`  | `int?`         | Pending queue depth (MD field)                              |
+| `total`        | `int?`         | Mirrors `worker_count` for the existing frontend            |
+| `workers`      | `WorkerItem[]` | Empty until MD enriches the endpoint with per-worker detail |
 
-**WorkerItem**:
+**WorkerItem** (reserved for when MD adds per-worker detail):
 
 | Field             | Type      |
 | ----------------- | --------- |

--- a/tests/test_maxwell_contract.py
+++ b/tests/test_maxwell_contract.py
@@ -81,23 +81,29 @@ class TestExtraFieldsDropped:
     """Maxwell adds new fields — dashboard response shape must be unchanged."""
 
     def test_version_extra_fields_dropped(self) -> None:
+        # Real MD shape is {daemon, contract} (#956).
         raw = {
-            "version": "1.2.3",
-            "build": "abc123",
+            "daemon": "1.2.3",
+            "contract": "2.0.0",
             "new_field_maxwell_added": "surprise",
             "internal_metric": 99,
         }
         result = mc.MaxwellVersionResponse.model_validate(raw).model_dump()
         assert "new_field_maxwell_added" not in result
         assert "internal_metric" not in result
+        assert result["daemon"] == "1.2.3"
+        # `version` mirrors `daemon` for the existing frontend.
         assert result["version"] == "1.2.3"
-        assert result["build"] == "abc123"
+        assert result["contract"] == "2.0.0"
+        assert result["contract_compatible"] is True
 
     def test_status_extra_fields_dropped(self) -> None:
+        # Real MD shape is {pipeline_state, active_task_id, gate, sandbox} (#955).
         raw = {
-            "state": "running",
-            "active_tasks": 3,
-            "queued_tasks": 1,
+            "pipeline_state": "running",
+            "active_task_id": "task-9",
+            "gate": "open",
+            "sandbox": "enabled",
             "maxwell_internal_secret": "should-not-appear",
             "new_metric": "yes",
         }
@@ -105,7 +111,8 @@ class TestExtraFieldsDropped:
         assert "maxwell_internal_secret" not in result
         assert "new_metric" not in result
         assert result["state"] == "running"
-        assert result["active_tasks"] == 3
+        # active_task_id present → at least one active task.
+        assert result["active_tasks"] == 1
 
     def test_task_list_extra_fields_dropped(self) -> None:
         raw = {
@@ -157,7 +164,8 @@ class TestSensitiveFieldsNeverForwarded:
 
     def test_api_key_stripped_from_version(self) -> None:
         raw = {
-            "version": "1.0.0",
+            "daemon": "1.0.0",
+            "contract": "2.0.0",
             "api_key": "sk-dangerous",  # pragma: allowlist secret
             "secret_token": "another",  # pragma: allowlist secret
         }
@@ -187,7 +195,8 @@ class TestSensitiveFieldsNeverForwarded:
 
     def test_all_known_sensitive_keys_stripped(self) -> None:
         raw = {
-            "version": "1.0.0",
+            "daemon": "1.0.0",
+            "contract": "2.0.0",
             "secret_token": "t1",  # pragma: allowlist secret
             "api_key": "k1",  # pragma: allowlist secret
             "api_secret": "s1",  # pragma: allowlist secret
@@ -212,17 +221,6 @@ class TestSensitiveFieldsNeverForwarded:
 
 
 class TestDefaults:
-    def test_version_defaults(self) -> None:
-        result = mc.MaxwellVersionResponse.model_validate({}).model_dump()
-        assert result["version"] == "unknown"
-        assert result["build"] is None
-
-    def test_status_defaults(self) -> None:
-        result = mc.MaxwellStatusResponse.model_validate({}).model_dump()
-        assert result["state"] == "unknown"
-        assert result["active_tasks"] == 0
-        assert result["paused"] is False
-
     def test_task_list_defaults(self) -> None:
         result = mc.MaxwellTaskListResponse.model_validate({}).model_dump()
         assert result["tasks"] == []
@@ -245,3 +243,88 @@ class TestDefaults:
         assert result["action"] == "pause"
         assert result["status"] == "ok"
         assert result["message"] is None
+
+
+# ---------------------------------------------------------------------------
+# Real MD-shape mapping + fail-loud on drift (issues #955, #956, #958)
+# ---------------------------------------------------------------------------
+
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+
+class TestVersionContractNegotiation:
+    """#956 — /api/version maps {daemon, contract} and negotiates compatibility."""
+
+    def test_compatible_contract(self) -> None:
+        result = mc.MaxwellVersionResponse.model_validate({"daemon": "3.1.0", "contract": "2.4.1"}).model_dump()
+        assert result["version"] == "3.1.0"
+        assert result["contract"] == "2.4.1"
+        assert result["contract_compatible"] is True  # major 2 == expected major 2
+
+    def test_incompatible_major_contract(self) -> None:
+        result = mc.MaxwellVersionResponse.model_validate({"daemon": "9.0.0", "contract": "3.0.0"}).model_dump()
+        assert result["contract_compatible"] is False
+
+    def test_missing_contract_fails_loud(self) -> None:
+        with pytest.raises(ValidationError):
+            mc.MaxwellVersionResponse.model_validate({"daemon": "1.0.0"})
+
+    def test_missing_daemon_fails_loud(self) -> None:
+        with pytest.raises(ValidationError):
+            mc.MaxwellVersionResponse.model_validate({"contract": "2.0.0"})
+
+
+class TestStatusMapping:
+    """#955 — /api/status maps pipeline_state→state; v2 counts refine tallies."""
+
+    def test_pipeline_state_maps_to_state(self) -> None:
+        result = mc.MaxwellStatusResponse.model_validate(
+            {"pipeline_state": "idle", "active_task_id": None, "gate": "open", "sandbox": "enabled"}
+        ).model_dump()
+        assert result["state"] == "idle"
+        assert result["active_tasks"] == 0
+        assert result["paused"] is False
+
+    def test_paused_derived(self) -> None:
+        result = mc.MaxwellStatusResponse.model_validate({"pipeline_state": "paused"}).model_dump()
+        assert result["paused"] is True
+
+    def test_missing_pipeline_state_fails_loud(self) -> None:
+        # The old imaginary {state, active_tasks} shape must now be rejected, not
+        # silently defaulted to "unknown / 0 tasks".
+        with pytest.raises(ValidationError):
+            mc.MaxwellStatusResponse.model_validate({"state": "running", "active_tasks": 3})
+
+    def test_v2_counts_merge(self) -> None:
+        status = mc.MaxwellStatusResponse.model_validate({"pipeline_state": "running", "active_task_id": "t1"})
+        v2 = mc.MaxwellStatusV2Response.model_validate(
+            {"counts": {"running": 2, "queued": 5, "completed": 10, "failed": 1}}
+        )
+        status.merge_v2_counts(v2)
+        d = status.model_dump()
+        assert d["active_tasks"] == 2
+        assert d["queued_tasks"] == 5
+        assert d["completed_tasks"] == 10
+        assert d["failed_tasks"] == 1
+
+    def test_v2_missing_counts_fails_loud(self) -> None:
+        with pytest.raises(ValidationError):
+            mc.MaxwellStatusV2Response.model_validate({"running": []})
+
+
+class TestWorkersMapping:
+    """#958 — /api/v1/workers maps {worker_count, queue_depth}."""
+
+    def test_worker_count_maps_to_total(self) -> None:
+        result = mc.MaxwellWorkersResponse.model_validate({"worker_count": 4, "queue_depth": 7}).model_dump()
+        assert result["worker_count"] == 4
+        assert result["total"] == 4
+        assert result["queue_depth"] == 7
+        assert result["workers"] == []
+
+    def test_missing_worker_count_fails_loud(self) -> None:
+        # The old {workers, total} shape (zero overlap with MD) must be rejected.
+        with pytest.raises(ValidationError):
+            mc.MaxwellWorkersResponse.model_validate({"workers": [], "total": 0})

--- a/tests/test_maxwell_proxy.py
+++ b/tests/test_maxwell_proxy.py
@@ -103,14 +103,16 @@ def _make_mock_client(get_return=None, post_return=None, get_side_effect=None, p
 @pytest.mark.asyncio
 async def test_get_maxwell_version_returns_200_with_contract(client) -> None:
     """GET /api/maxwell/version proxies daemon response through the contract model."""
-    payload = {"version": "1.0.0", "build": "abc123"}
+    # Real MD /api/version shape is {daemon, contract} (#956).
+    payload = {"daemon": "1.0.0", "contract": "2.0.0"}
     mock_cm = _make_mock_client(get_return=_mock_httpx_response(payload))
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.get("/api/maxwell/version")
     assert resp.status_code == 200
     data = resp.json()
     assert data["version"] == "1.0.0"
-    assert data["build"] == "abc123"
+    assert data["contract"] == "2.0.0"
+    assert data["contract_compatible"] is True
 
 
 @pytest.mark.asyncio
@@ -181,14 +183,25 @@ async def test_get_maxwell_task_detail_daemon_unreachable_returns_503(client) ->
 
 @pytest.mark.asyncio
 async def test_get_maxwell_daemon_status_returns_200(client) -> None:
-    """GET /api/maxwell/daemon-status proxies pipeline state from daemon."""
-    payload = {"state": "idle", "active_tasks": 0, "queued_tasks": 0}
-    mock_cm = _make_mock_client(get_return=_mock_httpx_response(payload))
+    """GET /api/maxwell/daemon-status maps pipeline_state→state and merges v2 counts (#955)."""
+
+    # The route fetches /api/status then /api/v2/status; dispatch by URL.
+    async def _get_by_url(url, *_a, **_kw):
+        if url.endswith("/api/v2/status"):
+            return _mock_httpx_response({"counts": {"running": 2, "queued": 3, "completed": 7, "failed": 1}})
+        return _mock_httpx_response(
+            {"pipeline_state": "running", "active_task_id": "t1", "gate": "open", "sandbox": "enabled"}
+        )
+
+    mock_cm = _make_mock_client(get_side_effect=_get_by_url)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         resp = await client.get("/api/maxwell/daemon-status")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["state"] == "idle"
+    assert data["state"] == "running"
+    assert data["active_tasks"] == 2
+    assert data["queued_tasks"] == 3
+    assert data["completed_tasks"] == 7
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #955, #956, #958. `backend/maxwell_contract.py` modelled an **imaginary** shape with zero overlapping keys against Maxwell-Daemon, so `/api/version`, `/api/status`, and `/api/v1/workers` had every field silently default — the Maxwell tab perpetually showed "unknown / 0 tasks" and an empty worker list against a healthy daemon.

The models now validate the daemon's **real** shapes (`maxwell_daemon/api/contract.py`, verified against `origin/main` of Maxwell_Daemon) and make the discriminating field of each **required** so drift fails loudly (`ValidationError` → `502`) instead of defaulting.

### #955 — `/api/status`
MD returns `{pipeline_state, active_task_id, gate, sandbox}`. `pipeline_state` is required and mapped to `state`; `paused` derived; `active_tasks` derived from `active_task_id`. Task counts (`active_tasks`/`queued_tasks`/`completed_tasks`/`failed_tasks`) are refined from `GET /api/v2/status`'s `counts` map (best-effort enrichment). Applies to both `/api/maxwell/daemon-status` and `/api/maxwell/pipeline-state`.

### #956 — `/api/version` negotiation
MD returns `{daemon, contract}` (both required). `daemon` mirrors to `version`; `contract_compatible` is computed against `EXPECTED_CONTRACT_VERSION = "2.0.0"` (major-version check). `GET /api/maxwell/status` now surfaces a `contract` block `{expected, daemon, compatible}` when the daemon is reachable, so the tab can show an incompatibility banner instead of rendering defaulted data.

### #958 — `/api/v1/workers`
MD returns `{worker_count, queue_depth}` (it does not emit per-worker items). `worker_count` is required and mirrored to `total`; `queue_depth` surfaced.

### Docs & tests
- `docs/contracts/maxwell.md` bumped from "v1" → `2.0.0` with the real shapes (#956 doc item).
- Existing contract/proxy tests rebased off the imaginary shapes; new fail-loud + mapping tests added. 48 maxwell tests pass locally; ruff clean. SPEC.md → 2.5.92.

### Cross-repo coordination
Producer side is `D-sorganization/Maxwell_Daemon` (`api/contract.py`, `api/routes/{status,health,fleet}.py`), already at port 8080 / contract `2.0.0` — these shapes were verified against its `origin/main`. No MD-side change required for this consumer fix. Per-issue lease comments posted on #955/#956/#958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Closes #955
Closes #956
Closes #958
