### PR TITLE
docs: README security posture — describe the real identity stack (#946)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,33 @@ backend serves as assets.
 ## Security
 
 > **Security Notice**: This dashboard provides full control over your GitHub
-> Actions runner fleet. It has no built-in authentication. Restrict network
-> access to trusted operators only. See [SECURITY.md](SECURITY.md) for the
+> Actions runner fleet. Treat the network it binds to as a trust boundary and
+> restrict access to trusted operators. See [SECURITY.md](SECURITY.md) for the
 > vulnerability disclosure policy.
+
+The dashboard ships with a built-in identity and authorization stack — it is
+**not** an unauthenticated service. Configure it before exposing the port:
+
+- **Principals, roles, and scopes** — every `/api/*` route is authenticated by
+  default (a structural perimeter rejects unauthenticated requests); operations
+  are gated by role-derived scopes. See `backend/identity.py`
+  (`require_principal`, `require_scope`, `SCOPE_PRESETS`).
+- **Sessions with revocation** — server-side sessions backed by
+  `backend/session_management.py`; revoked/expired sessions are rejected.
+- **GitHub OAuth + org membership check** — operators sign in via GitHub and are
+  admitted only if they belong to the configured org
+  (`backend/routers/auth.py`).
+- **WebAuthn** — passkey registration/assertion scaffolding in
+  `backend/auth_webauthn.py`.
+- **Service tokens / API-key bootstrap** — bot principals authenticate with
+  minted service tokens; see `backend/server.py` and the admin token routes.
+- **Intra-fleet auth** — hub-reachable fleet routes validate `HUB_FLEET_TOKEN`;
+  see [`docs/runbooks/hub-credentials.md`](docs/runbooks/hub-credentials.md).
+
+`require_principal` **fails closed**: a request with no valid credential gets
+`401`. A local development bypass exists only when `DASHBOARD_LOOPBACK_AUTH=1`
+and the peer is loopback. Network isolation is a defense-in-depth layer on top
+of this stack, not a replacement for it.
 
 ## Features
 

--- a/tests/test_documentation_freshness.py
+++ b/tests/test_documentation_freshness.py
@@ -30,6 +30,7 @@ CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
 MIDDLEWARE_PATH = REPO_ROOT / "backend" / "middleware.py"
 CLAUDE_PATH = REPO_ROOT / "CLAUDE.md"
 CONTRIBUTING_PATH = REPO_ROOT / "CONTRIBUTING.md"
+README_PATH = REPO_ROOT / "README.md"
 
 # Phrases that must NOT appear in CLAUDE.md / CONTRIBUTING.md after the
 # Vite migration. Case-insensitive.
@@ -167,6 +168,36 @@ def test_contributing_md_does_not_claim_no_build_step_or_no_jsx() -> None:
             f"CONTRIBUTING.md contains forbidden phrase '{phrase}'. The "
             "frontend is a Vite + React + TypeScript SPA — update the docs."
         )
+
+
+def test_readme_security_section_describes_real_auth_stack() -> None:
+    """Issue #946: the README Security section must describe the actual identity
+    stack, not claim the dashboard has "no built-in authentication".
+
+    The contradiction was dangerous: operators reading "no built-in
+    authentication" would deploy assuming network isolation is the only control
+    and never configure OAuth/principals.
+    """
+    text = _read(README_PATH)
+    lower = text.lower()
+
+    # The false claim must be gone.
+    assert "no built-in authentication" not in lower, (
+        "README still claims 'no built-in authentication' — the dashboard ships "
+        "an identity/role/scope stack (backend/identity.py). Update the Security section (#946)."
+    )
+
+    # The Security section must reference the real auth modules / mechanisms so it
+    # cannot silently rot back to the old wording.
+    required_references = (
+        "backend/identity.py",
+        "require_principal",
+        "session_management",
+        "oauth",
+        "hub-credentials.md",
+    )
+    missing = [ref for ref in required_references if ref.lower() not in lower]
+    assert not missing, f"README Security section must reference the auth stack; missing {missing} (#946)."
 
 
 def test_frontend_actually_uses_vite_and_typescript() -> None:


### PR DESCRIPTION
## Summary

Closes #946. The README Security section claimed the dashboard "has no built-in authentication" — directly contradicting the shipped identity stack (`backend/identity.py` principals/roles/scopes, sessions with revocation, GitHub OAuth + org check, WebAuthn scaffolding, service tokens, fail-closed `require_principal`). Operators reading the old wording would deploy assuming network isolation is the only control and never configure OAuth/principals.

### Changes
- Rewrote the README Security section to describe the actual model and its configuration entry points (principals/scopes, sessions, OAuth, WebAuthn, service tokens, intra-fleet `HUB_FLEET_TOKEN`), linking `docs/runbooks/hub-credentials.md`. Notes that `require_principal` fails closed and that network isolation is defense-in-depth, not a replacement.
- Added a freshness test (`tests/test_documentation_freshness.py`) asserting the section references the auth modules and no longer contains the phrase "no built-in authentication", so it cannot silently rot again.

Docs + test only; no backend source change. Tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)