### PR TITLE
fix(auth): exempt read-only fleet-telemetry endpoints from the #924 perimeter

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,18 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.161
+**Spec Version:** 2.5.162
 **Application Version:** 4.9.17 (see `VERSION`)
-**Last Updated:** 2026-06-16T01:00:00-07:00
+**Last Updated:** 2026-06-17T00:00:00-07:00
 **Status:** Active
 
+- **2026-06-17 (2.5.162):** Exempted the read-only fleet-telemetry endpoints
+  `/api/system` and `/api/fleet/status` from the #924 structural auth perimeter.
+  The hub's fleet fan-out (`fetch_node` → `/api/system`; peer pools →
+  `/api/fleet/status`) presents no operator principal, so the perimeter 401-ed
+  every node once it moved to >=4.9 code, marking the whole fleet offline. These
+  are tailnet-scoped GET metrics already intended as tailnet-public fleet reads
+  (`require_fleet_peer`); `/api/fleet/status` keeps its own `require_fleet_peer`
+  dependency. Restores hub→node fleet status across the fleet.
 - **2026-06-16 (2.5.161):** Fixed the DeskComputer node `dashboard_url` in
   `machine_registry.yml` to its MagicDNS name
   (`http://deskcomputer.tail2bbcc7.ts.net:8321`) instead of the raw tailnet IP.

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -109,6 +109,17 @@ _AUTH_EXEMPT_PATHS = {
     "/",
     "/health",
     "/api/health",
+    # Read-only fleet telemetry consumed hub→node over the Tailscale mesh. The
+    # hub's fleet fan-out (`routers.fleet.fetch_node` → GET `/api/system`, and
+    # peer-pool GET `/api/fleet/status`) presents no operator principal, and the
+    # fleet model already treats these as tailnet-public reads (see
+    # `require_fleet_peer` (#922): "fleet reads remain tailnet-public" when no
+    # HUB_FLEET_TOKEN is set). The #924 structural perimeter over-blocked them,
+    # 401-ing every >=4.9 node so the hub marked the whole fleet offline. These
+    # are GET-only system metrics on a private tailnet; `/api/fleet/status` also
+    # keeps its own `require_fleet_peer` route dependency.
+    "/api/system",
+    "/api/fleet/status",
     "/manifest.webmanifest",
     "/icon.svg",
     "/api/auth/github",

--- a/tests/api/test_structural_auth_perimeter.py
+++ b/tests/api/test_structural_auth_perimeter.py
@@ -188,3 +188,27 @@ def test_dependency_override_defers_to_route(_no_loopback_bypass) -> None:
         assert resp.status_code != 401
     finally:
         server.app.dependency_overrides.clear()
+
+
+def test_fleet_read_endpoints_are_exempt() -> None:
+    """Hub→node fleet telemetry reads must not be force-401'd by the perimeter.
+
+    The hub fans out to `{node}/api/system` (and peer pools to
+    `/api/fleet/status`) with no operator principal; these are tailnet-scoped
+    read-only metrics. Regression guard for the whole fleet showing offline-401
+    after every node moved to >=4.9 code.
+    """
+    assert is_auth_exempt("/api/system")
+    assert is_auth_exempt("/api/fleet/status")
+
+
+def test_fleet_status_keeps_its_own_fleet_peer_dependency() -> None:
+    """Exempting `/api/fleet/status` from the structural perimeter must not strip
+    its dedicated `require_fleet_peer` auth — it stays governed by the fleet
+    model, just not by the operator-principal perimeter."""
+    routes = [r for r in server.app.routes if getattr(r, "path", None) == "/api/fleet/status"]
+    assert routes, "/api/fleet/status route not found"
+    names: set[str] = set()
+    for r in routes:
+        names |= _dependency_callable_names(r)
+    assert "require_fleet_peer" in names


### PR DESCRIPTION
## Problem

The #924 structural auth perimeter force-401s every non-exempt `/api/*` request that does not resolve an operator principal. But the **hub reads node telemetry over the tailnet** via `fetch_node` → `GET /api/system` (and peer pools → `GET /api/fleet/status`) with **no operator principal** — so the perimeter 401-ed every node once it moved to ≥4.9 code, and **the hub marked the entire fleet offline**.

Observed live: `ControlTower-SSD` and `DeskComputer` both showed `offline | 401 Unauthorized` in the hub fleet view. Confirmed: `curl /api/system` **on** a node = 200; via the hub/tailscale-serve path = 401.

## Fix

Add `/api/system` and `/api/fleet/status` to `_AUTH_EXEMPT_PATHS`. These are **tailnet-scoped, read-only system metrics** that the fleet model already treats as tailnet-public (`require_fleet_peer` #922: *"fleet reads remain tailnet-public"* when no `HUB_FLEET_TOKEN`). The #924 perimeter over-blocked them. `/api/fleet/status` **keeps its own `require_fleet_peer` dependency** (asserted by a test), so it stays governed by the fleet model — just not by the operator-principal perimeter.

## Tests

- `test_fleet_read_endpoints_are_exempt` — both endpoints are `is_auth_exempt`.
- `test_fleet_status_keeps_its_own_fleet_peer_dependency` — exempting it did not strip `require_fleet_peer`.
- Full structural-perimeter suite: **12 passing**. ruff clean.

## Impact

Restores hub→node fleet status across the fleet. Once merged + redeployed by node automation, ControlTower-SSD comes back online and the temporary middleware hotfix currently on DeskComputer becomes permanent. **Security note:** this only exposes GET-only system metrics on the private tailnet (consistent with `/health` being exempt); no operator/mutating routes are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
