### PR TITLE
fix: Quick Start works on clean checkout + gh_client robustness (#945, #938)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,14 @@ export GITHUB_TOKEN=ghp_your_token_here
 
 Open http://localhost:8321 in your browser.
 
-**Requirements:** Python 3.11+, a GitHub PAT with `repo` and `admin:org` scopes.
+On a clean checkout `start-dashboard.sh` provisions a project-local `.venv` from
+the repo-root `requirements.txt` and builds the frontend bundle
+(`frontend/dist/`) via `npm ci && npm run build`. It exits non-zero with
+instructions if the dependencies or a working `npm` are unavailable, rather than
+starting a broken server.
+
+**Requirements:** Python 3.11+, Node.js 18+/npm (for the frontend build), and a
+GitHub PAT with `repo` and `admin:org` scopes.
 
 ## Production Deployment
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,28 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.108
+**Spec Version:** 2.5.109
 **Application Version:** 4.8.0 (see `VERSION`)
 **Last Updated:** 2026-06-12T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-12 (2.5.109):** Quick Start works on a clean checkout + gh_client
+  robustness (issues #945, #938). (#945) `start-dashboard.sh` now installs from
+  the repo-root `requirements.txt` (the phantom `backend/requirements.txt` path
+  silently fell back to a fastapi+uvicorn-only install that crashed on
+  `import httpx/psutil/yaml`); it fails loudly if the requirements file is
+  missing and builds the gitignored `frontend/dist/` via `npm ci && npm run build`
+  (or exits non-zero with instructions) so the served page is the real SPA, not
+  the "index.html not found" fallback. README documents the Node/npm requirement;
+  `tests/test_start_dashboard_script.py` guards the script against regressing.
+  (#938) `backend/gh_client.py`: (a) `_request` now treats any `2xx` as success
+  so GitHub's `202 Accepted` (e.g. `cancel_run`) is no longer reported as a
+  `GhServerError`; (b) `paginate` routes every page through `_request`, so a
+  primary-rate-limit `403` (`X-RateLimit-Remaining: 0`) raises the typed
+  `GhRateLimited` and transient `5xx` retry/backoff applies, instead of only
+  special-casing `429`; (c) the GitHub App installation-token exchange is now
+  async (`httpx.AsyncClient`) under an `asyncio.Lock`, so it no longer blocks the
+  event loop ~hourly and a refresh storm dedupes to one upstream exchange.
+  Tests in `tests/test_gh_client.py` and `tests/test_start_dashboard_script.py`.
 - **2026-06-12 (2.5.108):** Single source of truth for fleet topology, runtime
   config, and the identity store (issues #942, #943, #944). (#942) `/api/fleet/status`
   no longer hardcodes `if PORT == 8322` to label itself ControlTower-NVMe and

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.15
+4.9.16

--- a/backend/gh_client.py
+++ b/backend/gh_client.py
@@ -52,6 +52,10 @@ assert _MAX_RETRIES > 0, "MAX_RETRIES must be positive"
 _cached_token: str | None = None
 _cached_token_expires_at: float = 0.0
 _cached_token_source: str = "unknown"
+# Issue #938(c): serialize concurrent GitHub App token exchanges so a refresh
+# storm (every request in flight when the ~hourly token expires) triggers
+# exactly one upstream exchange instead of one per coroutine.
+_token_refresh_lock: asyncio.Lock = asyncio.Lock()
 _last_status: dict[str, Any] = {
     "status": "unknown",
     "detail": "No GitHub API request has completed in this process.",
@@ -93,23 +97,19 @@ def _get_token() -> str:
     Raises:
         GhAuthError: when no token is available.
     """
-    global _cached_token, _cached_token_expires_at, _cached_token_source
     if _cached_token and (_cached_token_expires_at == 0.0 or time.time() < _cached_token_expires_at):
         return _cached_token
-
     if _github_app_auth_configured():
-        try:
-            _cached_token = _fetch_github_app_installation_token()
-            _cached_token_source = "github_app"
-            _last_status["auth_source"] = _cached_token_source
-            return _cached_token
-        except Exception as exc:
-            _cached_token = None
-            _cached_token_expires_at = 0.0
-            _cached_token_source = "github_app_error"
-            _set_status("auth_error", f"GitHub App token exchange failed: {type(exc).__name__}: {exc}")
-            log.exception("GitHub App token exchange failed; falling back to GH_TOKEN when present")
+        raise GhAuthError(
+            "GitHub App auth requires the async token path; call _get_token_async() "
+            "from the request path (issue #938c)."
+        )
+    return _resolve_env_token()
 
+
+def _resolve_env_token() -> str:
+    """Resolve and cache a GH_TOKEN / GITHUB_TOKEN env credential (sync)."""
+    global _cached_token, _cached_token_expires_at, _cached_token_source
     token = os.environ.get("GH_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
     if not token:
         _cached_token_source = "missing"
@@ -123,6 +123,39 @@ def _get_token() -> str:
     _cached_token_source = "env_token"
     _last_status["auth_source"] = _cached_token_source
     return token
+
+
+async def _get_token_async() -> str:
+    """Async token resolver used by the request path (issue #938c).
+
+    GitHub App installation tokens are exchanged via an async client under a
+    shared lock, so a refresh storm at token expiry triggers exactly one
+    upstream exchange. Falls back to GH_TOKEN / GITHUB_TOKEN when the App
+    exchange fails or App auth is not configured.
+    """
+    global _cached_token, _cached_token_expires_at, _cached_token_source
+    if _cached_token and (_cached_token_expires_at == 0.0 or time.time() < _cached_token_expires_at):
+        return _cached_token
+
+    if _github_app_auth_configured():
+        async with _token_refresh_lock:
+            # Re-check under the lock: a concurrent coroutine may have just
+            # refreshed the token while we waited (dedupe the exchange).
+            if _cached_token and (_cached_token_expires_at == 0.0 or time.time() < _cached_token_expires_at):
+                return _cached_token
+            try:
+                _cached_token = await _fetch_github_app_installation_token()
+                _cached_token_source = "github_app"
+                _last_status["auth_source"] = _cached_token_source
+                return _cached_token
+            except Exception as exc:
+                _cached_token = None
+                _cached_token_expires_at = 0.0
+                _cached_token_source = "github_app_error"
+                _set_status("auth_error", f"GitHub App token exchange failed: {type(exc).__name__}: {exc}")
+                log.exception("GitHub App token exchange failed; falling back to GH_TOKEN when present")
+
+    return _resolve_env_token()
 
 
 def clear_token_cache() -> None:
@@ -182,8 +215,13 @@ def _build_app_jwt(now: datetime | None = None) -> str:
     return jwt.encode(payload, _github_app_private_key(), algorithm="RS256")
 
 
-def _fetch_github_app_installation_token() -> str:
-    """Exchange a GitHub App JWT for an installation access token."""
+async def _fetch_github_app_installation_token() -> str:
+    """Exchange a GitHub App JWT for an installation access token.
+
+    Issue #938(c): uses an ``httpx.AsyncClient`` so the exchange never blocks the
+    event loop. The previous sync ``httpx.Client`` froze the whole dashboard for
+    up to ~50s on every (~hourly) App-token expiry.
+    """
     global _cached_token_expires_at
 
     installation_id = os.environ["GITHUB_APP_INSTALLATION_ID"].strip()
@@ -193,8 +231,8 @@ def _fetch_github_app_installation_token() -> str:
         "X-GitHub-Api-Version": "2022-11-28",
         "Authorization": f"Bearer {_build_app_jwt()}",
     }
-    with httpx.Client(timeout=httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)) as client:
-        resp = client.post(url, headers=headers)
+    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)) as client:
+        resp = await client.post(url, headers=headers)
     if resp.status_code not in (200, 201):
         raise GhServerError(resp.status_code, "/app/installations/.../access_tokens", resp.text)
     body = resp.json()
@@ -293,8 +331,8 @@ class GhServerError(GhClientError):
 # ── Core helpers ──────────────────────────────────────────────────────────────
 
 
-def _auth_headers() -> dict[str, str]:
-    return {"Authorization": f"Bearer {_get_token()}"}
+async def _auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {await _get_token_async()}"}
 
 
 def _parse_retry_after(resp: httpx.Response) -> int:
@@ -336,7 +374,7 @@ async def _request(method: str, path: str, *, json: Any = None) -> httpx.Respons
         GhClientError: timeout/connect error after all retries exhausted.
     """
     client = _get_client()
-    headers = _auth_headers()
+    headers = await _auth_headers()
     last_exc: Exception | None = None
 
     for attempt in range(_MAX_RETRIES):
@@ -356,7 +394,10 @@ async def _request(method: str, path: str, *, json: Any = None) -> httpx.Respons
                 await asyncio.sleep(backoff)
             continue
 
-        if resp.status_code in (200, 201, 204):
+        # Issue #938(a): accept any 2xx as success. GitHub returns 202 Accepted
+        # for async-processed actions (e.g. cancel_run); treating it as an error
+        # reported a successful cancel as a GhServerError.
+        if 200 <= resp.status_code < 300:
             _set_status("ok", "GitHub API requests are succeeding.", endpoint=path)
             return resp
         if resp.status_code in (401, 403) and not _is_rate_limited_response(resp):
@@ -475,30 +516,17 @@ async def paginate(path: str, *, per_page: int = 100) -> AsyncIterator[dict]:
     """
     sep = "&" if "?" in path else "?"
     url: str | None = f"{path}{sep}per_page={per_page}"
-    client = _get_client()
-    headers = _auth_headers()
 
     while url:
-        page_attempt = 0
-        while True:
-            resp = await client.get(url, headers={**headers, **client.headers})
-            if resp.status_code == 404:
-                return
-            if resp.status_code == 429:
-                retry_after = _parse_retry_after(resp)
-                if retry_after <= 60 and page_attempt == 0:
-                    log.warning(
-                        "gh_client: paginate rate limited at %s; sleeping %ds",
-                        url,
-                        retry_after,
-                    )
-                    await asyncio.sleep(retry_after)
-                    page_attempt += 1
-                    continue
-                raise GhRateLimited(retry_after_seconds=retry_after, endpoint=url)
-            if resp.status_code >= 400:
-                raise GhServerError(resp.status_code, url, resp.text)
-            break
+        # Issue #938(b): route every page through _request so the shared
+        # 403-primary-rate-limit detection (X-RateLimit-Remaining: 0), 429
+        # back-off, and 5xx retry/backoff apply. paginate previously only
+        # special-cased 429 and aborted on a primary-rate-limit 403 or a
+        # transient 5xx.
+        try:
+            resp = await _request("GET", url)
+        except GhNotFound:
+            return
         body = resp.json()
         items: list[dict] = body if isinstance(body, list) else []
         for key in ("workflow_runs", "jobs", "runners", "items", "repositories"):

--- a/start-dashboard.sh
+++ b/start-dashboard.sh
@@ -18,7 +18,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BACKEND_DIR="${SCRIPT_DIR}/backend"
 VENV_DIR="${SCRIPT_DIR}/.venv"
-REQUIREMENTS_FILE="${BACKEND_DIR}/requirements.txt"
+# Issue #945: Python deps live in the repo-root requirements.txt, not backend/.
+REQUIREMENTS_FILE="${SCRIPT_DIR}/requirements.txt"
+FRONTEND_DIR="${SCRIPT_DIR}/frontend"
+DIST_DIR="${FRONTEND_DIR}/dist"
 INSTALL_STAMP="${VENV_DIR}/.installed-stamp"
 PORT="${DASHBOARD_PORT:-8321}"
 HOST="${DASHBOARD_HOST:-127.0.0.1}"
@@ -71,17 +74,36 @@ fi
 # shellcheck disable=SC1091
 source "${VENV_DIR}/bin/activate"
 
+# Issue #945: fail loudly if the requirements file is missing instead of
+# silently installing a fastapi+uvicorn subset that crashes on first import
+# (server.py needs httpx/psutil/yaml/... too).
+if [[ ! -f "${REQUIREMENTS_FILE}" ]]; then
+    echo "[ERROR] requirements file not found: ${REQUIREMENTS_FILE}" >&2
+    echo "        The dashboard cannot start without its Python dependencies." >&2
+    exit 1
+fi
+
 # Cached install: only re-run pip if requirements.txt is newer than the stamp.
 if [[ ! -f "${INSTALL_STAMP}" ]] || [[ "${REQUIREMENTS_FILE}" -nt "${INSTALL_STAMP}" ]]; then
     echo "[INFO] Installing dependencies from ${REQUIREMENTS_FILE}"
     python -m pip install --upgrade pip >/dev/null
-    if [[ -f "${REQUIREMENTS_FILE}" ]]; then
-        python -m pip install -r "${REQUIREMENTS_FILE}"
-    else
-        # Fallback for minimal environments without a requirements.txt yet.
-        python -m pip install fastapi 'uvicorn[standard]'
-    fi
+    python -m pip install -r "${REQUIREMENTS_FILE}"
     touch "${INSTALL_STAMP}"
+fi
+
+# Issue #945: the backend serves the SPA from frontend/dist/ (gitignored). On a
+# clean checkout that directory is absent and the server falls back to a bare
+# "Frontend index.html not found" page. Build it (or fail with instructions)
+# so the documented Quick Start yields a working app.
+if [[ ! -f "${DIST_DIR}/index.html" ]]; then
+    echo "[INFO] Frontend bundle missing at ${DIST_DIR}; building it"
+    if command -v npm >/dev/null 2>&1; then
+        ( cd "${FRONTEND_DIR}" && npm ci && npm run build )
+    else
+        echo "[ERROR] npm not found and ${DIST_DIR}/index.html is missing." >&2
+        echo "        Install Node.js/npm, then run: (cd frontend && npm ci && npm run build)" >&2
+        exit 1
+    fi
 fi
 
 echo ""

--- a/tests/test_gh_client.py
+++ b/tests/test_gh_client.py
@@ -80,8 +80,9 @@ def test_get_token_raises_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     gh_client.clear_token_cache()
 
 
-def test_get_token_prefers_github_app(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_token_prefers_github_app(monkeypatch: pytest.MonkeyPatch) -> None:
     import gh_client
+    from unittest.mock import AsyncMock
 
     gh_client.clear_token_cache()
     monkeypatch.setenv("GITHUB_APP_ID", "12345")
@@ -89,15 +90,16 @@ def test_get_token_prefers_github_app(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "fake-key")
     monkeypatch.setenv("GH_TOKEN", "fallback-token")
 
-    with patch.object(gh_client, "_fetch_github_app_installation_token", return_value="installation-token"):
-        assert gh_client._get_token() == "installation-token"
+    with patch.object(gh_client, "_fetch_github_app_installation_token", AsyncMock(return_value="installation-token")):
+        assert await gh_client._get_token_async() == "installation-token"
 
     assert gh_client.get_status()["auth_source"] == "github_app"
     gh_client.clear_token_cache()
 
 
-def test_get_token_falls_back_when_github_app_exchange_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_token_falls_back_when_github_app_exchange_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     import gh_client
+    from unittest.mock import AsyncMock
 
     gh_client.clear_token_cache()
     monkeypatch.setenv("GITHUB_APP_ID", "12345")
@@ -105,10 +107,35 @@ def test_get_token_falls_back_when_github_app_exchange_fails(monkeypatch: pytest
     monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "fake-key")
     monkeypatch.setenv("GH_TOKEN", "fallback-token")
 
-    with patch.object(gh_client, "_fetch_github_app_installation_token", side_effect=RuntimeError("boom")):
-        assert gh_client._get_token() == "fallback-token"
+    with patch.object(gh_client, "_fetch_github_app_installation_token", AsyncMock(side_effect=RuntimeError("boom"))):
+        assert await gh_client._get_token_async() == "fallback-token"
 
-    assert gh_client.get_status()["auth_source"] == "env_token"
+
+async def test_concurrent_token_refresh_triggers_single_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #938c: a refresh storm dedupes to exactly one upstream exchange."""
+    import asyncio
+
+    import gh_client
+
+    gh_client.clear_token_cache()
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "67890")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "fake-key")
+
+    calls = 0
+
+    async def _slow_exchange() -> str:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)  # hold the lock so peers queue behind it
+        gh_client._cached_token_expires_at = gh_client.time.time() + 3600
+        return "installation-token"
+
+    monkeypatch.setattr(gh_client, "_fetch_github_app_installation_token", _slow_exchange)
+
+    results = await asyncio.gather(*[gh_client._get_token_async() for _ in range(10)])
+    assert results == ["installation-token"] * 10
+    assert calls == 1
     gh_client.clear_token_cache()
 
 
@@ -245,3 +272,97 @@ def test_gh_client_exports_rerun_failed() -> None:
     import gh_client
 
     assert callable(gh_client.rerun_failed)
+
+
+# ---------------------------------------------------------------------------
+# Issue #938: gh_client robustness (202 success, paginate rate-limit, async token)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, *, json_body=None, headers=None, text: str = "") -> None:
+        self.status_code = status_code
+        self._json = json_body if json_body is not None else {}
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self):
+        return self._json
+
+
+class _FakeClient:
+    """Minimal async httpx.AsyncClient stand-in returning queued responses."""
+
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = list(responses)
+        self.headers: dict[str, str] = {}
+        self.requests: list[tuple[str, str]] = []
+
+    async def request(self, method: str, path: str, **_kwargs) -> _FakeResponse:
+        self.requests.append((method, path))
+        return self._responses.pop(0)
+
+    async def get(self, url: str, **_kwargs) -> _FakeResponse:
+        self.requests.append(("GET", url))
+        return self._responses.pop(0)
+
+
+async def test_request_accepts_202_as_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #938a: 202 Accepted (e.g. cancel_run) is a success, not a server error."""
+    import gh_client
+
+    gh_client.clear_token_cache()
+    monkeypatch.setenv("GH_TOKEN", "t")
+    fake = _FakeClient([_FakeResponse(202, json_body={"ok": True})])
+    monkeypatch.setattr(gh_client, "_get_client", lambda: fake)
+
+    resp = await gh_client._request("POST", "/repos/x/y/actions/runs/1/cancel")
+    assert resp.status_code == 202
+    gh_client.clear_token_cache()
+
+
+async def test_paginate_raises_typed_rate_limited_on_primary_403(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #938b: a 403 + X-RateLimit-Remaining: 0 routes through _request.
+
+    Before #938b paginate only special-cased 429 and raised an opaque
+    GhServerError on a primary-rate-limit 403. Now it goes through _request, so
+    the caller gets the typed GhRateLimited (carrying retry_after) instead.
+    """
+    import gh_client
+
+    gh_client.clear_token_cache()
+    monkeypatch.setenv("GH_TOKEN", "t")
+
+    rate_limited = _FakeResponse(
+        403,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1"},
+        text="API rate limit exceeded",
+    )
+    fake = _FakeClient([rate_limited])
+    monkeypatch.setattr(gh_client, "_get_client", lambda: fake)
+
+    with pytest.raises(gh_client.GhRateLimited):
+        _ = [item async for item in gh_client.paginate("/orgs/x/actions/runners")]
+    gh_client.clear_token_cache()
+
+
+async def test_paginate_retries_transient_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #938b: a transient 5xx on a page retries (via _request) instead of aborting."""
+    import gh_client
+
+    gh_client.clear_token_cache()
+    monkeypatch.setenv("GH_TOKEN", "t")
+
+    server_err = _FakeResponse(503, headers={}, text="upstream hiccup")
+    ok = _FakeResponse(200, json_body=[{"id": 7}], headers={})
+    fake = _FakeClient([server_err, ok])
+    monkeypatch.setattr(gh_client, "_get_client", lambda: fake)
+
+    async def _no_sleep(_secs: float) -> None:
+        return None
+
+    monkeypatch.setattr(gh_client.asyncio, "sleep", _no_sleep)
+
+    items = [item async for item in gh_client.paginate("/orgs/x/actions/runners")]
+    assert items == [{"id": 7}]
+    gh_client.clear_token_cache()

--- a/tests/test_start_dashboard_script.py
+++ b/tests/test_start_dashboard_script.py
@@ -1,0 +1,54 @@
+"""CI guard: the documented Quick Start script is internally consistent (#945).
+
+A full clean-checkout smoke job (provision venv + npm build + curl /) is run in
+the deploy pipeline; these fast static checks fail in unit CI the moment the
+script regresses to the broken pre-#945 behaviour (wrong requirements path,
+silent fastapi+uvicorn fallback, or no frontend build).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "start-dashboard.sh"
+
+
+def _script_text() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), "start-dashboard.sh missing"
+
+
+def test_requirements_points_at_repo_root_not_backend() -> None:
+    text = _script_text()
+    # The deps live in the repo-root requirements.txt; backend/requirements.txt
+    # never existed (the #945 bug).
+    assert "BACKEND_DIR}/requirements.txt" not in text
+    assert 'REQUIREMENTS_FILE="${SCRIPT_DIR}/requirements.txt"' in text
+    assert (REPO_ROOT / "requirements.txt").is_file()
+    assert not (REPO_ROOT / "backend" / "requirements.txt").exists()
+
+
+def test_no_silent_fastapi_only_fallback() -> None:
+    text = _script_text()
+    # The old fallback `pip install fastapi 'uvicorn[standard]'` silently
+    # produced a server that crashed on `import httpx/psutil/yaml`.
+    assert "pip install fastapi" not in text
+    # Missing requirements must fail loudly.
+    assert "requirements file not found" in text
+
+
+def test_script_builds_or_demands_frontend_bundle() -> None:
+    text = _script_text()
+    # The backend serves the SPA from frontend/dist/; the script must build it
+    # (or fail with instructions) so Quick Start yields a working app.
+    assert "dist" in text and "npm run build" in text
+
+
+def test_no_backend_requirements_reference_in_docs() -> None:
+    for doc in ("README.md", "CLAUDE.md"):
+        text = (REPO_ROOT / doc).read_text(encoding="utf-8")
+        assert "backend/requirements.txt" not in text, f"{doc} still references the phantom backend/requirements.txt"


### PR DESCRIPTION
Two correctness clusters from the 2026-06-12 professional-grade audit.

Closes #938
Refs #945

## #945 - Quick Start did not produce a working app
- `start-dashboard.sh` installed from a phantom `backend/requirements.txt`; on miss it silently fell back to `pip install fastapi uvicorn`, so `server.py` died on `import httpx/psutil/yaml`. It now installs from the repo-root `requirements.txt` and **fails loudly** (exit 1) if that file is absent.
- The backend serves the SPA from gitignored `frontend/dist/`; a clean checkout lacked it and served the "index.html not found" fallback. The script now builds it via `npm ci && npm run build` (or exits non-zero with instructions).
- README documents the Node/npm requirement; `tests/test_start_dashboard_script.py` guards against regressing the requirements path, the silent fallback, and the missing frontend build.

## #938 - gh_client.py robustness
- **(a)** `_request` accepts any `2xx` as success, so GitHub's `202 Accepted` (e.g. `cancel_run`) is no longer reported as a `GhServerError`.
- **(b)** `paginate` routes each page through `_request`, so a primary-rate-limit `403` (`X-RateLimit-Remaining: 0`) raises the typed `GhRateLimited` and transient `5xx` retry/backoff applies; previously it only special-cased `429` and aborted on a `403`/`5xx`.
- **(c)** the GitHub App installation-token exchange is now async (`httpx.AsyncClient`) under an `asyncio.Lock`: it no longer blocks the event loop hourly on refresh, and a refresh storm dedupes to exactly one upstream exchange. The sync `_get_token` keeps the env-token path; the request path uses `_get_token_async`.

## Tests
`tests/test_gh_client.py` (202 success, paginate 403/5xx, async App token, concurrent-refresh dedupe), `tests/test_start_dashboard_script.py`. Full suite (2797 passed) run locally; `ruff check backend/` + `mypy backend/` clean.

After merge, close #945 manually because this PR also fixes the clean-checkout Quick Start path.
