### PR TITLE
fix(autoscaler): correctness + robustness cluster (#932, #935, #936, #937)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,34 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.99
+**Spec Version:** 2.5.101
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.101):** Autoscaler correctness/robustness cluster (issues
+  #932, #935, #936, #937). (#932) The autoscaler read leases from a repo-relative
+  `config/leases.yml` that nothing ever wrote, so lease protection was a permanent
+  no-op and actively-leased runners could be stopped; `_leased_runners`
+  (`backend/autoscaler_sampling.py`) now resolves the path through
+  `runner_lease._default_config_dir()` — the same `RUNNER_DASHBOARD_CONFIG_DIR`
+  store the `LeaseManager` writer uses — so reader and writer can never drift.
+  (#935) `_stop_unit`/`_start_unit` (`backend/autoscaler_systemd.py`) issued a
+  blocking `systemctl stop`; a legitimate >=120s drain starved the systemd
+  watchdog (WatchdogSec=120) and SIGABRTed the autoscaler mid-scale-down. Both now
+  use `--no-block` plus an explicit client-call timeout and re-read unit state the
+  next tick. (#936) `prune_expired` (`backend/runner_lease.py`) wrote a stale
+  in-memory snapshot via an unlocked `save_leases` on every reaper tick, clobbering
+  leases acquired by another process since the last load, and a crash mid-write
+  reset the file to `[]`; pruning now goes through the locked
+  `_atomic_read_modify_write` (re-read under exclusive lock) and all writes use
+  temp-file + `os.replace` for crash-safety. (#937) Five autoscaler defects fixed:
+  busy-query timeout no longer aborts the tick (fail-safe busy), exact lease-name
+  match (not substring), one malformed lease record is skipped not fatal, the
+  label-less default pool is exempt from start/stop label filters, and
+  `ACTION_COOLDOWN_SECONDS` is enforced on the stop side. Tests across
+  `tests/test_autoscaler_sampling.py`, `tests/test_runner_lease.py`,
+  `tests/api/test_lease_pruning.py`, `tests/test_autoscaler_systemd.py`,
+  `tests/test_autoscaler_busy.py`, and `tests/test_pool_autoscaler.py`.
 - **2026-06-12 (2.5.99):** RD↔MD integration contract cluster (issues #959, #961,
   #963). (#959) `MAXWELL_PORT` defaulted to 8322 — a port that appears nowhere in
   Maxwell_Daemon (which serves on 8080) and that collided with the

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.5
+4.9.7

--- a/backend/autoscaler_busy.py
+++ b/backend/autoscaler_busy.py
@@ -265,13 +265,23 @@ def _runner_is_busy(unit: str) -> bool:
         return True
 
     # ── Strategy 3: MainPID-based child scan ─────────────────────────────────
-    r = subprocess.run(
-        ["systemctl", "show", unit, "--property=MainPID", "--value"],
-        capture_output=True,
-        text=True,
-        timeout=_SYSTEMCTL_TIMEOUT_S,
-        check=False,
-    )
+    # Issue #937a: a slow/hung host can make this systemctl query raise
+    # TimeoutExpired. Previously that propagated up to the poll loop's broad
+    # except and aborted the entire scaling tick for *every* pool — on exactly
+    # the overloaded host where scaling matters most. Treat a failed/timed-out
+    # busy query as "busy" (fail safe: never stop a runner we cannot confirm is
+    # idle) and let the tick continue for the other pools.
+    try:
+        r = subprocess.run(
+            ["systemctl", "show", unit, "--property=MainPID", "--value"],
+            capture_output=True,
+            text=True,
+            timeout=_SYSTEMCTL_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("MainPID query failed for %s (%s) — treating as busy (fail safe)", unit, exc)
+        return True
     pid_str = (r.stdout or "").strip()
 
     main_pid: int | None = None

--- a/backend/autoscaler_sampling.py
+++ b/backend/autoscaler_sampling.py
@@ -3,7 +3,8 @@
 Provides:
   - _sample()                  — one-shot CPU / memory / load / disk measurement
   - _scheduled_desired_count() — integrate with the runner-scheduler binary
-  - _leased_runners()          — read active runner leases from config/leases.yml
+  - _leased_runners()          — read active runner leases from the shared
+                                 LeaseManager store (RUNNER_DASHBOARD_CONFIG_DIR)
 """
 
 from __future__ import annotations
@@ -55,27 +56,53 @@ def _psutil_dep() -> Any:
     return psutil
 
 
+def _leases_path() -> Path:
+    """Resolve the leases.yml path the LeaseManager writer actually uses.
+
+    Issue #932: the autoscaler previously read ``<repo>/config/leases.yml``
+    (repo-relative), but the only writer — ``runner_lease.LeaseManager`` —
+    persists to ``$RUNNER_DASHBOARD_CONFIG_DIR`` (default
+    ``~/.config/runner-dashboard``). Reader and writer must share one path
+    helper or lease protection is a permanent no-op. We delegate to
+    ``runner_lease._default_config_dir`` so the two can never drift again.
+    """
+    from runner_lease import _default_config_dir  # noqa: PLC0415
+
+    return _default_config_dir() / "leases.yml"
+
+
 def _leased_runners() -> set[str]:
-    """Read config/leases.yml and return a set of leased runner_ids."""
-    # Assuming config is relative to the dashboard root.
-    # The autoscaler might run from a different CWD, so we should resolve this.
-    path = Path(__file__).resolve().parent.parent / "config" / "leases.yml"
+    """Return the set of currently-leased runner_ids from the shared leases file.
+
+    Reads the same ``leases.yml`` the LeaseManager writes (issue #932). Each
+    record is validated independently: a single malformed entry is skipped and
+    logged, but the remaining valid leases are still honoured (issue #937c) —
+    one bad record must never disable protection for every leased runner.
+    """
+    path = _leases_path()
     if not path.exists():
         return set()
     try:
         with open(path) as f:
             data = yaml.safe_load(f)
-        if not data or "leases" not in data:
-            return set()
-        now = time.time()
-        return {
-            str(lease_rec["runner_id"])
-            for lease_rec in data["leases"]
-            if lease_rec.get("expires_at") is None or float(lease_rec["expires_at"]) > now
-        }
     except Exception as exc:
         log.warning("Failed to read leases: %s", exc)
         return set()
+    if not data or "leases" not in data:
+        return set()
+
+    now = time.time()
+    leased: set[str] = set()
+    for lease_rec in data["leases"]:
+        try:
+            runner_id = str(lease_rec["runner_id"])
+            expires_at = lease_rec.get("expires_at")
+            if expires_at is None or float(expires_at) > now:
+                leased.add(runner_id)
+        except (KeyError, TypeError, ValueError) as exc:
+            log.warning("Skipping malformed lease record %r: %s", lease_rec, exc)
+            continue
+    return leased
 
 
 def _scheduled_desired_count(default: int) -> int:

--- a/backend/autoscaler_systemd.py
+++ b/backend/autoscaler_systemd.py
@@ -199,17 +199,36 @@ def _stop_unit(unit: str, *, reason: str = "host overloaded") -> bool:
         return True
     if not _unit_has_safe_stop_contract(unit):
         return False
-    r = subprocess.run(
-        ["sudo", "-n", "systemctl", "stop", unit],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    success = r.returncode == 0
-    if not success:
-        log.warning("Failed to stop %s: %s", unit, r.stderr.strip()[:200])
-    else:
-        log.warning("Autoscaler STOPPED %s (%s)", unit, reason)
+    # Issue #935: stop with ``--no-block``. The #640/#679 drain contract lets a
+    # busy runner legally hold systemd's stop for up to TimeoutStopUSec (>=120s),
+    # but the autoscaler's systemd watchdog only beats at the top/end of each
+    # poll tick. A blocking ``systemctl stop`` that waits out a 120s drain
+    # starves the watchdog, and systemd SIGABRTs the autoscaler mid-scale-down —
+    # killing the service for correctly honouring the very stop contract it
+    # requires. ``--no-block`` enqueues the stop job and returns immediately; the
+    # drain proceeds in the background and the next poll tick re-reads unit state
+    # (active → inactive) to confirm completion. The explicit timeout guards the
+    # systemctl client call itself (job enqueue), never the drain.
+    try:
+        r = subprocess.run(
+            ["sudo", "-n", "systemctl", "stop", "--no-block", unit],
+            capture_output=True,
+            text=True,
+            timeout=_SYSTEMCTL_TIMEOUT_S,
+            check=False,
+        )
+        success = r.returncode == 0
+        if not success:
+            log.warning("Failed to stop %s: %s", unit, r.stderr.strip()[:200])
+        else:
+            log.warning("Autoscaler STOPPED %s (%s)", unit, reason)
+    except (OSError, subprocess.SubprocessError) as exc:
+        # The enqueue itself failed (e.g. systemctl client timeout). The unit
+        # may or may not have been signalled, so run cleanup on this path too —
+        # the #640 ~/.gitconfig.lock contract requires cleanup on EVERY stop
+        # attempt — and report failure.
+        log.warning("Failed to enqueue stop for %s: %s", unit, exc)
+        success = False
 
     # Recovery half of the stop contract — best-effort, never raises.
     try:
@@ -230,12 +249,21 @@ def _start_unit(unit: str) -> bool:
     if _dry_run_enabled():
         log.info("[dry-run] would start %s", unit)
         return True
-    r = subprocess.run(
-        ["sudo", "-n", "systemctl", "start", unit],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    # Issue #935: ``--no-block`` so a slow unit start cannot starve the watchdog,
+    # plus an explicit client-call timeout. Start is far quicker than a drained
+    # stop, but the watchdog-starvation reasoning is identical, and the next tick
+    # re-reads ActiveState to confirm the unit came up.
+    try:
+        r = subprocess.run(
+            ["sudo", "-n", "systemctl", "start", "--no-block", unit],
+            capture_output=True,
+            text=True,
+            timeout=_SYSTEMCTL_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("Failed to enqueue start for %s: %s", unit, exc)
+        return False
     if r.returncode != 0:
         log.warning("Failed to start %s: %s", unit, r.stderr.strip()[:200])
         return False

--- a/backend/runner_autoscaler.py
+++ b/backend/runner_autoscaler.py
@@ -180,6 +180,12 @@ __all__ = [
     "_send_watchdog",
     "_notify_systemd",
     "_sd_notify_socket",
+    "_is_start_allowed",
+    "_is_stop_allowed",
+    "_pool_passes_label_filter",
+    "_stop_in_cooldown",
+    "_record_stop_action",
+    "pool_last_stop_action",
 ]
 
 
@@ -420,16 +426,29 @@ def _get_pool_config(pool_name: str) -> dict:
         }
 
 
+def _pool_passes_label_filter(pool_labels: list[str], filter_labels: list[str]) -> bool:
+    """Return True if *pool_labels* satisfies *filter_labels*.
+
+    Issue #937d: the default pool has ``labels == []`` by design. When a label
+    filter is configured, an empty-label pool can never match any required
+    label, so the previous ``any(...)`` check silently froze the default pool
+    (no starts, no stops) the moment any filter was set. A label-less pool is
+    the generic/catch-all pool and must be *exempt* from label filtering rather
+    than permanently disabled.
+    """
+    if not filter_labels:
+        return True
+    if not pool_labels:
+        return True
+    return any(label in filter_labels for label in pool_labels)
+
+
 def _is_start_allowed(pool_name: str) -> bool:
     """Check if starting runners is allowed for the specified pool, considering labels/filters."""
     cfg = _get_pool_config(pool_name)
     if not cfg["start_enabled"]:
         return False
-    if FILTER_START_LABELS:
-        pool_labels = cfg.get("labels", [])
-        if not any(label in FILTER_START_LABELS for label in pool_labels):
-            return False
-    return True
+    return _pool_passes_label_filter(cfg.get("labels", []), FILTER_START_LABELS)
 
 
 def _is_stop_allowed(pool_name: str) -> bool:
@@ -437,11 +456,7 @@ def _is_stop_allowed(pool_name: str) -> bool:
     cfg = _get_pool_config(pool_name)
     if not cfg["stop_enabled"]:
         return False
-    if FILTER_STOP_LABELS:
-        pool_labels = cfg.get("labels", [])
-        if not any(label in FILTER_STOP_LABELS for label in pool_labels):
-            return False
-    return True
+    return _pool_passes_label_filter(cfg.get("labels", []), FILTER_STOP_LABELS)
 
 
 def _get_scheduled_pool_desired(pool_name: str, pool_units_count: int) -> int:
@@ -565,6 +580,37 @@ pool_last_overloaded: dict[str, float] = {
     "hdd": 0.0,
 }
 
+# Issue #937e: track the wall-clock time of the last STOP action per pool so
+# ACTION_COOLDOWN_SECONDS is actually enforced. Previously the setting was
+# documented, configured, and logged but never gated any decision, so a 45s
+# spike could trim a pool to min_online in well under a minute. Keys mirror the
+# pool names above; 0.0 means "no stop yet".
+pool_last_stop_action: dict[str, float] = {
+    "default": 0.0,
+    "nvme": 0.0,
+    "hdd": 0.0,
+}
+
+
+def _stop_in_cooldown(pool_name: str, now: float | None = None) -> bool:
+    """Return True if *pool_name* stopped a runner within ACTION_COOLDOWN_SECONDS.
+
+    Enforces per-pool spacing between destructive scale-downs (issue #937e).
+    A cooldown of 0 disables spacing entirely (opt-out).
+    """
+    if ACTION_COOLDOWN_SECONDS <= 0:
+        return False
+    last = pool_last_stop_action.get(pool_name, 0.0)
+    if last <= 0.0:
+        return False
+    current = time.time() if now is None else now
+    return (current - last) < ACTION_COOLDOWN_SECONDS
+
+
+def _record_stop_action(pool_name: str, now: float | None = None) -> None:
+    """Record that *pool_name* just performed a stop action (issue #937e)."""
+    pool_last_stop_action[pool_name] = time.time() if now is None else now
+
 
 def _run_poll_loop() -> None:
     """Infinite poll loop: sample resources, classify runners, scale up/down."""
@@ -627,7 +673,9 @@ def _run_poll_loop() -> None:
                 pool_active = [u for u in pool_units if _unit_is_active(u)]
                 pool_inactive = [u for u in pool_units if u not in pool_active]
                 pool_busy = {u for u in pool_active if _runner_is_busy(u)}
-                pool_idle_active = [u for u in pool_active if u not in pool_busy and not any(r in u for r in leased)]
+                pool_idle_active = [
+                    u for u in pool_active if u not in pool_busy and _runner_name_for_unit(u) not in leased
+                ]
 
                 hist = pool_samples[pool_name]
                 overloaded = False
@@ -733,7 +781,16 @@ def _run_poll_loop() -> None:
                             in_soft_recovery = True
 
                 if surplus and pool_idle_active:
-                    if _is_stop_allowed(pool_name):
+                    if not _is_stop_allowed(pool_name):
+                        log.debug("pool=%s stop action filtered/disabled", pool_name)
+                    elif _stop_in_cooldown(pool_name):
+                        log.info(
+                            "pool=%s surplus=%d but within action cooldown (%ds) — deferring stop",
+                            pool_name,
+                            surplus,
+                            ACTION_COOLDOWN_SECONDS,
+                        )
+                    else:
                         to_stop = pool_idle_active[: min(MAX_STEP, surplus)]
                         log.info(
                             "pool=%s surplus=%d, stopping %d idle active runners",
@@ -743,12 +800,20 @@ def _run_poll_loop() -> None:
                         )
                         for u in to_stop:
                             _stop_unit(u, reason="scheduled surplus")
-                    else:
-                        log.debug("pool=%s stop action filtered/disabled", pool_name)
+                        if to_stop:
+                            _record_stop_action(pool_name)
 
                 elif overloaded and len(pool_active) > pool_cfg["min_online"]:
                     room = len(pool_active) - pool_cfg["min_online"]
-                    if _is_stop_allowed(pool_name):
+                    if not _is_stop_allowed(pool_name):
+                        log.debug("pool=%s stop action filtered/disabled during overload", pool_name)
+                    elif _stop_in_cooldown(pool_name):
+                        log.info(
+                            "pool=%s overloaded but within action cooldown (%ds) — deferring stop",
+                            pool_name,
+                            ACTION_COOLDOWN_SECONDS,
+                        )
+                    else:
                         to_stop = pool_idle_active[: min(MAX_STEP, room)]
                         if not to_stop and pool_busy:
                             log.info(
@@ -765,8 +830,7 @@ def _run_poll_loop() -> None:
                             )
                             for u in to_stop:
                                 _stop_unit(u, reason="host overloaded")
-                    else:
-                        log.debug("pool=%s stop action filtered/disabled during overload", pool_name)
+                            _record_stop_action(pool_name)
 
                 elif recovered and pool_inactive and len(pool_active) < pool_desired:
                     if in_cooldown:

--- a/backend/runner_lease.py
+++ b/backend/runner_lease.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -101,22 +102,52 @@ class LeaseManager:
             self.leases = []
 
     def save_leases(self):
-        """Save leases with security validation (issue #355)."""
+        """Atomically persist the in-memory leases to ``leases.yml``.
+
+        Security validation (issue #355). Crash-safety (issue #936): writes via
+        a temp file + ``os.replace`` so a crash mid-dump can never leave partial
+        YAML — ``load_leases`` would otherwise silently reset a truncated file to
+        ``[]``, wiping every lease. Readers see either the old or the new
+        complete file, never a half-written one. Mirrors the pattern in
+        ``identity.IdentityStore.save_principals``.
+
+        Note: callers needing process-safe concurrency (the reaper, pruning)
+        must go through :meth:`_atomic_read_modify_write`, which holds the
+        exclusive lock across read+modify+write. ``save_leases`` only guarantees
+        a single write is atomic; it does not re-read under lock.
+        """
         try:
             self.config_dir.mkdir(parents=True, exist_ok=True)
             validate_config_path(self.leases_path.parent)
-            with open(self.leases_path, "w") as f:
-                yaml.dump({"leases": [lease.model_dump() for lease in self.leases]}, f)
+            payload = {"leases": [lease.model_dump() for lease in self.leases]}
+            fd, tmp_path = tempfile.mkstemp(
+                dir=self.leases_path.parent,
+                prefix=".tmp-leases-",
+                suffix=".yml",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    yaml.dump(payload, fh)
+                os.replace(tmp_path, self.leases_path)
+            except (OSError, yaml.YAMLError):
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_path)
+                raise
         except Exception as exc:
             log.error("Failed to save leases: %s", exc)
 
-    def _atomic_read_modify_write(self, mutate):
+    def _atomic_read_modify_write(self, mutate, on_pruned=None):
         """Perform a process-safe read-modify-write on leases.yml.
 
         mutate receives the current expiry-pruned list of LeaseRecord objects
         and must return the new list. The file is re-read inside the exclusive
         lock so writes from concurrent processes are incorporated before the
         mutation is applied (fixes issue #327).
+
+        ``on_pruned``, when supplied, is called with the number of expired
+        records dropped during the in-lock expiry sweep — used by
+        :meth:`prune_expired` to report an accurate removed count computed from
+        the freshly re-read file rather than a stale in-memory snapshot (#936).
         """
         self.config_dir.mkdir(parents=True, exist_ok=True)
         validate_config_path(self.leases_path.parent)
@@ -131,33 +162,73 @@ class LeaseManager:
                 records = []
 
             now = time.time()
+            pre_prune_count = len(records)
             records = [r for r in records if r.expires_at is None or r.expires_at > now]
+            if on_pruned is not None:
+                on_pruned(pre_prune_count - len(records))
 
             new_records = mutate(records)
 
-            fh.seek(0)
-            yaml.dump({"leases": [r.model_dump() for r in new_records]}, fh)
-            fh.truncate()
+            # Crash-safe persist (issue #936): write a temp file and atomically
+            # ``os.replace`` it over leases.yml. A crash mid-write leaves either
+            # the old or the new complete file, never partial YAML. The exclusive
+            # fcntl lock on the (locked) handle still serializes concurrent
+            # processes: every writer locks the same path before reading, so the
+            # replace cannot interleave with another process's read-modify cycle.
+            payload = {"leases": [r.model_dump() for r in new_records]}
+            fd, tmp_path = tempfile.mkstemp(
+                dir=self.leases_path.parent,
+                prefix=".tmp-leases-",
+                suffix=".yml",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as tmp_fh:
+                    yaml.dump(payload, tmp_fh)
+                # On platforms without fcntl (Windows dev/test) there is no real
+                # advisory lock and an open handle blocks os.replace over the
+                # target. Close the lock handle before replacing there. On POSIX
+                # we keep the handle open across the replace so the advisory lock
+                # is held for the entire read-modify-write window.
+                if fcntl is None:
+                    fh.close()
+                os.replace(tmp_path, self.leases_path)
+            except (OSError, yaml.YAMLError):
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_path)
+                raise
 
         self.leases = new_records
 
     def prune_expired(self) -> int:
-        """Drop all expired leases from the in-memory store.
+        """Drop all expired leases from the shared store under the file lock.
 
         Pre-condition: ``self.leases`` is a list.
         Post-condition: returns the count of leases that were removed
         (always ``>= 0``, never ``None``). The background lease reaper
         in ``server.py`` relies on this contract to emit accurate metrics
         and to log only when work was actually done.
+
+        Issue #936: pruning now goes through ``_atomic_read_modify_write`` so it
+        re-reads under the exclusive lock before writing. The previous
+        implementation pruned a stale in-memory snapshot and called the unlocked
+        ``save_leases``, clobbering leases that another process had acquired
+        between this manager's last load and the prune — silently losing
+        concurrent acquisitions on every reaper tick. ``_atomic_read_modify_write``
+        already drops expired records before invoking the mutator, so the mutator
+        is an identity function and the removed count is computed from the
+        before/after record counts inside the lock.
         """
         assert isinstance(self.leases, list), "leases must be a list"
-        now = time.time()
-        initial_count = len(self.leases)
-        self.leases = [lease for lease in self.leases if lease.expires_at is None or lease.expires_at > now]
-        removed = initial_count - len(self.leases)
+        removed_holder: list[int] = []
+
+        def _mutate(records: list[LeaseRecord]) -> list[LeaseRecord]:
+            # records is already expiry-pruned by _atomic_read_modify_write.
+            return records
+
+        before = len(self.leases)
+        self._atomic_read_modify_write(_mutate, on_pruned=lambda n: removed_holder.append(n))
+        removed = removed_holder[0] if removed_holder else max(0, before - len(self.leases))
         assert removed >= 0, "removed count must be non-negative"
-        if removed > 0:
-            self.save_leases()
         return removed
 
     def get_active_leases(self, principal_id: str | None = None) -> list[LeaseRecord]:

--- a/tests/api/test_lease_pruning.py
+++ b/tests/api/test_lease_pruning.py
@@ -1,9 +1,15 @@
-"""Tests for background lease reaper (issue #708)."""
+"""Tests for background lease reaper (issue #708).
+
+Pruning performs a locked read-modify-write that re-reads leases.yml from disk
+(issue #936), so each manager persists its leases before pruning and the
+allowed-roots security guard is bypassed for the throwaway tmp config dir.
+"""
 
 import sys
 import tempfile
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "backend"))
 
@@ -19,42 +25,53 @@ def make_lease(runner_id, expires_delta, principal_id="test"):
     )
 
 
+def _persist(mgr, records):
+    mgr.leases = list(records)
+    mgr.save_leases()
+
+
 def test_prune_expired_returns_count():
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir, patch("runner_lease.validate_config_path"):
         mgr = LeaseManager(config_dir=Path(tmpdir))
-        mgr.leases = [
-            make_lease("runner-1", -1),  # expired
-            make_lease("runner-2", 3600),  # active
-        ]
+        _persist(
+            mgr,
+            [
+                make_lease("runner-1", -1),  # expired
+                make_lease("runner-2", 3600),  # active
+            ],
+        )
         count = mgr.prune_expired()
         assert isinstance(count, int), "prune_expired must return int"
         assert count == 1
 
 
 def test_prune_expired_returns_zero_when_none_expired():
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir, patch("runner_lease.validate_config_path"):
         mgr = LeaseManager(config_dir=Path(tmpdir))
-        mgr.leases = [make_lease("runner-1", 3600)]
+        _persist(mgr, [make_lease("runner-1", 3600)])
         count = mgr.prune_expired()
         assert count == 0
 
 
 def test_prune_expired_empty_lease_list():
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir, patch("runner_lease.validate_config_path"):
         mgr = LeaseManager(config_dir=Path(tmpdir))
-        mgr.leases = []
+        _persist(mgr, [])
         count = mgr.prune_expired()
         assert count == 0
 
 
 def test_prune_expired_removes_expired_from_list():
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir, patch("runner_lease.validate_config_path"):
         mgr = LeaseManager(config_dir=Path(tmpdir))
-        mgr.leases = [
-            make_lease("runner-1", -100),  # expired
-            make_lease("runner-2", -50),  # expired
-            make_lease("runner-3", 3600),  # active
-        ]
+        _persist(
+            mgr,
+            [
+                make_lease("runner-1", -100),  # expired
+                make_lease("runner-2", -50),  # expired
+                make_lease("runner-3", 3600),  # active
+            ],
+        )
         count = mgr.prune_expired()
         assert count == 2
         assert len(mgr.leases) == 1
@@ -63,16 +80,19 @@ def test_prune_expired_removes_expired_from_list():
 
 def test_prune_expired_none_expires_at_not_pruned():
     """Leases with expires_at=None should never be pruned."""
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir, patch("runner_lease.validate_config_path"):
         mgr = LeaseManager(config_dir=Path(tmpdir))
-        mgr.leases = [
-            LeaseRecord(
-                principal_id="test",
-                runner_id="runner-permanent",
-                acquired_at=time.time(),
-                expires_at=None,
-            )
-        ]
+        _persist(
+            mgr,
+            [
+                LeaseRecord(
+                    principal_id="test",
+                    runner_id="runner-permanent",
+                    acquired_at=time.time(),
+                    expires_at=None,
+                )
+            ],
+        )
         count = mgr.prune_expired()
         assert count == 0
         assert len(mgr.leases) == 1

--- a/tests/test_autoscaler_busy.py
+++ b/tests/test_autoscaler_busy.py
@@ -98,6 +98,25 @@ def test_runner_is_busy_short_circuits_on_pickup_dir(
         assert busy._runner_is_busy(UNIT) is True
 
 
+def test_runner_is_busy_treats_mainpid_timeout_as_busy(
+    monkeypatch: pytest.MonkeyPatch,  # type: ignore[name-defined]
+) -> None:
+    """Issue #937a: a TimeoutExpired querying MainPID must NOT abort the tick.
+
+    The query is treated as 'busy' (fail safe — never stop a runner we cannot
+    confirm idle) and the exception is swallowed so the poll loop's broad except
+    is never reached and the other pools' scaling still runs.
+    """
+    # Force Strategies 1 and 2 to miss so control reaches the MainPID query.
+    monkeypatch.setattr(busy, "_runner_busy_via_pickup_dir_public", lambda _u: False)
+    monkeypatch.setattr(busy, "_runner_busy_via_lockfile", lambda _u: False)
+    import subprocess as _sp  # noqa: PLC0415
+
+    with patch("subprocess.run", side_effect=_sp.TimeoutExpired("systemctl", 5)):
+        # Must return True (busy) rather than propagating TimeoutExpired.
+        assert busy._runner_is_busy(UNIT) is True
+
+
 class _FakeProc:
     """Minimal psutil.Process stand-in exposing the .info dict process_iter sets."""
 

--- a/tests/test_autoscaler_sampling.py
+++ b/tests/test_autoscaler_sampling.py
@@ -119,14 +119,22 @@ def test_windows_host_snapshot_uses_absolute_powershell_fallback(monkeypatch: py
     ]
 
 
-def test_leased_runners_no_file() -> None:
+def test_leased_runners_no_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """_leased_runners returns empty set when leases.yml does not exist."""
-    with patch.object(Path, "exists", return_value=False):
-        assert samp._leased_runners() == set()
+    monkeypatch.setenv("RUNNER_DASHBOARD_CONFIG_DIR", str(tmp_path / "missing"))
+    assert samp._leased_runners() == set()
+
+
+def test_leases_path_matches_lease_manager_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #932: reader path must equal the LeaseManager writer path."""
+    import runner_lease as rl  # noqa: PLC0415
+
+    monkeypatch.setenv("RUNNER_DASHBOARD_CONFIG_DIR", str(tmp_path / "cfg"))
+    assert samp._leases_path() == rl._default_config_dir() / "leases.yml"
 
 
 def test_leased_runners_filters_expired_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    config_dir = tmp_path / "config"
+    config_dir = tmp_path / "cfg"
     config_dir.mkdir()
     (config_dir / "leases.yml").write_text(
         "leases:\n"
@@ -137,19 +145,40 @@ def test_leased_runners_filters_expired_entries(tmp_path: Path, monkeypatch: pyt
         "  - runner_id: sticky-runner\n",
         encoding="utf-8",
     )
-    monkeypatch.setattr(samp, "__file__", str(tmp_path / "backend" / "autoscaler_sampling.py"))
+    monkeypatch.setenv("RUNNER_DASHBOARD_CONFIG_DIR", str(config_dir))
     monkeypatch.setattr(samp.time, "time", lambda: 1000.0)
 
     assert samp._leased_runners() == {"live-runner", "sticky-runner"}
 
 
-def test_leased_runners_invalid_file_returns_empty_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    config_dir = tmp_path / "config"
+def test_leased_runners_unparseable_yaml_returns_empty_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = tmp_path / "cfg"
     config_dir.mkdir()
     (config_dir / "leases.yml").write_text("leases:\n  - runner_id: [\n", encoding="utf-8")
-    monkeypatch.setattr(samp, "__file__", str(tmp_path / "backend" / "autoscaler_sampling.py"))
+    monkeypatch.setenv("RUNNER_DASHBOARD_CONFIG_DIR", str(config_dir))
 
     assert samp._leased_runners() == set()
+
+
+def test_leased_runners_skips_one_bad_record_keeps_good(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #937c: one malformed record must not disable protection for all."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    (config_dir / "leases.yml").write_text(
+        "leases:\n"
+        "  - runner_id: good-1\n"
+        "    expires_at: 9999999999\n"
+        "  - expires_at: 9999999999\n"  # missing runner_id → bad record
+        "  - runner_id: good-2\n"
+        "    expires_at: not-a-number\n"  # unparseable expiry → bad record
+        "  - runner_id: good-3\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("RUNNER_DASHBOARD_CONFIG_DIR", str(config_dir))
+    monkeypatch.setattr(samp.time, "time", lambda: 1000.0)
+
+    # good-1 and good-3 survive; the two malformed records are skipped, not fatal.
+    assert samp._leased_runners() == {"good-1", "good-3"}
 
 
 def test_sample_uses_fallback_load_and_root_disk(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_autoscaler_systemd.py
+++ b/tests/test_autoscaler_systemd.py
@@ -184,3 +184,58 @@ class TestStartUnit:
     def test_failure(self) -> None:
         with patch("subprocess.run", return_value=_cp(returncode=1)):
             assert sd._start_unit("actions.runner.org.r.service") is False
+
+    def test_start_uses_no_block_and_timeout(self) -> None:
+        """Issue #935: start must not block the watchdog — --no-block + timeout."""
+        with patch("subprocess.run", return_value=_cp(returncode=0)) as mock_run:
+            sd._start_unit("actions.runner.org.r.service")
+        args, kwargs = mock_run.call_args
+        assert "--no-block" in args[0]
+        assert kwargs.get("timeout") == sd._SYSTEMCTL_TIMEOUT_S
+
+    def test_start_timeout_returns_false(self) -> None:
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("systemctl", 5)):
+            assert sd._start_unit("actions.runner.org.r.service") is False
+
+
+class TestStopStartWatchdogContract:
+    """Issue #935: neither stop nor start may block the systemd watchdog.
+
+    Every systemctl invocation in the module must carry either ``--no-block`` or
+    an explicit ``timeout=``; a blocking stop that waits out a >=120s drain
+    starves WatchdogSec=120 and systemd SIGABRTs the autoscaler mid-scale-down.
+    """
+
+    def test_stop_uses_no_block_and_timeout(self) -> None:
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    _cp("KillMode=mixed\nTimeoutStopUSec=2min\n"),
+                    _cp(returncode=0),
+                ],
+            ) as mock_run,
+            patch("runner_state_cleanup.cleanup_runner_state"),
+        ):
+            sd._stop_unit("actions.runner.org.r.service")
+        # The second call is the actual `systemctl stop`.
+        stop_call = mock_run.call_args_list[1]
+        argv = stop_call.args[0]
+        assert "stop" in argv
+        assert "--no-block" in argv
+        assert stop_call.kwargs.get("timeout") == sd._SYSTEMCTL_TIMEOUT_S
+
+    def test_stop_timeout_returns_false_without_crashing(self) -> None:
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    _cp("KillMode=mixed\nTimeoutStopUSec=2min\n"),
+                    subprocess.TimeoutExpired("systemctl", 5),
+                ],
+            ),
+            patch("runner_state_cleanup.cleanup_runner_state") as mock_clean,
+        ):
+            assert sd._stop_unit("actions.runner.org.r.service") is False
+            # Cleanup still runs even when the stop enqueue itself failed.
+            mock_clean.assert_called_once()

--- a/tests/test_pool_autoscaler.py
+++ b/tests/test_pool_autoscaler.py
@@ -183,3 +183,74 @@ def test_cooldown_and_soft_recovery_logic(monkeypatch: pytest.MonkeyPatch) -> No
     with patch("time.time", return_value=overload_time + 15):
         elapsed = time.time() - ra.pool_last_overloaded["nvme"]
         assert 10 <= elapsed < 20  # in soft recovery
+
+
+# ---------------------------------------------------------------------------
+# Issue #937d: empty-label (default) pool must be EXEMPT from label filtering,
+# not silently frozen, when a start/stop label filter is configured.
+# ---------------------------------------------------------------------------
+
+
+def test_default_pool_exempt_from_start_label_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A label filter set for nvme/hdd must not freeze the label-less default pool."""
+    monkeypatch.setattr(ra, "FILTER_START_LABELS", ["nvme"])
+    # default pool has labels == [] (see _get_pool_config); it is the catch-all.
+    assert ra._is_start_allowed("default") is True
+    # A labelled pool that does not match the filter is still excluded.
+    monkeypatch.setattr(ra, "NVME_LABELS", ["nvme"])
+    monkeypatch.setattr(ra, "HDD_LABELS", ["hdd"])
+    assert ra._is_start_allowed("nvme") is True
+    assert ra._is_start_allowed("hdd") is False
+
+
+def test_default_pool_exempt_from_stop_label_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ra, "FILTER_STOP_LABELS", ["nvme"])
+    assert ra._is_stop_allowed("default") is True
+
+
+def test_pool_passes_label_filter_helper() -> None:
+    assert ra._pool_passes_label_filter([], []) is True  # no filter
+    assert ra._pool_passes_label_filter([], ["x"]) is True  # empty pool exempt
+    assert ra._pool_passes_label_filter(["x"], ["x"]) is True  # match
+    assert ra._pool_passes_label_filter(["y"], ["x"]) is False  # no match
+
+
+# ---------------------------------------------------------------------------
+# Issue #937e: ACTION_COOLDOWN_SECONDS must actually space out stop actions.
+# ---------------------------------------------------------------------------
+
+
+def test_stop_in_cooldown_defers_second_stop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ra, "ACTION_COOLDOWN_SECONDS", 120)
+    ra.pool_last_stop_action["default"] = 0.0
+    # No prior stop -> not in cooldown.
+    assert ra._stop_in_cooldown("default", now=1000.0) is False
+    # Record a stop, then a second decision 45s later is within cooldown.
+    ra._record_stop_action("default", now=1000.0)
+    assert ra._stop_in_cooldown("default", now=1045.0) is True
+    # After the cooldown window elapses, stops are allowed again.
+    assert ra._stop_in_cooldown("default", now=1121.0) is False
+
+
+def test_stop_cooldown_disabled_when_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ra, "ACTION_COOLDOWN_SECONDS", 0)
+    ra._record_stop_action("nvme", now=1000.0)
+    assert ra._stop_in_cooldown("nvme", now=1001.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #937b: lease protection must be an EXACT runner-name match, not a
+# substring (a lease on runner-1 must not shield runner-10..19).
+# ---------------------------------------------------------------------------
+
+
+def test_lease_protection_exact_match_not_substring() -> None:
+    """A lease on 'runner-1' must protect exactly that runner, not 'runner-10'."""
+    leased = {"runner-1"}
+    unit_1 = "actions.runner.org.runner-1.service"
+    unit_10 = "actions.runner.org.runner-10.service"
+    # Exact-name comparison: only runner-1 is shielded.
+    assert (ra._runner_name_for_unit(unit_1) in leased) is True
+    assert (ra._runner_name_for_unit(unit_10) in leased) is False
+    # The old substring test (`'runner-1' in unit_10`) would have wrongly shielded it.
+    assert ("runner-1" in unit_10) is True  # demonstrates the old bug

--- a/tests/test_runner_lease.py
+++ b/tests/test_runner_lease.py
@@ -31,6 +31,23 @@ def _make_manager(tmp_path: Path) -> rl.LeaseManager:
     return mgr
 
 
+@pytest.fixture
+def _unguard_config_path():
+    """Disable the allowed-roots security check so leases can persist under tmp_path.
+
+    prune_expired now performs a locked read-modify-write (issue #936) that
+    re-reads leases.yml from disk; tests exercising it must let the manager
+    actually write to, and load from, the tmp config dir. load_leases routes
+    through ``security.safe_yaml_load`` (which validates via the ``security``
+    module reference), so both references are patched.
+    """
+    with (
+        patch("runner_lease.validate_config_path"),
+        patch("security.validate_config_path", side_effect=lambda p, *a, **k: p),
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # LeaseRecord
 # ---------------------------------------------------------------------------
@@ -96,12 +113,11 @@ def test_acquire_lease_runner_already_leased(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_release_lease_removes_entry(tmp_path: Path) -> None:
+def test_release_lease_removes_entry(tmp_path: Path, _unguard_config_path) -> None:
     mgr = _make_manager(tmp_path)
     principal = _make_principal()
-    with patch("runner_lease.validate_config_path"), patch.object(mgr, "save_leases"):
-        mgr.acquire_lease(principal, "runner-1")
-        mgr.release_lease("runner-1", "p1")
+    mgr.acquire_lease(principal, "runner-1")
+    mgr.release_lease("runner-1", "p1")
     assert mgr.get_active_leases("p1") == []
 
 
@@ -110,19 +126,26 @@ def test_release_lease_removes_entry(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_prune_expired_removes_old_leases(tmp_path: Path) -> None:
+def _persist(mgr: rl.LeaseManager, records: list[rl.LeaseRecord]) -> None:
+    """Write *records* to the manager's leases.yml so a locked re-read sees them."""
+    mgr.leases = list(records)
+    mgr.save_leases()
+
+
+def test_prune_expired_removes_old_leases(tmp_path: Path, _unguard_config_path) -> None:
     mgr = _make_manager(tmp_path)
-    # Insert an expired lease directly
-    mgr.leases.append(
-        rl.LeaseRecord(
-            principal_id="p1",
-            runner_id="old-runner",
-            acquired_at=time.time() - 7200,
-            expires_at=time.time() - 3600,  # expired 1h ago
-        )
+    _persist(
+        mgr,
+        [
+            rl.LeaseRecord(
+                principal_id="p1",
+                runner_id="old-runner",
+                acquired_at=time.time() - 7200,
+                expires_at=time.time() - 3600,  # expired 1h ago
+            )
+        ],
     )
-    with patch.object(mgr, "save_leases"):
-        mgr.prune_expired()
+    mgr.prune_expired()
     assert not any(r.runner_id == "old-runner" for r in mgr.leases)
 
 
@@ -131,21 +154,21 @@ def test_prune_expired_removes_old_leases(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_prune_expired_returns_count_of_removed_leases(tmp_path: Path) -> None:
+def test_prune_expired_returns_count_of_removed_leases(tmp_path: Path, _unguard_config_path) -> None:
     """A2: prune_expired must return the number of removed entries so the
     background reaper can emit accurate metrics and log lines."""
     mgr = _make_manager(tmp_path)
     now = time.time()
-    mgr.leases.extend(
+    _persist(
+        mgr,
         [
             rl.LeaseRecord(principal_id="p1", runner_id="r-old-1", acquired_at=now - 7200, expires_at=now - 3600),
             rl.LeaseRecord(principal_id="p1", runner_id="r-old-2", acquired_at=now - 7200, expires_at=now - 100),
             rl.LeaseRecord(principal_id="p2", runner_id="r-fresh", acquired_at=now, expires_at=now + 3600),
             rl.LeaseRecord(principal_id="p3", runner_id="r-perm", acquired_at=now, expires_at=None),
-        ]
+        ],
     )
-    with patch.object(mgr, "save_leases"):
-        removed = mgr.prune_expired()
+    removed = mgr.prune_expired()
     # Post-condition: returns an int matching the number actually pruned.
     assert isinstance(removed, int)
     assert removed == 2
@@ -153,20 +176,44 @@ def test_prune_expired_returns_count_of_removed_leases(tmp_path: Path) -> None:
     assert {r.runner_id for r in mgr.leases} == {"r-fresh", "r-perm"}
 
 
-def test_prune_expired_returns_zero_when_nothing_to_prune(tmp_path: Path) -> None:
+def test_prune_expired_returns_zero_when_nothing_to_prune(tmp_path: Path, _unguard_config_path) -> None:
     """A2: when no leases are expired, the reaper must see 0 — never None."""
     mgr = _make_manager(tmp_path)
     now = time.time()
-    mgr.leases.append(rl.LeaseRecord(principal_id="p1", runner_id="r-fresh", acquired_at=now, expires_at=now + 3600))
-    with patch.object(mgr, "save_leases"):
-        removed = mgr.prune_expired()
+    _persist(mgr, [rl.LeaseRecord(principal_id="p1", runner_id="r-fresh", acquired_at=now, expires_at=now + 3600)])
+    removed = mgr.prune_expired()
     assert removed == 0
     assert len(mgr.leases) == 1
 
 
-def test_prune_expired_returns_zero_on_empty_store(tmp_path: Path) -> None:
+def test_prune_expired_returns_zero_on_empty_store(tmp_path: Path, _unguard_config_path) -> None:
     """A2: empty lease store is a valid steady-state for the reaper."""
     mgr = _make_manager(tmp_path)
-    with patch.object(mgr, "save_leases"):
-        removed = mgr.prune_expired()
+    removed = mgr.prune_expired()
     assert removed == 0
+
+
+def test_prune_does_not_clobber_concurrent_acquisition(tmp_path: Path, _unguard_config_path) -> None:
+    """Issue #936: a lease written between this manager's load and its prune
+    must survive the prune (no unlocked stale-snapshot clobber)."""
+    now = time.time()
+    writer = _make_manager(tmp_path)
+    _persist(writer, [rl.LeaseRecord(principal_id="p1", runner_id="r-old", acquired_at=now - 7200, expires_at=now - 1)])
+
+    # Manager A loads the single (expired) lease.
+    mgr_a = _make_manager(tmp_path)
+    assert {r.runner_id for r in mgr_a.leases} == {"r-old"}
+
+    # Process B acquires a fresh lease *after* A loaded its snapshot.
+    mgr_b = _make_manager(tmp_path)
+    mgr_b.leases.append(rl.LeaseRecord(principal_id="p2", runner_id="r-new", acquired_at=now, expires_at=now + 3600))
+    mgr_b.save_leases()
+
+    # A prunes: it must re-read under lock, drop only the expired r-old, and
+    # preserve B's r-new rather than overwriting it from A's stale snapshot.
+    removed = mgr_a.prune_expired()
+    assert removed == 1
+    assert {r.runner_id for r in mgr_a.leases} == {"r-new"}
+    # And the on-disk file agrees.
+    reloaded = _make_manager(tmp_path)
+    assert {r.runner_id for r in reloaded.leases} == {"r-new"}


### PR DESCRIPTION
Autoscaler correctness + robustness cluster from the 2026-06-12 adversarial audit.

Closes #932
Closes #935
Closes #936
Closes #937

## #932 — lease protection was a permanent no-op
`_leased_runners` (`backend/autoscaler_sampling.py`) read a repo-relative `config/leases.yml` that **nothing ever wrote** — the `LeaseManager` writer persists to `$RUNNER_DASHBOARD_CONFIG_DIR` (`~/.config/runner-dashboard`). The autoscaler therefore always saw zero leases and could stop actively-leased runners. Now resolves the path through `runner_lease._default_config_dir()` so reader and writer share one location and cannot drift.

## #935 — blocking systemctl stop starves the watchdog
`_stop_unit`/`_start_unit` (`backend/autoscaler_systemd.py`) used a blocking `systemctl stop`. A legitimate >=120s drain (the #640/#679 stop contract) starved the systemd watchdog (WatchdogSec=120) and SIGABRTed the autoscaler mid-scale-down. Both now use `--no-block` + an explicit client-call timeout; the next poll tick re-reads unit state to confirm completion.

## #936 — leases.yml clobbered by unlocked stale-snapshot writer
`prune_expired` (`backend/runner_lease.py`) wrote a stale in-memory snapshot via the unlocked `save_leases` on every reaper tick, erasing leases acquired by another process since the last load; a crash mid-write reset the file to `[]`. Pruning now goes through the locked `_atomic_read_modify_write` (re-read under exclusive lock), and all writes use temp-file + `os.replace` for crash-safety.

## #937 — five autoscaler robustness defects
- **(a)** A `TimeoutExpired` on the MainPID busy-query no longer aborts the whole tick — treated as busy (fail safe).
- **(b)** Lease protection uses an exact `_runner_name_for_unit(u) in leased` match instead of a substring (a lease on `runner-1` no longer shields `runner-10`).
- **(c)** One malformed lease record is skipped + logged instead of disabling protection for all.
- **(d)** The label-less default pool is exempt from `AUTOSCALER_FILTER_START_LABELS`/`FILTER_STOP_LABELS` rather than silently frozen.
- **(e)** `ACTION_COOLDOWN_SECONDS` is enforced on the stop side (per-pool spacing) instead of documented-but-ignored.

## Tests
New + updated tests across `test_autoscaler_sampling.py`, `test_runner_lease.py`, `test_lease_pruning.py`, `test_autoscaler_systemd.py`, `test_autoscaler_busy.py`, `test_pool_autoscaler.py`. Full suite: **2738 passed, 18 skipped, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)