### PR TITLE
fix(security): env hygiene, TLS-conditional cookies, atomic tokens + drain guard (#929, #930, #939)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,32 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.104
+**Spec Version:** 2.5.106
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.106):** Security/robustness hardening (issues #929, #930,
+  #939). (#929) `safe_subprocess_env` (`backend/security.py`) stripped only a
+  hand-maintained denylist, so any *new* `*_TOKEN`/`*_SECRET` env var leaked to
+  every spawned subprocess by default; added a rot-proof suffix catch-all
+  (`*_SECRET`/`*_TOKEN`/`*_KEY`/`*_PASSWORD`/`*_PASSWD`/`*_CREDENTIALS`) on top of
+  the denylist (anchored at end-of-name, so `TOKEN_FILE_PATH` still passes
+  through). (#930) The session cookie was unconditionally `https_only=True` and
+  HSTS was always sent, but browsers drop Secure cookies on http:// origins — so
+  session auth silently never worked on the documented plain-HTTP-over-tailnet
+  deployment. Both are now gated on a new `DASHBOARD_TLS` flag
+  (`dashboard_config.TLS_ENABLED`): default HTTP mode issues a usable cookie and
+  sends no HSTS; TLS mode enforces Secure + HSTS. (#939) (a) `save_tokens`
+  (`backend/identity.py`) is now an atomic tempfile + `os.replace` write like
+  `save_principals`, so a crash mid-dump can't corrupt tokens.yml and lock
+  everyone out; (c) the `POST /_drain` loopback guard (`backend/server.py`) is now
+  an explicit `HTTPException(403)` instead of a bare `assert` (which `python -O`
+  compiles out, letting any peer drain the server); (d) the subprocess timeout
+  paths in `system_utils.run_cmd` and `queue_cleanup` now kill *then* `await
+  wait()` and tolerate `ProcessLookupError`, preventing zombie/transport leaks.
+  Tests in `tests/test_security.py`, `tests/test_middleware.py`,
+  `tests/test_identity.py`, `tests/api/test_drain_mode.py`, and
+  `tests/test_system_utils.py`.
 - **2026-06-12 (2.5.104):** server.py god-module duplicate sweep (architecture,
   issue #941). Removed two body-identical twins from the ~2.3k-line wiring
   module: the `POST /api/launchers/generate` route handler (a shadowed dead copy
@@ -18,6 +40,28 @@
   Pruned the now-resolved launchers entry from the #941 route-uniqueness allowlist
   and corrected the CLAUDE.md architecture block (server.py size ~2.3k not ~6800;
   requirements.txt lives at the repo root, not `backend/`).
+- **2026-06-12 (2.5.105):** Security/robustness hardening (issues #929, #930,
+  #939). (#929) `safe_subprocess_env` (`backend/security.py`) stripped only a
+  hand-maintained denylist, so any *new* `*_TOKEN`/`*_SECRET` env var leaked to
+  every spawned subprocess by default; added a rot-proof suffix catch-all
+  (`*_SECRET`/`*_TOKEN`/`*_KEY`/`*_PASSWORD`/`*_PASSWD`/`*_CREDENTIALS`) on top of
+  the denylist (anchored at end-of-name, so `TOKEN_FILE_PATH` still passes
+  through). (#930) The session cookie was unconditionally `https_only=True` and
+  HSTS was always sent, but browsers drop Secure cookies on http:// origins — so
+  session auth silently never worked on the documented plain-HTTP-over-tailnet
+  deployment. Both are now gated on a new `DASHBOARD_TLS` flag
+  (`dashboard_config.TLS_ENABLED`): default HTTP mode issues a usable cookie and
+  sends no HSTS; TLS mode enforces Secure + HSTS. (#939) (a) `save_tokens`
+  (`backend/identity.py`) is now an atomic tempfile + `os.replace` write like
+  `save_principals`, so a crash mid-dump can't corrupt tokens.yml and lock
+  everyone out; (c) the `POST /_drain` loopback guard (`backend/server.py`) is now
+  an explicit `HTTPException(403)` instead of a bare `assert` (which `python -O`
+  compiles out, letting any peer drain the server); (d) the subprocess timeout
+  paths in `system_utils.run_cmd` and `queue_cleanup` now kill *then* `await
+  wait()` and tolerate `ProcessLookupError`, preventing zombie/transport leaks.
+  Tests in `tests/test_security.py`, `tests/test_middleware.py`,
+  `tests/test_identity.py`, `tests/api/test_drain_mode.py`, and
+  `tests/test_system_utils.py`.
 - **2026-06-12 (2.5.101):** Autoscaler correctness/robustness cluster (issues
   #932, #935, #936, #937). (#932) The autoscaler read leases from a repo-relative
   `config/leases.yml` that nothing ever wrote, so lease protection was a permanent

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.12
+4.9.13

--- a/backend/dashboard_config/__init__.py
+++ b/backend/dashboard_config/__init__.py
@@ -65,6 +65,23 @@ PORT = int(os.environ.get("DASHBOARD_PORT", "8321"))
 HOSTNAME = os.environ.get("DISPLAY_NAME") or platform.node()
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Parse a boolean-ish env var (1/true/yes/on → True)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+# Issue #930: the dashboard documents a plain-HTTP-over-tailnet deployment, but
+# the session cookie was unconditionally `https_only=True` (Secure) and HSTS was
+# always sent. Browsers DROP Secure cookies on http:// origins, so session auth
+# silently never worked in the documented mode — pushing operators toward the
+# unauthenticated paths. TLS-only protections are now gated on DASHBOARD_TLS:
+# unset (default) = HTTP-mode (no Secure cookie, no HSTS); set = TLS-mode.
+TLS_ENABLED = _env_flag("DASHBOARD_TLS", default=False)
+
+
 def _resolve_bind_host() -> str:
     """Return the interface uvicorn should bind for incoming HTTP.
 
@@ -287,6 +304,7 @@ __all__ = [
     "SESSION_SECRET",
     "SESSION_SECRET_SOURCE",
     "SYSTEMCTL_BIN",
+    "TLS_ENABLED",
     "VERSION",
     "WSL_KEEPALIVE_SERVICE",
     "WSL_KEEPALIVE_TASK_NAME",

--- a/backend/identity.py
+++ b/backend/identity.py
@@ -130,14 +130,34 @@ class IdentityManager:
             self.tokens.append(TokenRecord(**t))
 
     def save_tokens(self):
-        """Save tokens with security validation (issue #355)."""
+        """Atomically persist tokens to ``tokens.yml`` (security: issue #355).
+
+        Crash-safety (issue #939a): writes via tempfile + ``os.replace`` so a
+        crash mid-dump can never leave a truncated tokens.yml — which
+        ``load_tokens`` would silently reset, locking every principal out.
+        Mirrors :meth:`save_principals`.
+        """
         self.tokens_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Security validation: ensure config dir is within allowed roots
         validate_config_path(self.tokens_path.parent, allowed_roots=[self.config_dir.resolve()])
 
-        with open(self.tokens_path, "w") as f:
-            yaml.dump({"tokens": [t.model_dump() for t in self.tokens]}, f)
+        payload = {"tokens": [t.model_dump() for t in self.tokens]}
+        fd, tmp_path = tempfile.mkstemp(
+            dir=self.tokens_path.parent,
+            prefix=".tmp-tokens-",
+            suffix=".yml",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                yaml.dump(payload, fh, default_flow_style=False, allow_unicode=True)
+            os.replace(tmp_path, self.tokens_path)
+        except (OSError, yaml.YAMLError):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def mint_service_token(self, principal_id: str, name: str, expires_in_days: int | None = None) -> str:
         if principal_id not in self.principals:

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -350,8 +350,13 @@ async def add_security_headers(request: Request, call_next: Any) -> Any:
         "frame-ancestors 'none';"
     )
     # HSTS: instruct browsers to use HTTPS for 1 year; include subdomains
-    # (issue #324).
-    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    # (issue #324). Only sent in TLS mode (issue #930): sending HSTS on the
+    # documented plain-HTTP-over-tailnet deployment would wedge browsers into
+    # HTTPS-only for a year against a server that does not speak TLS.
+    from dashboard_config import TLS_ENABLED  # noqa: PLC0415
+
+    if TLS_ENABLED:
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     # Permissions-Policy: microphone allowed on self for VoiceInputButton.
     response.headers["Permissions-Policy"] = (
         "camera=(), microphone=(self), geolocation=(), payment=(), usb=(), interest-cohort=()"

--- a/backend/queue_cleanup.py
+++ b/backend/queue_cleanup.py
@@ -22,6 +22,7 @@ Common sources of stale runs:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime as _dt
 import json
 import logging
@@ -196,7 +197,11 @@ async def _gh(*args: str, timeout: int = 30) -> tuple[int, str, str]:
     try:
         raw_out, raw_err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
-        proc.kill()
+        # Issue #939d: kill then reap, tolerating an already-exited process.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(ProcessLookupError):
+            await proc.wait()
         return 1, "", "timeout"
     return (
         proc.returncode or 0,

--- a/backend/security.py
+++ b/backend/security.py
@@ -64,15 +64,34 @@ _DENIED_SUBPROCESS_ENV_KEYS = frozenset(
 
 _DENIED_SUBPROCESS_ENV_PREFIXES = ("AWS_", "AZURE_")
 
+# Issue #929: a hand-maintained denylist rots — any *new* secret-bearing env var
+# (a future ``*_TOKEN``/``*_SECRET`` nobody remembered to enumerate) would leak
+# to every spawned subprocess by default. Strip anything whose name ends in a
+# secret-shaped suffix as a catch-all on top of the explicit denylist. The suffix
+# set is deliberately conservative; ``PUBLIC_KEY`` still ends in ``_KEY`` and is
+# stripped — that is the safe direction (a subprocess that genuinely needs a
+# value should be passed it explicitly, not via inherited ambient env).
+_DENIED_SUBPROCESS_ENV_SUFFIXES = ("_SECRET", "_TOKEN", "_KEY", "_PASSWORD", "_PASSWD", "_CREDENTIALS")
+
+
+def _is_secret_env_key(key: str) -> bool:
+    """Return True when *key* names a secret-bearing env var that must not leak."""
+    upper = key.upper()
+    if upper in _DENIED_SUBPROCESS_ENV_KEYS:
+        return True
+    if upper.startswith(_DENIED_SUBPROCESS_ENV_PREFIXES):
+        return True
+    return upper.endswith(_DENIED_SUBPROCESS_ENV_SUFFIXES)
+
 
 def safe_subprocess_env() -> dict[str, str]:
-    """Return os.environ with known secret-bearing keys stripped for subprocess calls."""
-    return {
-        key: value
-        for key, value in os.environ.items()
-        if key.upper() not in _DENIED_SUBPROCESS_ENV_KEYS
-        and not key.upper().startswith(_DENIED_SUBPROCESS_ENV_PREFIXES)
-    }
+    """Return os.environ with secret-bearing keys stripped for subprocess calls.
+
+    Strips the explicit denylist, the cloud-provider prefixes, and — as a
+    rot-proof catch-all (#929) — any key ending in a secret-shaped suffix
+    (``*_SECRET``/``*_TOKEN``/``*_KEY``/``*_PASSWORD``/…).
+    """
+    return {key: value for key, value in os.environ.items() if not _is_secret_env_key(key)}
 
 
 # ─── URL Validation ────────────────────────────────────────────────────────────

--- a/backend/server.py
+++ b/backend/server.py
@@ -160,6 +160,7 @@ from runners.service_control import (  # noqa: E402
 )
 from security import (  # noqa: E402
     safe_subprocess_env,  # noqa: E402
+    sanitize_log_value,  # noqa: E402
     validate_fleet_node_url,  # noqa: E402
 )
 from system_utils import get_system_metrics_snapshot  # noqa: E402
@@ -702,7 +703,11 @@ app.add_middleware(
     session_cookie="dashboard_session",
     max_age=86400 * 7,  # 7 days
     same_site="strict",
-    https_only=True,
+    # Issue #930: Secure cookies are dropped by browsers on http:// origins, so
+    # forcing https_only broke session auth on the documented HTTP-over-tailnet
+    # deployment. Gate it on DASHBOARD_TLS so the default HTTP mode issues a
+    # usable cookie and TLS deployments still get the Secure attribute.
+    https_only=dashboard_config.TLS_ENABLED,
 )
 
 app.add_middleware(
@@ -2552,7 +2557,12 @@ async def drain_endpoint(request: Request) -> dict:
     """
     global _drain_mode
     client_host = request.client.host if request.client else "unknown"
-    assert client_host in ("127.0.0.1", "::1", "localhost"), "drain only from loopback"
+    # Issue #939c: a bare `assert` is compiled out under `python -O`, which would
+    # let ANY network peer drain the server. Enforce the loopback restriction
+    # with an explicit check that raises regardless of optimization level.
+    if client_host not in ("127.0.0.1", "::1", "localhost"):
+        log.warning("/_drain refused for non-loopback client %s", sanitize_log_value(client_host))
+        raise HTTPException(status_code=403, detail="drain only from loopback")
     _drain_mode = True
     log.info("/_drain activated by %s", client_host)
     return {"status": "draining"}

--- a/backend/system_utils.py
+++ b/backend/system_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import errno
 import json
 import logging
@@ -1102,8 +1103,14 @@ async def run_cmd(cmd: list[str], timeout: int = 30, cwd: Path | None = None) ->
     except FileNotFoundError as exc:
         return 127, "", str(exc)
     except TimeoutError:
+        # Issue #939d: kill THEN reap. A bare proc.kill() without awaiting wait()
+        # leaks a zombie/transport; kill() also raises ProcessLookupError if the
+        # process already exited between the timeout and the kill.
         if "proc" in locals():
-            proc.kill()
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(ProcessLookupError):
+                await proc.wait()
         return -1, "", "Command timed out"
 
 

--- a/tests/api/test_drain_mode.py
+++ b/tests/api/test_drain_mode.py
@@ -43,3 +43,65 @@ def test_drain_script_has_timeout():
     script = Path(__file__).resolve().parents[2] / "deploy" / "drain-dashboard.sh"
     content = script.read_text()
     assert "DRAIN_TIMEOUT_S" in content, "drain-dashboard.sh must have a timeout"
+
+
+# ─── Issue #939c: loopback guard must be an explicit check, not a bare assert ──
+
+
+def _drain_source() -> str:
+    return (Path(__file__).resolve().parents[2] / "backend" / "server.py").read_text(encoding="utf-8")
+
+
+def test_drain_handler_has_no_bare_assert_guard():
+    """The /_drain loopback guard must NOT be a bare `assert` (compiled out under -O).
+
+    Greps the handler body to ensure the security check survives `python -O`.
+    """
+    import ast
+
+    tree = ast.parse(_drain_source())
+    drain_fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "drain_endpoint"
+    )
+    asserts = [n for n in ast.walk(drain_fn) if isinstance(n, ast.Assert)]
+    assert not asserts, "drain_endpoint must not guard the loopback restriction with a bare assert (#939c)"
+
+
+def test_drain_rejects_non_loopback_with_403():
+    """A non-loopback client must get HTTP 403, regardless of optimization level."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    import server  # noqa: PLC0415
+
+    req = MagicMock()
+    req.client.host = "10.0.0.5"  # not loopback
+    server._drain_mode = False
+    try:
+        asyncio.run(server.drain_endpoint(req))
+    except HTTPException as exc:
+        assert exc.status_code == 403
+    else:  # pragma: no cover
+        raise AssertionError("drain_endpoint must reject non-loopback clients with 403")
+    assert server._drain_mode is False, "drain must not activate for a rejected client"
+
+
+def test_drain_accepts_loopback():
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import server  # noqa: PLC0415
+
+    req = MagicMock()
+    req.client.host = "127.0.0.1"
+    server._drain_mode = False
+    try:
+        result = asyncio.run(server.drain_endpoint(req))
+        assert result["status"] == "draining"
+        assert server._drain_mode is True
+    finally:
+        server._drain_mode = False

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -79,3 +79,58 @@ def test_identity_manager_principals_dict_empty(tmp_path: Path) -> None:
     # principals dict should be empty for a fresh config dir
     assert isinstance(mgr.principals, dict)
     assert len(mgr.principals) == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #939a: save_tokens must be atomic (tempfile + os.replace), like
+# save_principals — a crash mid-write must never leave a truncated tokens.yml.
+# ---------------------------------------------------------------------------
+
+
+def test_save_tokens_writes_atomically_via_replace(tmp_path: Path, monkeypatch) -> None:
+    import os as _os
+
+    mgr = id_mod.IdentityManager(config_dir=tmp_path)
+    mgr.tokens = [id_mod.TokenRecord(token_hash="h1", principal_id="p1", created_at=1.0, expires_at=2.0, name="t1")]
+
+    seen: dict[str, str] = {}
+    real_replace = _os.replace
+
+    def _spy_replace(src, dst):
+        seen["src"] = str(src)
+        seen["dst"] = str(dst)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(id_mod.os, "replace", _spy_replace)
+    mgr.save_tokens()
+
+    # Persisted via a temp file then atomically renamed onto tokens.yml.
+    assert seen["dst"].endswith("tokens.yml")
+    assert ".tmp-tokens-" in seen["src"]
+    # Reloading yields the token back.
+    mgr2 = id_mod.IdentityManager(config_dir=tmp_path)
+    assert any(t.token_hash == "h1" for t in mgr2.tokens)
+
+
+def test_save_tokens_crash_leaves_old_file_intact(tmp_path: Path, monkeypatch) -> None:
+    """A failure during the dump must not corrupt an existing tokens.yml."""
+    mgr = id_mod.IdentityManager(config_dir=tmp_path)
+    mgr.tokens = [id_mod.TokenRecord(token_hash="orig", principal_id="p1", created_at=1.0, expires_at=2.0, name="t1")]
+    mgr.save_tokens()
+    original = mgr.tokens_path.read_text(encoding="utf-8")
+
+    # Simulate a crash mid-write: os.replace raises after the temp file is written.
+    def _boom(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(id_mod.os, "replace", _boom)
+    mgr.tokens = [id_mod.TokenRecord(token_hash="new", principal_id="p1", created_at=3.0, expires_at=4.0, name="t2")]
+    import pytest
+
+    with pytest.raises(OSError, match="disk full"):
+        mgr.save_tokens()
+
+    # The original file is untouched (atomic replace never happened) and no
+    # stray temp files leaked into the config dir.
+    assert mgr.tokens_path.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob(".tmp-tokens-*"))

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -127,6 +127,28 @@ def test_security_headers_present_on_post() -> None:
     assert resp.headers.get("X-Content-Type-Options") == "nosniff"
 
 
+def test_hsts_absent_in_http_mode(monkeypatch) -> None:
+    """Issue #930: no HSTS header in the default plain-HTTP deployment mode."""
+    import dashboard_config
+
+    monkeypatch.setattr(dashboard_config, "TLS_ENABLED", False)
+    app = _make_app_with_security_headers()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/anything")
+    assert "Strict-Transport-Security" not in resp.headers
+
+
+def test_hsts_present_in_tls_mode(monkeypatch) -> None:
+    """Issue #930: HSTS is sent only when DASHBOARD_TLS is enabled."""
+    import dashboard_config
+
+    monkeypatch.setattr(dashboard_config, "TLS_ENABLED", True)
+    app = _make_app_with_security_headers()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/anything")
+    assert resp.headers.get("Strict-Transport-Security") == "max-age=31536000; includeSubDomains"
+
+
 # ---------------------------------------------------------------------------
 # MaxBodySizeMiddleware
 # ---------------------------------------------------------------------------

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -371,11 +371,13 @@ def test_safe_subprocess_env_excludes_secrets(monkeypatch) -> None:
     monkeypatch.setattr("os.environ", fake_env)
 
     result = security.safe_subprocess_env()
+    # Issue #929: the suffix catch-all now also strips ad-hoc secret-shaped vars
+    # (MY_SECRET / DATABASE_PASSWORD / SOME_TOKEN) that the explicit denylist
+    # never knew about. Vars that merely *contain* a secret word but end in a
+    # non-secret suffix (_PATH, _DISABLED) are still passed through — the suffix
+    # rule is anchored at the end of the name, not a substring match.
     assert result == {
         "PATH": "/usr/bin",
-        "MY_SECRET": "shh",
-        "DATABASE_PASSWORD": "password",
-        "SOME_TOKEN": "tok",
         "MAINTENANCE_TOKEN_FILE_PATH": "/tmp/token-file",
         "MAINTENANCE_PASSWORD_PROMPT_DISABLED": "1",
         "XDG_TOKEN_PATH": "/tmp/xdg-token",
@@ -409,6 +411,38 @@ def test_safe_subprocess_env_excludes_provider_key_map_values(monkeypatch) -> No
 def test_safe_subprocess_env_empty(monkeypatch) -> None:
     monkeypatch.setattr("os.environ", {})
     assert security.safe_subprocess_env() == {}
+
+
+def test_safe_subprocess_env_strips_new_secret_suffixes(monkeypatch) -> None:
+    """Issue #929: a brand-new secret var the denylist never enumerated is still
+    stripped by the suffix catch-all, while known-required vars pass through."""
+    fake_env = {
+        "PATH": "/usr/bin",
+        "HOME": "/home/dieter",
+        "LANG": "en_US.UTF-8",
+        "MY_NEW_SECRET": "x",
+        "FOO_TOKEN": "y",
+        "BAR_API_KEY": "z",
+        "DB_PASSWORD": "p",
+        "SVC_CREDENTIALS": "c",
+        "ROOT_PASSWD": "q",
+    }
+    monkeypatch.setattr("os.environ", fake_env)
+    result = security.safe_subprocess_env()
+    # None of the secret-suffixed vars survive.
+    for leaked in ("MY_NEW_SECRET", "FOO_TOKEN", "BAR_API_KEY", "DB_PASSWORD", "SVC_CREDENTIALS", "ROOT_PASSWD"):
+        assert leaked not in result, f"{leaked} leaked to subprocess env"
+    # Required, non-secret vars still pass through.
+    assert result == {"PATH": "/usr/bin", "HOME": "/home/dieter", "LANG": "en_US.UTF-8"}
+
+
+def test_is_secret_env_key_suffix_anchored() -> None:
+    """The suffix rule is anchored at the end of the name, not a substring match."""
+    assert security._is_secret_env_key("ANY_TOKEN") is True
+    assert security._is_secret_env_key("ANY_API_KEY") is True
+    # Substring-but-not-suffix names are NOT secrets.
+    assert security._is_secret_env_key("TOKEN_FILE_PATH") is False
+    assert security._is_secret_env_key("PASSWORD_PROMPT_DISABLED") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -846,6 +846,80 @@ def test_tier_hdd_capacity_pressure_primary_signal() -> None:
     assert result["binding_constraint"] == "capacity"
 
 
+# ---------------------------------------------------------------------------
+# Issue #939d: run_cmd timeout must kill THEN reap, tolerating an already-exited
+# process (no zombie/transport leak, no unhandled ProcessLookupError).
+# ---------------------------------------------------------------------------
+
+
+def test_run_cmd_timeout_kills_and_reaps(monkeypatch) -> None:
+    import asyncio
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.killed = False
+            self.waited = False
+            self.returncode = None
+
+        async def communicate(self):
+            raise TimeoutError
+
+        def kill(self):
+            self.killed = True
+
+        async def wait(self):
+            self.waited = True
+            return -9
+
+    fake = _FakeProc()
+
+    async def _fake_create(*_a, **_kw):
+        return fake
+
+    async def _fake_wait_for(coro, timeout):  # noqa: ARG001
+        # Drive the coroutine so it raises TimeoutError as the real one would.
+        await coro
+
+    monkeypatch.setattr(system_utils.asyncio, "create_subprocess_exec", _fake_create)
+    monkeypatch.setattr(system_utils.asyncio, "wait_for", _fake_wait_for)
+
+    code, out, err = asyncio.run(system_utils.run_cmd(["sleep", "100"], timeout=1))
+    assert code == -1
+    assert "timed out" in err.lower()
+    assert fake.killed is True, "process must be killed on timeout"
+    assert fake.waited is True, "process must be reaped (awaited) after kill"
+
+
+def test_run_cmd_timeout_tolerates_already_exited(monkeypatch) -> None:
+    import asyncio
+
+    class _GoneProc:
+        returncode = None
+
+        async def communicate(self):
+            raise TimeoutError
+
+        def kill(self):
+            raise ProcessLookupError  # already exited between timeout and kill
+
+        async def wait(self):
+            return 0
+
+    async def _fake_create(*_a, **_kw):
+        return _GoneProc()
+
+    async def _fake_wait_for(coro, timeout):  # noqa: ARG001
+        await coro
+
+    monkeypatch.setattr(system_utils.asyncio, "create_subprocess_exec", _fake_create)
+    monkeypatch.setattr(system_utils.asyncio, "wait_for", _fake_wait_for)
+
+    # Must not raise ProcessLookupError.
+    code, _out, err = asyncio.run(system_utils.run_cmd(["sleep", "100"], timeout=1))
+    assert code == -1
+    assert "timed out" in err.lower()
+
+
 def test_tier_hdd_critical_capacity() -> None:
     """HDD tier: capacity > 93% triggers critical."""
     result = system_utils.classify_disk_pressure_by_tier(


### PR DESCRIPTION
Security/robustness hardening cluster from the 2026-06-12 adversarial audit.

Closes #929
Closes #930
Closes #939

## #929 — denylist rot lets new secrets leak to subprocesses
`safe_subprocess_env` stripped only a hand-maintained denylist, so any future `*_TOKEN`/`*_SECRET` env var nobody remembered to enumerate would leak to every spawned subprocess. Added a rot-proof **end-of-name suffix** catch-all (`_SECRET`/`_TOKEN`/`_KEY`/`_PASSWORD`/`_PASSWD`/`_CREDENTIALS`) on top of the denylist. The rule is anchored at the end of the name, so `TOKEN_FILE_PATH`/`PASSWORD_PROMPT_DISABLED` (substring but not suffix) still pass through.

## #930 — Secure cookie breaks auth on the documented HTTP deployment
The session cookie was unconditionally `https_only=True` and HSTS was always sent, but browsers **drop Secure cookies on http:// origins** — so session auth silently never worked on the documented plain-HTTP-over-tailnet deployment, pushing operators toward unauthenticated paths. Both are now gated on a new `DASHBOARD_TLS` flag (`dashboard_config.TLS_ENABLED`): default HTTP mode issues a usable cookie and sends no HSTS; TLS mode enforces Secure + HSTS.

## #939 — persistence / drain-auth / subprocess-reap
- **(a)** `save_tokens` (`backend/identity.py`) now writes atomically via tempfile + `os.replace` (mirrors `save_principals`), so a crash mid-dump can't corrupt `tokens.yml` and lock everyone out.
- **(c)** The `POST /_drain` loopback guard (`backend/server.py`) is now an explicit `HTTPException(403)` instead of a bare `assert` — which `python -O` compiles out, letting any peer drain the server.
- **(d)** The subprocess timeout paths in `system_utils.run_cmd` and `queue_cleanup` now kill **then** `await wait()` and tolerate `ProcessLookupError`, preventing zombie/transport leaks.

`#939b` (multi-process spend re-read under flock) is deferred — it needs a store redesign and is tracked separately; this PR ships (a)/(c)/(d).

## Tests
New/updated tests in `test_security.py`, `test_middleware.py`, `test_identity.py`, `test_drain_mode.py`, `test_system_utils.py`. Full suite: **2760 passed, 18 skipped, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)