### PR TITLE
fix(orchestrator): route Conductor capacity gate through shared runners cache

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,17 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.158
+**Spec Version:** 2.5.159
 **Application Version:** 4.9.17 (see `VERSION`)
-**Last Updated:** 2026-06-15T20:35:00-07:00
+**Last Updated:** 2026-06-16T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-16 (2.5.159):** Routed the Conductor admission gate's capacity
+  provider through the shared `runners` cache via a new
+  `gh_utils.get_cached_org_runners` helper (also adopted by the GitHub health
+  summary), so each admission decision reuses one GitHub round-trip per
+  `CacheTtl.RUNNERS_S` window instead of issuing an uncached call on every
+  Conductor poll. Corrected the stale "cached upstream" comment on
+  `_orchestrator_capacity_provider`.
 - **2026-06-15 (2.5.158):** Stabilized FIFO session-eviction coverage after
   the post-merge `main` CI run exposed another wall-clock-sensitive session
   test. Session record defaults now use the module clock helper, and the FIFO

--- a/backend/gh_utils.py
+++ b/backend/gh_utils.py
@@ -12,6 +12,7 @@ from hashlib import sha256
 
 from cache_utils import cache_get, cache_set
 from dashboard_config import DEPLOYMENT_FILE, HOSTNAME, VERSION
+from dashboard_config.cache_ttls import CacheTtl
 from fastapi import HTTPException
 from system_utils import BOOT_TIME, get_deployment_info, run_cmd
 
@@ -205,6 +206,28 @@ async def gh_api(endpoint: str) -> dict:
 gh_api_admin = gh_api
 
 
+async def get_cached_org_runners(org: str) -> dict:
+    """Return the org's self-hosted runners, reusing the shared ``runners`` cache.
+
+    Single source of truth for "the current runner inventory" so every
+    caller — the runners list, the health summary, and the Conductor admission
+    gate — shares one GitHub round-trip per ``CacheTtl.RUNNERS_S`` window
+    instead of each issuing its own uncached call (DRY; bounds rate-limit
+    pressure under Conductor polling).
+
+    Postcondition: always returns a dict (``{}`` on a cache miss that also
+    failed upstream is the caller's concern; this raises on fetch failure so
+    callers can degrade explicitly).
+    """
+    from runner_inventory import fetch_org_runners  # noqa: PLC0415 — avoid import cycle
+
+    data = cache_get("runners", float(CacheTtl.RUNNERS_S))
+    if data is None:
+        data = await fetch_org_runners(gh_api_admin, org)
+        cache_set("runners", data)
+    return data or {}
+
+
 async def gh_api_raw(endpoint: str) -> str:
     """Call the GitHub API via gh CLI and return the raw body text."""
     code, stdout, stderr = await run_cmd(["gh", "api", "-H", "Accept: application/vnd.github.raw", endpoint])
@@ -216,13 +239,8 @@ async def gh_api_raw(endpoint: str) -> str:
 async def get_gh_health_summary(org: str) -> dict:
     """Core health logic for GitHub runners and dashboard state."""
     try:
-        from runner_inventory import fetch_org_runners  # noqa: PLC0415
-
-        # Reuse the runner cache so health checks don't add extra API calls.
-        data = cache_get("runners", 25.0)
-        if data is None:
-            data = await fetch_org_runners(gh_api_admin, org)
-            cache_set("runners", data)
+        # Reuse the shared runner cache so health checks add no extra API calls.
+        data = await get_cached_org_runners(org)
         gh_ok = True
         runner_count = len(data.get("runners", []))
     except Exception as exc:  # noqa: BLE001

--- a/backend/server.py
+++ b/backend/server.py
@@ -2382,15 +2382,16 @@ _system_router.set_runner_capacity_snapshot_func(get_runner_capacity_snapshot)
 
 # Conductor admission gate (issue #1282): wire the orchestrator capacity
 # provider to the SAME runner-counting logic as /api/runners/fleet/capacity
