### PR TITLE
fix(security): fail-closed approval HMAC, drop hardcoded Maxwell secret, symlinked-root path fix (#925, #926, #927)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -422,7 +422,7 @@
         "filename": "tests\\test_envelope_signing.py",
         "hashed_secret": "c26f6021cef733c56580a7d4dc45db5f6526e22c",
         "is_verified": false,
-        "line_number": 709
+        "line_number": 721
       }
     ],
     "tests\\test_linear_taxonomy_utils.py": [
@@ -468,7 +468,7 @@
         "filename": "tests\\test_maxwell_contract.py",
         "hashed_secret": "10eb5a758459a052469c09f5cd56bab6036af011",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 101
       }
     ],
     "tests\\test_push_module.py": [
@@ -495,86 +495,86 @@
         "filename": "tests\\test_security.py",
         "hashed_secret": "52e0b684278a23a4df0591929d470b8a8af68bcb",
         "is_verified": false,
-        "line_number": 323
+        "line_number": 351
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "7d3bbb5cbbc497d78ad547d8d39cbea2b3b8b69e",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 352
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "759730a97e4373f3a0ee12805db065e3a4a649a5",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 353
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "a0843b8e5129c07d9c7785182089001803f7c3b9",
         "is_verified": false,
-        "line_number": 326
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "cb1fa73a03da3c48374cd4146f394733df379201",
         "is_verified": false,
-        "line_number": 327
+        "line_number": 355
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_verified": false,
-        "line_number": 329
+        "line_number": 357
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "fcbdc4c271c889825d8338d2d8f10b6e5e95c171",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 358
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "05b145cfb6fbc24d08a8e01155c0aa2bf8460c87",
         "is_verified": false,
-        "line_number": 331
+        "line_number": 359
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "8fd5ad24df1e1b800d670e563b1b83591980060a",
         "is_verified": false,
-        "line_number": 332
+        "line_number": 360
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "80b3364deb09ee4c7f775a999a72ccb433d596c9",
         "is_verified": false,
-        "line_number": 334
+        "line_number": 362
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "0c731a5f1dc781894b434c27b9f6a9cd9d9bdfcb",
         "is_verified": false,
-        "line_number": 335
+        "line_number": 363
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_security.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 336
+        "line_number": 364
       }
     ]
   },
