### PR TITLE
test(spa-fallback): unknown /api/* returns 401 not 404 under the auth perimeter (#924)

### DIFF
--- a/tests/test_spa_fallback.py
+++ b/tests/test_spa_fallback.py
@@ -12,7 +12,9 @@ falls back to OFFLINE_URL, not index.html.
 This module pins the contract that:
   - client routes (/t/queue, /settings/push) return 200 text/html SPA shell;
   - real API routes (/api/health) still return their JSON;
-  - unknown /api/* paths still 404 instead of being masked by the HTML shell.
+  - unknown /api/* paths are NOT masked by the HTML shell — they return a JSON
+    error (401 to an unauthenticated caller behind the structural auth perimeter
+    of #924; 404 once authenticated), never a 200 HTML page.
 
 Marked `unit` so the conftest network-block fixture is active: /api/health
 catches its (refused) GitHub call and returns a degraded JSON body, keeping the
@@ -84,9 +86,32 @@ def test_api_health_still_returns_json(client: TestClient) -> None:
 
 
 @pytest.mark.unit
-def test_unknown_api_path_still_404s(client: TestClient) -> None:
-    """An unknown /api/* path must 404 (excluded from the fallback), not be
-    masked by a 200 HTML shell."""
+def test_unknown_api_path_not_masked_by_spa_shell(client: TestClient) -> None:
+    """An unknown /api/* path must NOT be masked by a 200 HTML shell.
+
+    Behind the structural auth perimeter (#924) an unauthenticated caller gets a
+    JSON 401 (the perimeter refuses to leak which /api/* paths exist before the
+    request is even routed). The load-bearing contract — never a 200 HTML SPA
+    shell for an /api/* path — still holds.
+    """
     resp = client.get("/api/this-endpoint-does-not-exist")
-    assert resp.status_code == 404
+    assert resp.status_code == 401
     assert "text/html" not in resp.headers.get("content-type", "")
+
+
+@pytest.mark.unit
+def test_unknown_api_path_404s_when_authenticated(client: TestClient) -> None:
+    """Once past the perimeter (authenticated principal injected), an unknown
+    /api/* path resolves to a genuine 404 — not the SPA shell — proving the path
+    is truly unregistered rather than merely auth-blocked (#924)."""
+    from identity import Principal, require_principal
+
+    server.app.dependency_overrides[require_principal] = lambda: Principal(
+        id="test-admin", type="bot", name="Admin", roles=["admin"]
+    )
+    try:
+        resp = client.get("/api/this-endpoint-does-not-exist")
+        assert resp.status_code == 404
+        assert "text/html" not in resp.headers.get("content-type", "")
+    finally:
+        server.app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

**Fixes a red `main`.** The structural auth perimeter (#924, merged via #972) rejects unauthenticated `/api/*` requests with a JSON `401` *before* routing. As a result `tests/test_spa_fallback.py::test_unknown_api_path_still_404s` — which asserted an unknown `/api/*` path returns `404` — now fails (it gets `401`), breaking the required `tests (3.11)` check on every branch cut from current `main`.

This was missed when #972 landed because that PR predated awareness of this test's exact assertion.

### Fix
Update the test to the post-perimeter contract. The **load-bearing invariant is unchanged**: an `/api/*` path must never be masked by a `200` HTML SPA shell. What changed is only the status for an *unauthenticated* caller:
- `test_unknown_api_path_not_masked_by_spa_shell` — unauthenticated unknown `/api/*` → JSON `401` (perimeter refuses to leak path existence), never `200`/HTML.
- `test_unknown_api_path_404s_when_authenticated` (new) — with a principal injected, the same path resolves to a genuine `404`, proving it is truly unregistered rather than merely auth-blocked.

Test-only change; no backend source touched. All 5 spa-fallback tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)