### PR TITLE
fix(fleet): make /api/fleet/status resilient to unreachable nodes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,17 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.159
+**Spec Version:** 2.5.160
 **Application Version:** 4.9.17 (see `VERSION`)
-**Last Updated:** 2026-06-16T00:00:00-07:00
+**Last Updated:** 2026-06-16T00:10:00-07:00
 **Status:** Active
 
+- **2026-06-16 (2.5.160):** Made `/api/fleet/status` resilient to unreachable
+  fleet nodes. Peer pools are now fetched concurrently (`asyncio.gather`)
+  instead of in a sequential loop, and cross-node probes use a connect-capped
+  `httpx.Timeout` (`HttpTimeout.NODE_CONNECT_S`) so a black-holed node fails in
+  ~5 s on the handshake instead of consuming the full 30 s read budget — the
+  endpoint no longer stalls to ~30 s when any node is offline. Extracted
+  `_fetch_peer_pool` / `_node_probe_timeout` helpers.
 - **2026-06-16 (2.5.159):** Routed the Conductor admission gate's capacity
   provider through the shared `runners` cache via a new
   `gh_utils.get_cached_org_runners` helper (also adopted by the GitHub health

--- a/backend/dashboard_config/timeouts.py
+++ b/backend/dashboard_config/timeouts.py
@@ -34,6 +34,14 @@ class HttpTimeout:
     # a larger budget here and keep the gather fan-out independent per node.
     PROXY_NODE_SYSTEM_S: float = 30.0
 
+    # Connect budget for cross-node probes. A black-holed peer (firewall drop,
+    # no RST) otherwise consumes the full PROXY_NODE_SYSTEM_S read budget just
+    # waiting for a TCP handshake, which stalled /api/fleet/status to ~30 s
+    # whenever any node was unreachable. Capping connect lets an unreachable
+    # node fail in NODE_CONNECT_S while a slow-but-alive node keeps the full
+    # read budget. A healthy tailnet handshake is sub-second.
+    NODE_CONNECT_S: float = 5.0
+
     # Hub-bound proxies and the default ``gh api`` budget. 15 s tolerates
     # GitHub API tail latency without holding workers too long.
     PROXY_TO_HUB_S: float = 15.0

--- a/backend/routers/fleet.py
+++ b/backend/routers/fleet.py
@@ -114,6 +114,40 @@ async def _fleet_control_local(action: str) -> dict:
 # Runner control routes are defined in routers/runners.py
 
 
+def _node_probe_timeout() -> httpx.Timeout:
+    """Bounded HTTP timeout for cross-node fleet probes.
+
+    Caps the TCP connect phase at ``NODE_CONNECT_S`` so a black-holed node
+    (firewall drop, no RST) fails fast instead of consuming the full
+    ``PROXY_NODE_SYSTEM_S`` read budget on the handshake, while a slow-but-alive
+    node keeps that full read budget.
+    """
+    return httpx.Timeout(HttpTimeout.PROXY_NODE_SYSTEM_S, connect=HttpTimeout.NODE_CONNECT_S)
+
+
+async def _fetch_peer_pool(peer: dict) -> dict[str, dict]:
+    """Fetch one peer pool's fleet status, classifying it offline on failure.
+
+    Returns a ``{node_name: metrics}`` mapping to merge into the aggregate
+    response. Independent per peer (no shared state) so callers can ``gather``
+    them concurrently; an unreachable peer resolves to a single offline entry
+    rather than raising.
+    """
+    peer_pool_name = peer["name"]
+    peer_url = f"{peer['url']}/api/fleet/status?exclude_pools=true"
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(peer_url, timeout=_node_probe_timeout())
+            if resp.status_code == 200:
+                return dict(resp.json())
+            reason = classify_node_offline(status_code=resp.status_code)
+            return {peer_pool_name: {"status": "offline", "error": reason["offline_detail"], **reason}}
+    except Exception as e:  # noqa: BLE001 — any failure means the peer is offline
+        log.warning("Failed to query peer pool %s at %s: %s", peer_pool_name, peer_url, e)
+        reason = classify_node_offline(e)
+        return {peer_pool_name: {"status": "offline", "error": reason["offline_detail"], **reason}}
+
+
 @router.get("/api/fleet/status", dependencies=[Depends(require_fleet_peer)])
 async def get_fleet_status(request: Request, response: Response, exclude_pools: bool = False):
     """Get full system metrics state for all machines in the fleet network.
@@ -151,7 +185,7 @@ async def get_fleet_status(request: Request, response: Response, exclude_pools: 
         try:
             async with httpx.AsyncClient() as client:
                 target = f"{url}/api/system"
-                resp = await client.get(target, timeout=HttpTimeout.PROXY_NODE_SYSTEM_S)
+                resp = await client.get(target, timeout=_node_probe_timeout())
                 if resp.status_code == 200:
                     data = resp.json()
                     data["_role"] = "node"
@@ -179,32 +213,13 @@ async def get_fleet_status(request: Request, response: Response, exclude_pools: 
         for name, data in results:
             responses[name] = data
 
-    if not exclude_pools:
-        for peer in peer_pools:
-            peer_pool_name = peer["name"]
-            peer_url = f"{peer['url']}/api/fleet/status?exclude_pools=true"
-            try:
-                async with httpx.AsyncClient() as client:
-                    resp = await client.get(peer_url, timeout=HttpTimeout.PROXY_NODE_SYSTEM_S)
-                    if resp.status_code == 200:
-                        peer_data = resp.json()
-                        for k, v in peer_data.items():
-                            responses[k] = v
-                    else:
-                        reason = classify_node_offline(status_code=resp.status_code)
-                        responses[peer_pool_name] = {
-                            "status": "offline",
-                            "error": reason["offline_detail"],
-                            **reason,
-                        }
-            except Exception as e:
-                log.warning("Failed to query peer pool %s at %s: %s", peer_pool_name, peer_url, e)
-                reason = classify_node_offline(e)
-                responses[peer_pool_name] = {
-                    "status": "offline",
-                    "error": reason["offline_detail"],
-                    **reason,
-                }
+    if not exclude_pools and peer_pools:
+        # Fan out to peer pools concurrently. The previous sequential loop let a
+        # single unreachable pool stall the whole response for its full connect
+        # budget; gather collapses N peer timeouts into one wall-clock window.
+        peer_results = await asyncio.gather(*[_fetch_peer_pool(peer) for peer in peer_pools])
+        for updates in peer_results:
+            responses.update(updates)
 
     _record_fleet_events(responses)
     if degraded_by_hub_circuit:

--- a/tests/api/test_fleet_status_peer_concurrency.py
+++ b/tests/api/test_fleet_status_peer_concurrency.py
@@ -1,0 +1,104 @@
+"""Regression: /api/fleet/status probes peers concurrently with a bounded connect.
+
+A single unreachable peer pool used to stall the whole endpoint for its full
+30 s read budget because the peer loop was sequential and the connect phase was
+unbounded. These tests pin the two fixes: a connect-capped timeout and a
+concurrent (gather) peer fan-out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import routers.fleet as fleet  # noqa: E402
+from dashboard_config import HttpTimeout  # noqa: E402
+
+
+def test_node_probe_timeout_caps_connect() -> None:
+    timeout = fleet._node_probe_timeout()
+    assert timeout.connect == HttpTimeout.NODE_CONNECT_S
+    assert timeout.read == HttpTimeout.PROXY_NODE_SYSTEM_S
+    # Dead hosts fail fast on connect; slow-but-alive hosts keep the read budget.
+    assert timeout.connect < timeout.read
+
+
+@pytest.mark.asyncio
+async def test_fetch_peer_pool_classifies_unreachable_as_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom:
+        async def __aenter__(self) -> _Boom:
+            return self
+
+        async def __aexit__(self, *_a: object) -> bool:
+            return False
+
+        async def get(self, *_a: object, **_k: object) -> object:
+            raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(fleet.httpx, "AsyncClient", lambda *_a, **_k: _Boom())
+
+    result = await fleet._fetch_peer_pool({"name": "DeskComputer", "url": "http://dead:8321"})
+
+    assert result["DeskComputer"]["status"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_fleet_status_queries_peer_pools_concurrently(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A barrier of 2 only releases once BOTH peer fetches are in-flight. The old
+    # sequential loop would start peer A, block here forever (B never starts),
+    # and time out; the gather-based fan-out lets both arrive and complete.
+    barrier = asyncio.Barrier(2)
+
+    class _Gated:
+        async def __aenter__(self) -> _Gated:
+            return self
+
+        async def __aexit__(self, *_a: object) -> bool:
+            return False
+
+        async def get(self, *_a: object, **_k: object) -> object:
+            await barrier.wait()
+
+            class _Resp:
+                status_code = 200
+
+                def json(self) -> dict:
+                    return {}
+
+            return _Resp()
+
+    monkeypatch.setattr(fleet.httpx, "AsyncClient", lambda *_a, **_k: _Gated())
+    monkeypatch.setattr(fleet, "should_proxy_fleet_to_hub", lambda _r: False)
+    monkeypatch.setattr(fleet, "should_mark_hub_circuit_degraded", lambda _r: False)
+
+    async def _metrics() -> dict:
+        return {"hostname": "local"}
+
+    monkeypatch.setattr(fleet, "get_system_metrics_snapshot", _metrics)
+    monkeypatch.setattr(fleet, "load_machine_registry", lambda: {})
+    monkeypatch.setattr(
+        fleet,
+        "derive_pool_topology",
+        lambda *_a, **_k: (
+            None,
+            [{"name": "A", "url": "http://a:8321"}, {"name": "B", "url": "http://b:8321"}],
+        ),
+    )
+    monkeypatch.setattr(fleet, "FLEET_NODES", {})
+    monkeypatch.setattr(fleet, "_record_fleet_events", lambda _r: None)
+
+    from fastapi import Response
+
+    class _Req:
+        pass
+
+    # Completes only if the two peers run concurrently; otherwise wait_for fires.
+    await asyncio.wait_for(fleet.get_fleet_status(_Req(), Response()), timeout=3.0)


### PR DESCRIPTION
## Problem

`/api/fleet/status` (an overview endpoint) could take ~30 s whenever a single fleet node was unreachable. Two causes:
1. The peer-pool fan-out was a **sequential** loop — each unreachable peer blocked the full timeout before the next was tried.
2. Cross-node probes used a single 30 s timeout with **no connect cap**, so a black-holed node (firewall drop, no RST) consumed the entire read budget just waiting for the TCP handshake.

Observed live: `/api/fleet/status` → HTTP 200 in **34 s** while every other overview endpoint was <5 ms.

## Fix

- Fetch peer pools **concurrently** via `asyncio.gather` (extracted `_fetch_peer_pool`), mirroring the existing node fan-out — collapses N sequential peer timeouts into one wall-clock window.
- Cap the connect phase: `httpx.Timeout(read=PROXY_NODE_SYSTEM_S, connect=NODE_CONNECT_S=5s)` for node and peer probes. A dead node now fails in ~5 s on connect; a slow-but-alive node keeps the full 30 s read budget.

## Tests

`tests/api/test_fleet_status_peer_concurrency.py`: the connect cap is below the read budget; an unreachable peer is classified offline; and a deterministic `asyncio.Barrier(2)` proves the two peers are fetched concurrently (a sequential loop would deadlock the barrier and time out). ruff + mypy clean; fleet tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
