### PR TITLE
refactor(server): remove god-module duplicate twins (#941)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,8 @@ from `frontend/src/` and served as static assets by the backend.
 ```
 runner-dashboard/
 ├── backend/            FastAPI server (Python 3.11+)
-│   ├── server.py           Main application (~6800 lines, all /api/* routes)
+│   ├── server.py           App wiring + remaining /api/* routes (~2.3k lines; most routes live in routers/)
+│   ├── routers/            Extracted FastAPI routers (fleet, queue, maxwell, diagnostics, …)
 │   ├── queue_cleanup.py        Stale-queue detection and bulk cancellation
 │   │                           (async helpers for /api/queue/stale and /api/queue/purge-stale)
 │   ├── agent_remediation.py    AI agent dispatch and remediation logic
@@ -118,8 +119,8 @@ runner-dashboard/
 │   ├── autoscaler_config.py    Autoscaler env helpers and threshold constants
 │   ├── autoscaler_systemd.py   Autoscaler systemd unit enumeration and control
 │   ├── autoscaler_busy.py      Autoscaler 4-strategy busy detection (issue #651)
-│   ├── autoscaler_sampling.py  Autoscaler resource sampling and scheduler
-│   └── requirements.txt        Python dependencies
+│   └── autoscaler_sampling.py  Autoscaler resource sampling and scheduler
+│                               (Python deps live in repo-root requirements.txt, not backend/)
 ├── frontend/           Vite-built React + TypeScript SPA
 │   ├── index.html          Vite entry HTML (~30 lines, mounts /src/main.tsx)
 │   ├── src/                TypeScript + TSX source tree
@@ -172,10 +173,10 @@ runner-dashboard/
 # Stop
 ./stop-dashboard.sh
 
-# Manual start
-cd backend
+# Manual start (requirements.txt lives at the repo root, not in backend/)
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
+cd backend
 python server.py
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,23 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.101
+**Spec Version:** 2.5.104
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.104):** server.py god-module duplicate sweep (architecture,
+  issue #941). Removed two body-identical twins from the ~2.3k-line wiring
+  module: the `POST /api/launchers/generate` route handler (a shadowed dead copy
+  of `routers/diagnostics.py`'s — FastAPI served the router's, never server.py's)
+  and the unused `_normalize_repository_input` helper (a copy of the ones in
+  `routers/assistant.py`/`routers/remediation.py` that server.py never called).
+  Extended `tests/test_no_duplicate_top_level_functions.py` from legacy/App.tsx
+  to all of `backend/**/*.py`: a new guard fails if server.py defines any function
+  body-identical to another backend module, plus a backend-wide "no new
+  body-identical duplicate" ratchet (pre-existing legitimate idioms allow-listed).
+  Pruned the now-resolved launchers entry from the #941 route-uniqueness allowlist
+  and corrected the CLAUDE.md architecture block (server.py size ~2.3k not ~6800;
+  requirements.txt lives at the repo root, not `backend/`).
 - **2026-06-12 (2.5.101):** Autoscaler correctness/robustness cluster (issues
   #932, #935, #936, #937). (#932) The autoscaler read leases from a repo-relative
   `config/leases.yml` that nothing ever wrote, so lease protection was a permanent

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.7
+4.9.10

--- a/backend/server.py
+++ b/backend/server.py
@@ -161,8 +161,6 @@ from runners.service_control import (  # noqa: E402
 from security import (  # noqa: E402
     safe_subprocess_env,  # noqa: E402
     validate_fleet_node_url,  # noqa: E402
-    validate_owner_repo_format,  # noqa: E402
-    validate_repo_slug,  # noqa: E402
 )
 from system_utils import get_system_metrics_snapshot  # noqa: E402
 from workflows.run_enrichment import (  # noqa: E402
@@ -1080,24 +1078,9 @@ async def _github_search_total(query: str) -> int:
 # workflows/run_enrichment.py (#719)
 
 
-def _normalize_repository_input(value: str) -> tuple[str, str]:
-    """Return (repo_name, full_name) for dashboard remediation inputs (issue #326).
-
-    Validates against a strict regex before any owner comparison or subprocess
-    interpolation to prevent SSRF via malformed owner/repo slugs.
-    """
-    text = str(value).strip()
-    if "/" in text:
-        # Validate full owner/repo format before extracting parts (issue #326)
-        validate_owner_repo_format(text)
-        owner, _, repo_name = text.partition("/")
-        if owner.lower() != ORG.lower():
-            raise HTTPException(status_code=422, detail=f"repository owner must be {ORG}")
-        repo_name = validate_repo_slug(repo_name)
-        return repo_name, f"{ORG}/{repo_name}"
-    repo_name = validate_repo_slug(text)
-    return repo_name, f"{ORG}/{repo_name}"
-
+# _normalize_repository_input was an unused body-identical twin of the copies in
+# routers/assistant.py and routers/remediation.py (the modules that actually call
+# it). server.py never referenced its own copy, so it was removed for issue #941.
 
 # _machine_name_from_runner_name, _placement_from_jobs, _enrich_run_with_job_placement
 # extracted to workflows/run_enrichment.py (#719)
@@ -2343,46 +2326,12 @@ async def help_chat(
 # Restart-service route extracted to routers/diagnostics.py (issue #360).
 
 
-@app.post("/api/launchers/generate")
-async def generate_launchers(
-    request: Request,
-    principal: Principal = Depends(require_scope("system.control")),  # noqa: B008
-) -> dict:
-    """Generate Windows PowerShell launcher scripts on the Desktop."""
-    output_dir = Path.home() / "Desktop" / "RunnerDashboard"
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    launchers_created: list[str] = []
-
-    script = output_dir / "Open-Dashboard.ps1"
-    script.write_text('Start-Process "http://localhost:8321"\n', encoding="utf-8")
-    launchers_created.append(str(script))
-
-    keepalive = output_dir / "Start-WSL-Keepalive.ps1"
-    keepalive.write_text(
-        'Start-ScheduledTask -TaskName "WSL-Dashboard-Keepalive" -ErrorAction SilentlyContinue\n'
-        'Write-Host "Keepalive task started"\n',
-        encoding="utf-8",
-    )
-    launchers_created.append(str(keepalive))
-
-    restart = output_dir / "Restart-Dashboard-Service.ps1"
-    restart.write_text(
-        'wsl -d Ubuntu -e bash -lc "sudo -n systemctl restart runner-dashboard.service && echo Service restarted"\n',
-        encoding="utf-8",
-    )
-    launchers_created.append(str(restart))
-
-    diag = output_dir / "Open-Diagnostics.ps1"
-    diag.write_text('Start-Process "http://localhost:8321/#diagnostics"\n', encoding="utf-8")
-    launchers_created.append(str(diag))
-
-    log.info("Generated %d launcher scripts in %s", len(launchers_created), output_dir)
-    return {
-        "output_dir": str(output_dir),
-        "launchers": launchers_created,
-        "message": f"Created {len(launchers_created)} launcher scripts in {output_dir}",
-    }
+# POST /api/launchers/generate is registered by routers/diagnostics.py
+# (issue #360). The previously-inline copy here was a body-identical dead twin —
+# shadowed by the router include above and never reached at runtime — and was
+# removed for issue #941 (server.py god-module duplicate sweep). The duplicate
+# guard in tests/test_no_duplicate_top_level_functions.py keeps it from coming
+# back.
 
 
 # ─── Hosted-Runner Billing Audit ─────────────────────────────────────────────

--- a/tests/api/test_route_uniqueness.py
+++ b/tests/api/test_route_uniqueness.py
@@ -55,7 +55,9 @@ def _method_path_pairs() -> list[tuple[str, str]]:
 _KNOWN_DUPLICATES_PENDING_941: set[tuple[str, str]] = {
     ("GET", "/api/runner-routing-audit"),
     ("POST", "/api/runner-routing-audit/refresh"),
-    ("POST", "/api/launchers/generate"),
+    # ("POST", "/api/launchers/generate") removed in #941 — the body-identical
+    # server.py twin of routers/diagnostics.py's handler was deleted; the route
+    # is now registered exactly once.
 }
 
 

--- a/tests/test_no_duplicate_top_level_functions.py
+++ b/tests/test_no_duplicate_top_level_functions.py
@@ -1,12 +1,107 @@
-"""Verify that legacy/App.tsx has no duplicate top-level function declarations.
+"""Verify there are no duplicate top-level function declarations.
 
-This catches commented-out dead code and copy-paste drift.
+Two guards:
+
+1. ``legacy/App.tsx`` has no duplicate top-level ``function <Name>``.
+2. ``backend/**/*.py`` has no *body-identical* twin of a top-level function
+   defined in another module — the copy-paste-drift pattern called out in
+   issue #941. Same-named twins drift independently: a fix lands in one copy and
+   not the runtime one (the proxy_to_hub credential leak was exactly this). The
+   ``server.py`` wiring module is held to a stricter rule: it must contain no
+   function body-identical to any other backend module (it is a wiring layer,
+   not a home for logic).
 """
 
 from __future__ import annotations
 
+import ast
+import hashlib
 import re
 from pathlib import Path
+
+_BACKEND = Path(__file__).parent.parent / "backend"
+
+# Pre-existing legitimate cross-module body-identical pairs that do NOT involve
+# server.py. These are small shared idioms (DB connectors, YAML lock helpers,
+# DI shims) that have their own consolidation tickets; allow-listing them keeps
+# this guard focused on the server.py god-module sweep (#941) and on *new*
+# drift, without forcing an unrelated refactor in the same change.
+_ALLOWLISTED_BODY_DUP_NAMES = frozenset(
+    {
+        "_age_hours",
+        "_default_config_dir",
+        "_ensure_dict",
+        "_locked_yaml_file",
+        "_normalize_token",
+        "_psutil_dep",
+        "_required_string",
+        "_run_gh",
+        "detect_sharing_violations",
+        "get_gpu_info",
+        "get_runner_routing_audit",
+    }
+)
+
+
+def _function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """Return a structural hash of a function body, ignoring its docstring."""
+    body = list(node.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(getattr(body[0], "value", None), ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    dumped = ast.dump(ast.Module(body=body, type_ignores=[]), annotate_fields=False)
+    return hashlib.sha256(dumped.encode()).hexdigest()[:16]
+
+
+def _collect_top_level_functions() -> dict[tuple[str, str], set[str]]:
+    """Map (name, body-hash) → set of backend modules defining it."""
+    index: dict[tuple[str, str], set[str]] = {}
+    for path in _BACKEND.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - parse-failure is its own bug
+            continue
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                key = (node.name, _function_signature(node))
+                index.setdefault(key, set()).add(path.as_posix())
+    return index
+
+
+def test_server_py_has_no_body_identical_twin() -> None:
+    """server.py must not define a function body-identical to one elsewhere (#941).
+
+    server.py is the FastAPI wiring module; logic lives in routers/ and helper
+    modules. A body-identical twin here is dead, shadowed, or drift-prone code.
+    """
+    index = _collect_top_level_functions()
+    offenders: list[str] = []
+    for (name, _hash), modules in index.items():
+        server_copies = {m for m in modules if m.endswith("backend/server.py")}
+        other_copies = modules - server_copies
+        if server_copies and other_copies:
+            offenders.append(f"{name}: server.py duplicates {sorted(other_copies)}")
+    assert not offenders, "server.py contains body-identical twins of helpers:\n" + "\n".join(sorted(offenders))
+
+
+def test_no_new_body_identical_backend_duplicates() -> None:
+    """No *new* body-identical cross-module backend duplicate may be introduced (#941).
+
+    Existing legitimate idioms are allow-listed; anything else is drift.
+    """
+    index = _collect_top_level_functions()
+    offenders: list[str] = []
+    for (name, _hash), modules in index.items():
+        if len(modules) > 1 and name not in _ALLOWLISTED_BODY_DUP_NAMES:
+            offenders.append(f"{name}: {sorted(modules)}")
+    assert not offenders, (
+        "New body-identical cross-module duplicates (extract to a shared module, "
+        "or add to the allowlist with a tracking issue):\n" + "\n".join(sorted(offenders))
+    )
 
 
 def test_no_duplicate_top_level_functions_in_legacy() -> None:

--- a/tests/test_owner_repo_validation.py
+++ b/tests/test_owner_repo_validation.py
@@ -78,9 +78,12 @@ def test_validate_owner_repo_rejects_extra_path() -> None:
 
 
 def test_normalizer_source_code_calls_validate_owner_repo_format() -> None:
-    """Verify that all three _normalize_repository_input bodies call validate_owner_repo_format."""
+    """Verify each _normalize_repository_input body calls validate_owner_repo_format.
+
+    server.py's unused body-identical copy was removed in #941; the function now
+    lives only in the two router modules that actually call it.
+    """
     source_paths = [
-        _BACKEND / "server.py",
         _BACKEND / "routers" / "assistant.py",
         _BACKEND / "routers" / "remediation.py",
     ]

--- a/tests/test_repo_slug_validation.py
+++ b/tests/test_repo_slug_validation.py
@@ -24,7 +24,8 @@ def test_validate_repo_slug_rejects_path_and_query_injection(repo: str) -> None:
 @pytest.mark.parametrize(
     "normalizer",
     [
-        server._normalize_repository_input,
+        # server._normalize_repository_input was removed in #941 (unused twin);
+        # the helper now lives only in the two router modules that call it.
         assistant._normalize_repository_input,
         remediation._normalize_repository_input,
     ],


### PR DESCRIPTION
server.py god-module duplicate sweep from the 2026-06-12 adversarial audit.

Closes #941

## What
server.py is the FastAPI wiring layer; logic belongs in `routers/` and helper modules. Two **body-identical twins** lived in the ~2.3k-line module and were removed:

- **`POST /api/launchers/generate`** — a shadowed dead copy of the handler in `routers/diagnostics.py`. The diagnostics router is `include_router`-ed (line ~690) before the inline `@app.post` executes (line ~2347), so FastAPI served the router's copy and server.py's was unreachable. Verified via `test_route_uniqueness.py`.
- **`_normalize_repository_input`** — an unused copy of the helpers in `routers/assistant.py`/`routers/remediation.py`. server.py never referenced its own copy. Removed along with the now-unused `validate_owner_repo_format`/`validate_repo_slug` imports.

## Guard against regression
Extended `tests/test_no_duplicate_top_level_functions.py` from `legacy/App.tsx` to all of `backend/**/*.py`:
- `test_server_py_has_no_body_identical_twin` — fails if server.py defines any function body-identical to another backend module.
- `test_no_new_body_identical_backend_duplicates` — a backend-wide ratchet failing on any **new** body-identical cross-module duplicate (pre-existing legitimate idioms — DB connectors, YAML lock helpers, DI shims — are allow-listed with a note).

Pruned the now-resolved `/api/launchers/generate` entry from the `#941` route-uniqueness allowlist and updated the two tests that asserted the removed server.py copies existed.

## Docs
Corrected the CLAUDE.md architecture block: server.py is **~2.3k lines** (not the stale "~6800"), and `requirements.txt` lives at the **repo root**, not `backend/` (the phantom path the issue flagged).

## Scope note
The broader #941 ask (moving remaining endpoint handlers/loops out of server.py, consolidating the 11 other legitimate cross-module name-collisions) is deliberately out of scope for this change to keep it low-risk and reviewable; the new ratchet prevents any *new* drift in the meantime.

## Tests
Full suite: **2727 passed, 18 skipped, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)