-# (DRY via routers.runner_helpers.count_runner_capacity). Synchronous wrapper
-# so the in-process lease lock stays simple; the gh call is cached upstream.
+# (DRY via routers.runner_helpers.count_runner_capacity). Reads the runner
+# inventory through the shared ``runners`` cache so each admission decision
+# reuses one GitHub round-trip per CacheTtl.RUNNERS_S window instead of issuing
+# an uncached call on every Conductor poll.
 async def _orchestrator_capacity_provider() -> dict[str, int]:
-    from gh_utils import gh_api_admin  # noqa: PLC0415
+    from gh_utils import get_cached_org_runners  # noqa: PLC0415
     from routers.runner_helpers import count_runner_capacity  # noqa: PLC0415
-    from runner_inventory import fetch_org_runners  # noqa: PLC0415
 
     try:
-        data = await fetch_org_runners(gh_api_admin, ORG)
+        data = await get_cached_org_runners(ORG)
         runners = (data or {}).get("runners", []) or []
         return count_runner_capacity(runners)
     except Exception as exc:  # noqa: BLE001 — fail safe: report zero capacity

--- a/tests/api/test_orchestrator_capacity_cache.py
+++ b/tests/api/test_orchestrator_capacity_cache.py
@@ -1,0 +1,62 @@
+"""The shared cached-runners helper backs the Conductor capacity gate.
+
+Regression coverage for the admission gate hitting GitHub uncached on every
+poll (issue: orchestrator capacity provider bypassed the shared ``runners``
+cache). ``gh_utils.get_cached_org_runners`` is now the single source of truth
+for the runner inventory, reused by the runners list, the health summary, and
+the Conductor capacity provider.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_runner_cache() -> object:
+    import cache_utils
+
+    cache_utils.cache_clear()
+    yield
+    cache_utils.cache_clear()
+
+
+def test_warm_cache_skips_upstream_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    import cache_utils
+    import gh_utils
+
+    cache_utils.cache_set("runners", {"runners": [{"status": "online"}], "total_count": 1})
+
+    calls = {"n": 0}
+
+    async def _should_not_be_called(*_args: object, **_kwargs: object) -> dict:
+        calls["n"] += 1
+        return {"runners": []}
+
+    monkeypatch.setattr("runner_inventory.fetch_org_runners", _should_not_be_called)
+
+    data = asyncio.run(gh_utils.get_cached_org_runners("D-sorganization"))
+
+    assert data["total_count"] == 1
+    assert calls["n"] == 0  # warm cache → zero upstream GitHub calls
+
+
+def test_cold_cache_fetches_once_then_serves_from_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    import gh_utils
+
+    calls = {"n": 0}
+
+    async def _fetch(*_args: object, **_kwargs: object) -> dict:
+        calls["n"] += 1
+        return {"runners": [{"status": "idle"}], "total_count": 1}
+
+    monkeypatch.setattr("runner_inventory.fetch_org_runners", _fetch)
+
+    first = asyncio.run(gh_utils.get_cached_org_runners("D-sorganization"))
+    second = asyncio.run(gh_utils.get_cached_org_runners("D-sorganization"))
+
+    assert first["total_count"] == 1
+    assert second["total_count"] == 1
+    assert calls["n"] == 1  # second call is served from the shared cache


### PR DESCRIPTION
## Problem

The Conductor admission gate (`_orchestrator_capacity_provider`) called `fetch_org_runners` directly on every poll, despite a comment claiming the gh call was "cached upstream." So each `/api/orchestrator/lease`, `/queue` GET, and `/queue` POST issued an **uncached** GitHub round-trip — steady rate-limit pressure once the Conductor polls the gate on every dispatch decision. (Found in a review of the Conductor implementation.)

## Fix

- Add `gh_utils.get_cached_org_runners(org)` — the single cached source of the runner inventory, reusing the shared `runners` cache (`CacheTtl.RUNNERS_S`).
- Use it in the orchestrator capacity provider **and** the GitHub health summary (DRY — removes the duplicated `cache_get`/fetch/`cache_set` pattern).
- Correct the misleading "cached upstream" comment.

## Tests

`tests/api/test_orchestrator_capacity_cache.py`: warm cache skips the upstream fetch; cold cache fetches once then serves from cache. Full local run: ruff + ruff-format + mypy clean; orchestrator + cache tests green (17 passed).

No behavior change to the admission decision itself — only where the runner inventory comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