-  "generated_at": "2026-06-13T00:22:26Z"
+  "generated_at": "2026-06-13T00:35:52Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -468,7 +468,7 @@
         "filename": "tests\\test_maxwell_contract.py",
         "hashed_secret": "10eb5a758459a052469c09f5cd56bab6036af011",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 107
       }
     ],
     "tests\\test_push_module.py": [
@@ -576,5 +576,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-13T00:35:52Z"
+  "generated_at": "2026-06-13T01:35:31Z"
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,27 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.95
+**Spec Version:** 2.5.96
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.96):** Hardened three dispatch/credential security defects
+  (security, issues #925, #926, #927). (1) `verify_approval_hmac`
+  (`backend/dispatch/signing.py`) returned `True` for any confirmation lacking an
+  `approval_hmac` ("backward compatibility"), so a forged approval with no HMAC
+  verified and the envelope/action binding was effectively optional. It now fails
+  closed: when a signing secret is configured an unsigned confirmation is
+  rejected, with the legacy permissive behaviour available only behind the
+  explicit, default-off `DISPATCH_ALLOW_UNSIGNED_APPROVAL` flag (which logs a
+  deprecation warning). (2) `MAXWELL_API_TOKEN`
+  (`backend/dashboard_config/__init__.py`) defaulted to the published string
+  `"maxwell-local-secret"` — anyone reading the source could mint valid Maxwell
+  bearer tokens. The default is now `""` (no token → no `Authorization` header,
+  correct for a token-less daemon); the hardcoded string is gone. (3)
+  `validate_local_path` (`backend/security.py`) resolved user input (following
+  symlinks) but compared against an UNresolved `allowed_root`, so a symlinked root
+  rejected legitimate paths and could let crafted symlinks pass containment. It
+  now resolves both sides (resolved-vs-resolved). Each fix ships fail-loud tests.
 - **2026-06-12 (2.5.95):** Fixed the autoscaler singleton lock falling through to
   an alternate path when the primary lock was HELD (correctness, issue #933).
   `_acquire_lock` (`backend/runner_autoscaler.py`) caught every `OSError` from the

--- a/backend/dashboard_config/__init__.py
+++ b/backend/dashboard_config/__init__.py
@@ -83,7 +83,12 @@ def _resolve_bind_host() -> str:
 HOST = _resolve_bind_host()
 MAXWELL_PORT = int(os.environ.get("MAXWELL_PORT", "8322"))
 MAXWELL_URL = (os.environ.get("MAXWELL_URL", "") or f"http://localhost:{MAXWELL_PORT}").rstrip("/")
-MAXWELL_API_TOKEN = os.environ.get("MAXWELL_API_TOKEN", "maxwell-local-secret")
+# Issue #926: no hardcoded default secret. When MAXWELL_API_TOKEN is unset the
+# dashboard sends NO Authorization header (routers.maxwell._maxwell_headers), which
+# is correct for a token-less Maxwell-Daemon (per its ConnectionProfile, the daemon
+# runs open only when no auth is configured). A published default string would let
+# anyone reading the source mint valid Maxwell bearer tokens.
+MAXWELL_API_TOKEN = os.environ.get("MAXWELL_API_TOKEN", "").strip()
 
 
 def runner_limit() -> int:

--- a/backend/dispatch/signing.py
+++ b/backend/dispatch/signing.py
@@ -23,10 +23,33 @@ import enum
 import hashlib
 import hmac
 import json
+import logging
 import os
 
 UTC = getattr(_dt_mod, "UTC", _dt_mod.timezone.utc)  # noqa: UP017
 datetime = _dt_mod.datetime
+
+log = logging.getLogger("dashboard.dispatch.signing")
+
+# Legacy escape hatch (issue #925): when a signing secret IS configured, a
+# confirmation that carries no approval HMAC is rejected by default (fail-closed).
+# Operators who genuinely still run pre-#318 clients can opt back into the old
+# permissive behaviour by setting this flag truthy; doing so logs a deprecation
+# warning on every unsigned confirmation so the gap is visible.
+_ALLOW_UNSIGNED_APPROVAL_ENV = "DISPATCH_ALLOW_UNSIGNED_APPROVAL"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _resolve_approval_secret() -> str:
+    """Return the configured approval HMAC secret, or '' when none is set.
+
+    Prefers ``APPROVAL_HMAC_SECRET`` and falls back to ``DISPATCH_SIGNING_SECRET``
+    so single-secret deployments work without extra configuration.
+    """
+    secret = os.environ.get("APPROVAL_HMAC_SECRET", "").strip()
+    if not secret:
+        secret = os.environ.get("DISPATCH_SIGNING_SECRET", "").strip()
+    return secret
 
 
 class _StrEnum(str, enum.Enum):  # noqa: UP042
@@ -117,25 +140,43 @@ def _compute_approval_hmac(envelope_id: str, action: str, secret: str) -> str:
 def verify_approval_hmac(confirmation: object, envelope_id: str, action: str) -> bool:
     """Verify that *confirmation.approval_hmac* is bound to *envelope_id* and *action*.
 
-    Loads the secret from ``APPROVAL_HMAC_SECRET`` (falls back to the
-    dispatch signing secret so that single-secret deployments work out of
-    the box).  Returns ``False`` immediately if no secret is configured.
+    Loads the secret from ``APPROVAL_HMAC_SECRET`` (falls back to the dispatch
+    signing secret so single-secret deployments work out of the box).
+
+    Fail-closed policy (issue #925): when a signing secret IS configured, a
+    confirmation that carries no ``approval_hmac`` is **rejected** — an attacker
+    can otherwise submit approvals with no HMAC and have them accepted, defeating
+    the envelope/action binding entirely. The legacy permissive behaviour (accept
+    unsigned confirmations) is available only behind the explicit, default-off
+    ``DISPATCH_ALLOW_UNSIGNED_APPROVAL`` flag, which logs a deprecation warning.
+
+    When NO secret is configured the binding cannot be checked at all, so the
+    result is ``False`` regardless (the dispatch path enforces other gates).
 
     ``confirmation`` is expected to be a ``DispatchConfirmation``-like object
     with an ``approval_hmac`` attribute.
     """
+    secret = _resolve_approval_secret()
     stored_hmac: str = getattr(confirmation, "approval_hmac", "")
+
     if not stored_hmac:
-        # No HMAC was recorded on this confirmation — skip binding check.
-        # Confirmations that include an approval_hmac must always verify;
-        # those without one are accepted for backward compatibility with
-        # clients that pre-date issue #318.
-        return True
-    secret = os.environ.get("APPROVAL_HMAC_SECRET", "").strip()
-    if not secret:
-        # Fall back to the dispatch signing secret so single-secret
-        # deployments work without extra configuration.
-        secret = os.environ.get("DISPATCH_SIGNING_SECRET", "").strip()
+        if not secret:
+            # No secret configured → binding cannot be established. Fail closed.
+            return False
+        # Secret IS configured but the confirmation is unsigned.
+        if os.environ.get(_ALLOW_UNSIGNED_APPROVAL_ENV, "").strip().lower() in _TRUTHY:
+            log.warning(
+                "DEPRECATED: accepting unsigned dispatch approval for envelope_id=%s "
+                "action=%s because %s is set. This bypass will be removed; migrate "
+                "clients to send an approval_hmac (issue #925).",
+                envelope_id,
+                action,
+                _ALLOW_UNSIGNED_APPROVAL_ENV,
+            )
+            return True
+        # Fail closed: a configured secret means approvals MUST be signed.
+        return False
+
     if not secret:
         return False
     expected = _compute_approval_hmac(envelope_id, action, secret)

--- a/backend/security.py
+++ b/backend/security.py
@@ -167,10 +167,19 @@ def validate_owner_repo_format(value: str) -> str:
 
 
 def validate_local_path(path_str: str, allowed_root: Path) -> Path:
-    """Resolve path and ensure it stays within allowed_root (issue #23)."""
+    """Resolve path and ensure it stays within allowed_root (issues #23, #927).
+
+    Both the user input AND ``allowed_root`` are fully resolved (following
+    symlinks) before the containment check, so the comparison is
+    resolved-vs-resolved. Previously ``allowed_root`` was compared unresolved
+    while ``resolved`` followed symlinks: when ``allowed_root`` itself was (or
+    contained) a symlink, legitimate paths inside the real root were rejected and,
+    worse, crafted symlinks could pass a containment check they should not (#927).
+    """
     resolved = Path(path_str).expanduser().resolve()
+    resolved_root = Path(allowed_root).expanduser().resolve()
     try:
-        resolved.relative_to(allowed_root)
+        resolved.relative_to(resolved_root)
     except ValueError as exc:
         raise ValueError(f"Path escapes allowed root: {path_str}") from exc
     return resolved

--- a/tests/test_dashboard_config_constants.py
+++ b/tests/test_dashboard_config_constants.py
@@ -43,6 +43,48 @@ def test_cache_ttls_are_positive_integers() -> None:
         assert value > 0, f"{name} must be positive, got {value}"
 
 
+def test_no_hardcoded_maxwell_default_secret() -> None:
+    """#926: the published default secret 'maxwell-local-secret' must not appear
+    in the source, and MAXWELL_API_TOKEN must default to '' (no token) when unset
+    so the dashboard never authenticates with a guessable string."""
+    import importlib
+    import os
+    from pathlib import Path
+    from unittest.mock import patch
+
+    src = (Path(__file__).resolve().parent.parent / "backend" / "dashboard_config" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+    assert "maxwell-local-secret" not in src, "hardcoded Maxwell default secret must be removed (#926)"
+
+    import dashboard_config
+
+    # With the env var unset, the resolved token is empty (no Authorization header).
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MAXWELL_API_TOKEN", None)
+        reloaded = importlib.reload(dashboard_config)
+        try:
+            assert reloaded.MAXWELL_API_TOKEN == ""
+        finally:
+            importlib.reload(dashboard_config)
+
+
+def test_maxwell_token_uses_env_when_set() -> None:
+    """When MAXWELL_API_TOKEN is set, the configured value is used (#926)."""
+    import importlib
+    import os
+    from unittest.mock import patch
+
+    import dashboard_config
+
+    with patch.dict(os.environ, {"MAXWELL_API_TOKEN": "operator-set-token"}, clear=False):
+        reloaded = importlib.reload(dashboard_config)
+        try:
+            assert reloaded.MAXWELL_API_TOKEN == "operator-set-token"
+        finally:
+            importlib.reload(dashboard_config)
+
+
 def test_http_timeout_module_importable() -> None:
     """``HttpTimeout`` is importable from the package and the leaf submodule."""
     from dashboard_config import HttpTimeout as PackageHttpTimeout

--- a/tests/test_envelope_signing.py
+++ b/tests/test_envelope_signing.py
@@ -366,19 +366,31 @@ class TestCryptoValidation:
             assert result.valid is False
 
     def test_crypto_validation_accepts_confirmation_with_valid_timestamp(self):
-        """validate_envelope_crypto accepts confirmation with fresh timestamp."""
+        """validate_envelope_crypto accepts confirmation with fresh timestamp.
+
+        A valid approval_hmac is supplied because, since #925, an unsigned
+        confirmation is rejected when a signing secret is configured (this test
+        exercises the timestamp-freshness path, not the unsigned-bypass).
+        """
+        from dispatch_contract import _compute_approval_hmac
+
         with patch.dict(os.environ, {"DISPATCH_SIGNING_SECRET": "test-secret"}):
             now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            envelope_id = "env-fresh-ts"
+            action = "test.action"
             confirmation = DispatchConfirmation(
                 approved_by="bob",
                 approved_at=now,
+                envelope_id=envelope_id,
+                approval_hmac=_compute_approval_hmac(envelope_id, action, "test-secret"),
             )
             envelope = CommandEnvelope(
-                action="test.action",
+                action=action,
                 source="hub",
                 target="node-1",
                 requested_by="alice",
                 confirmation=confirmation,
+                envelope_id=envelope_id,
             )
             result = validate_envelope_crypto(envelope)
             assert result.valid is True
@@ -750,3 +762,68 @@ class TestApprovalHmacFunctions:
         with patch.dict(os.environ, {}, clear=True):
             # Neither APPROVAL_HMAC_SECRET nor DISPATCH_SIGNING_SECRET present
             assert verify_approval_hmac(confirmation, "env-xyz", "runner.stop") is False
+
+
+class TestApprovalHmacFailClosed:
+    """#925 — an absent approval HMAC must NOT verify when a secret is configured.
+
+    Previously ``verify_approval_hmac`` returned True for any confirmation lacking
+    an ``approval_hmac`` ("backward compatibility"), so an attacker could submit
+    approvals with no HMAC and have them accepted, defeating the envelope/action
+    binding entirely.
+    """
+
+    def test_absent_hmac_rejected_when_secret_configured(self):
+        from dispatch_contract import DispatchConfirmation, verify_approval_hmac
+
+        confirmation = DispatchConfirmation(
+            approved_by="mallory",
+            approved_at="2026-01-01T12:00:00Z",
+            envelope_id="env-1",
+            approval_hmac="",  # forged: no binding
+        )
+        with patch.dict(os.environ, {"APPROVAL_HMAC_SECRET": "test-secret"}, clear=True):
+            assert verify_approval_hmac(confirmation, "env-1", "runner.restart") is False
+
+    def test_absent_hmac_rejected_when_no_secret(self):
+        from dispatch_contract import DispatchConfirmation, verify_approval_hmac
+
+        confirmation = DispatchConfirmation(
+            approved_by="mallory",
+            approved_at="2026-01-01T12:00:00Z",
+            envelope_id="env-1",
+            approval_hmac="",
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            assert verify_approval_hmac(confirmation, "env-1", "runner.restart") is False
+
+    def test_legacy_flag_re_enables_unsigned_acceptance(self):
+        """The explicit, default-off escape hatch restores legacy permissiveness."""
+        from dispatch_contract import DispatchConfirmation, verify_approval_hmac
+
+        confirmation = DispatchConfirmation(
+            approved_by="legacy-client",
+            approved_at="2026-01-01T12:00:00Z",
+            envelope_id="env-1",
+            approval_hmac="",
+        )
+        env = {
+            "APPROVAL_HMAC_SECRET": "test-secret",
+            "DISPATCH_ALLOW_UNSIGNED_APPROVAL": "1",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            assert verify_approval_hmac(confirmation, "env-1", "runner.restart") is True
+
+    def test_signed_confirmation_still_verifies(self):
+        """A correctly signed confirmation continues to verify (no regression)."""
+        from dispatch_contract import DispatchConfirmation, _compute_approval_hmac, verify_approval_hmac
+
+        with patch.dict(os.environ, {"APPROVAL_HMAC_SECRET": "test-secret"}, clear=True):
+            correct = _compute_approval_hmac("env-1", "runner.restart", "test-secret")
+            confirmation = DispatchConfirmation(
+                approved_by="alice",
+                approved_at="2026-01-01T12:00:00Z",
+                envelope_id="env-1",
+                approval_hmac=correct,
+            )
+            assert verify_approval_hmac(confirmation, "env-1", "runner.restart") is True

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -181,6 +181,34 @@ def test_validate_local_path_dotdot_escape(tmp_path: Path) -> None:
         security.validate_local_path(str(tmp_path / ".." / "etc" / "passwd"), tmp_path)
 
 
+def test_validate_local_path_symlinked_root_resolves_both(tmp_path: Path) -> None:
+    """#927: when allowed_root is itself a symlink, paths inside the REAL root
+    must validate (resolved-vs-resolved). Previously allowed_root was compared
+    unresolved, so a legitimate path inside the real root was rejected."""
+    real_root = tmp_path / "real_root"
+    real_root.mkdir()
+    link_root = tmp_path / "link_root"
+    _symlink_or_skip(link_root, real_root)
+
+    target = real_root / "data" / "file.txt"
+    # Pass the SYMLINK as allowed_root; the input lives under the real root.
+    result = security.validate_local_path(str(target), link_root)
+    assert result == target.resolve()
+
+
+def test_validate_local_path_symlinked_root_still_blocks_escape(tmp_path: Path) -> None:
+    """#927: a path outside the real root must still be rejected even when
+    allowed_root is provided as a symlink."""
+    real_root = tmp_path / "real_root"
+    real_root.mkdir()
+    link_root = tmp_path / "link_root"
+    _symlink_or_skip(link_root, real_root)
+
+    outside = tmp_path / "outside" / "secret.txt"
+    with pytest.raises(ValueError, match="Path escapes"):
+        security.validate_local_path(str(outside), link_root)
+
+
 # ---------------------------------------------------------------------------
 # validate_health_command
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #925, #926, #927 — three dispatch/credential security defects.

### #925 — `verify_approval_hmac` returned True when the HMAC was absent
`backend/dispatch/signing.py` returned `True` for any confirmation lacking an `approval_hmac` ("backward compatibility"), so a forged approval with **no HMAC** verified — the envelope/action binding was optional in practice. Now **fails closed**: when a signing secret is configured an unsigned confirmation is rejected. The legacy permissive behaviour is available only behind the explicit, default-off `DISPATCH_ALLOW_UNSIGNED_APPROVAL` env flag, which logs a deprecation warning on every unsigned confirmation.

### #926 — hardcoded default Maxwell secret
`MAXWELL_API_TOKEN` (`backend/dashboard_config/__init__.py`) defaulted to the published string `"maxwell-local-secret"` — anyone reading the source could mint valid Maxwell bearer tokens. The default is now `""`: with no token the dashboard sends **no** `Authorization` header (correct for a token-less daemon per its `ConnectionProfile`). The string no longer appears in the codebase. (The issue's optional "503 when unset" behaviour was deliberately not adopted, as it would break a valid token-less MD deployment; noted for follow-up.)

### #927 — `validate_local_path` resolved input but not the root
`backend/security.py` resolved user input (following symlinks) but compared against an **unresolved** `allowed_root`. When the root was/contained a symlink, legitimate paths inside the real root were rejected and crafted symlinks could pass containment. Now resolves both sides (resolved-vs-resolved). The function had no callers, so this fixes a latent footgun before it is wired up.

### Tests
Fail-loud tests added for each: unsigned-approval rejection + legacy-flag re-enable (`tests/test_envelope_signing.py`), no-hardcoded-secret + env-driven token (`tests/test_dashboard_config_constants.py`), symlinked-root validate/escape (`tests/test_security.py`). One pre-existing test that relied on the #925 bug (`test_crypto_validation_accepts_confirmation_with_valid_timestamp`) was updated to supply a valid HMAC. 168 dispatch/security/config tests pass locally; ruff clean. SPEC.md → 2.5.93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Closes #925
Closes #926
Closes #927
