### PR TITLE
ci(mypy): shrink-only ratchet for relaxed overrides (#950)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -273,9 +273,13 @@ jobs:
       - name: Install type stubs
         run: pip install types-PyYAML types-requests
       - name: Type Check
-        # disallow_untyped_defs is now true globally (pyproject.toml).
-        # Per-module overrides shrink each release (tracked in #161).
-        # The override count is printed to the log so it cannot grow silently.
+        # disallow_untyped_defs is true globally (pyproject.toml). Per-module
+        # relaxed overrides are a shrink-only ratchet (issue #950, tracking #161):
+        # the count may go DOWN but a PR that ADDS a relaxed override fails CI.
+        # MYPY_OVERRIDE_BASELINE is the current allowance; lower it as overrides
+        # are removed. Target is 0.
+        env:
+          MYPY_OVERRIDE_BASELINE: "24"
         run: |
           OVERRIDE_COUNT=$(python - <<'EOF'
           import tomllib, pathlib
@@ -289,7 +293,15 @@ jobs:
           print(relaxed_count)
           EOF
           )
-          echo "::notice::mypy relaxed-override module count: ${OVERRIDE_COUNT} (target: 0, tracked in #161)"
+          echo "::notice::mypy relaxed-override module count: ${OVERRIDE_COUNT} (baseline ${MYPY_OVERRIDE_BASELINE}, target 0; #161)"
+          if [ "${OVERRIDE_COUNT}" -gt "${MYPY_OVERRIDE_BASELINE}" ]; then
+            echo "::error::mypy relaxed-override count ${OVERRIDE_COUNT} exceeds baseline ${MYPY_OVERRIDE_BASELINE}." \
+              "Type the new module instead of relaxing it, or justify and bump MYPY_OVERRIDE_BASELINE in ci-standard.yml."
+            exit 1
+          fi
+          if [ "${OVERRIDE_COUNT}" -lt "${MYPY_OVERRIDE_BASELINE}" ]; then
+            echo "::notice::Override count dropped below baseline — lower MYPY_OVERRIDE_BASELINE to ${OVERRIDE_COUNT} to lock in the win."
+          fi
           mypy backend/ --ignore-missing-imports --exclude 'backend/__pycache__' --no-implicit-optional
       - name: Run bandit security scan
         # Blocking for HIGH severity (-lll = high severity, -i = low+ confidence).

--- a/tests/test_mypy_override_ratchet.py
+++ b/tests/test_mypy_override_ratchet.py
@@ -1,0 +1,67 @@
+"""Guard the mypy relaxed-override ratchet (issue #950).
+
+The CI Type Check step fails when the number of relaxed ``tool.mypy.overrides``
+modules exceeds ``MYPY_OVERRIDE_BASELINE`` in ``.github/workflows/ci-standard.yml``.
+These tests keep the in-repo baseline honest:
+
+- the workflow's baseline must be >= the actual current count (otherwise CI is
+  already red), and
+- the baseline must not be set wastefully high above the actual count (so the
+  ratchet stays meaningful), and
+- the count-extraction logic matches what the workflow runs.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO / "pyproject.toml"
+_WORKFLOW = _REPO / ".github" / "workflows" / "ci-standard.yml"
+
+
+def _relaxed_override_count() -> int:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    overrides = data.get("tool", {}).get("mypy", {}).get("overrides", [])
+    count = 0
+    for override in overrides:
+        if override.get("disallow_untyped_defs") is False or override.get("strict_optional") is False:
+            modules = override.get("module", [])
+            count += len(modules) if isinstance(modules, list) else 1
+    return count
+
+
+def _workflow_baseline() -> int:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(r'MYPY_OVERRIDE_BASELINE:\s*"?(\d+)"?', text)
+    assert match, "MYPY_OVERRIDE_BASELINE must be declared in ci-standard.yml (#950)"
+    return int(match.group(1))
+
+
+def test_workflow_baseline_not_below_actual_count() -> None:
+    """The ratchet baseline must be >= the real count, or CI is already red."""
+    assert _workflow_baseline() >= _relaxed_override_count()
+
+
+def test_workflow_baseline_is_tight() -> None:
+    """The baseline must equal the actual count — a shrink-only ratchet has no slack.
+
+    If this fails because the count dropped, lower MYPY_OVERRIDE_BASELINE to match
+    (locking in the improvement). If it fails because the count grew, the new
+    override is the regression #950 guards against — type the module instead.
+    """
+    assert _workflow_baseline() == _relaxed_override_count(), (
+        "MYPY_OVERRIDE_BASELINE drifted from the actual relaxed-override count; "
+        "update the baseline in .github/workflows/ci-standard.yml."
+    )
+
+
+def test_ratchet_step_fails_above_baseline() -> None:
+    """The workflow must `exit 1` when the count exceeds the baseline (#950)."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert 'if [ "${OVERRIDE_COUNT}" -gt "${MYPY_OVERRIDE_BASELINE}" ]; then' in text
+    # An exit 1 must follow the over-baseline guard.
+    guard_idx = text.index('-gt "${MYPY_OVERRIDE_BASELINE}"')
+    assert "exit 1" in text[guard_idx : guard_idx + 400], "over-baseline branch must hard-fail (exit 1)"


### PR DESCRIPTION
Closes #950

The CI Type Check step counted relaxed `tool.mypy.overrides` modules but only emitted a `::notice::`, so overrides could accumulate indefinitely and type regressions landed silently — the advisory-gate problem #950 describes.

## Change
The step now hard-fails when the relaxed-override module count exceeds `MYPY_OVERRIDE_BASELINE` (currently **24** — the existing #161 allowance), and nudges the baseline down when the count drops. The allowance is now **shrink-only** with a target of 0: a PR that adds a relaxed override fails CI (the exact acceptance criterion), while removing overrides is encouraged.

`tests/test_mypy_override_ratchet.py` keeps the workflow baseline pinned to the actual pyproject count (fails on drift) and asserts the over-baseline branch hard-fails.

## Scope
This lands the "ratchet downward" half of #950 (the regression gate). The second bullet — replacing `--ignore-missing-imports` with `types-*` stubs and driving the count to 0 — is a larger, separate effort and is intentionally **not** in this PR; the ratchet makes that a monotonic, low-risk follow-up. If you'd prefer to keep #950 open for the stub work, relabel after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)