### PR TITLE
chore(deploy): seed DASHBOARD_LOOPBACK_AUTH for local operator access

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -276,6 +276,19 @@ else
     warn "(The refresh-token.sh script will pick it up automatically on restart)"
 fi
 
+# Seed loopback operator auth (issue #924 fail-closed perimeter).
+# The dashboard is a local operator console reached at http://localhost:8321;
+# without this flag every /api/* request from the local browser is rejected with
+# 401 "Authentication required" once the perimeter is active. Only loopback
+# (127.0.0.1) callers are granted the admin principal — the service binds
+# 0.0.0.0 but network/tailnet peers still require a real service token or
+# session, so seeding this default is safe. Respect an explicit operator choice:
+# only seed when the key is absent, never override an existing value.
+if ! grep -qE '^DASHBOARD_LOOPBACK_AUTH=' "${SECRETS_FILE}"; then
+    printf 'DASHBOARD_LOOPBACK_AUTH=1\n' >> "${SECRETS_FILE}"
+    ok "DASHBOARD_LOOPBACK_AUTH=1 seeded (local operator access via loopback)"
+fi
+
 # Append FLEET_NODES to secrets file if provided
 if [[ -n "$FLEET_NODES_VAL" ]]; then
     # Remove existing FLEET_NODES line, then re-add


### PR DESCRIPTION
## Problem

The fail-closed auth perimeter (issue #924) rejects every `/api/*` request from the local browser with `401 "Authentication required"` unless the loopback admin principal is enabled via `DASHBOARD_LOOPBACK_AUTH=1`. A fresh deploy never seeded that flag, so the dashboard came up unusable on `localhost` — the symptom was the overview showing **"failed to load overview data — HTTP 401"**.

## Fix

`deploy/setup.sh` now seeds `DASHBOARD_LOOPBACK_AUTH=1` into the secrets `EnvironmentFile` when the key is absent.

**Safety:** only loopback (`127.0.0.1`) callers are granted the admin principal. The service binds `0.0.0.0`, but network/tailnet peers still require a real service token or session — so seeding this default does not widen remote access. An explicit operator value is preserved (seeded only when unset).

This codifies the live remediation already applied to ControlTower so a redeploy cannot reintroduce the 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
