### PR TITLE
fix(config): tolerate missing REPO_ROOT/VERSION at import

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -378,28 +378,28 @@
         "filename": "tests\\test_dashboard_config.py",
         "hashed_secret": "02c173fc064db3d5d36ffbea6e3d09a6ca93ae45",
         "is_verified": false,
-        "line_number": 360
+        "line_number": 389
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_dashboard_config.py",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 365
+        "line_number": 394
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_dashboard_config.py",
         "hashed_secret": "67bd5810ec8162548419905bc9769ccf95fe3a1f",
         "is_verified": false,
-        "line_number": 376
+        "line_number": 405
       },
       {
         "type": "Secret Keyword",
         "filename": "tests\\test_dashboard_config.py",
         "hashed_secret": "9c9c2851a11f00c5ae73b5d4f45b10f104868644",
         "is_verified": false,
-        "line_number": 399
+        "line_number": 428
       }
     ],
     "tests\\test_envelope_signing.py": [
@@ -576,5 +576,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-14T19:21:08Z"
+  "generated_at": "2026-06-18T03:26:37Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.9.18] - 2026-06-17
+
+### Fixed
+
+- `_read_repo_version()` no longer crashes the dashboard at import when
+  `REPO_ROOT/VERSION` is missing. `REPO_ROOT` is operator-overridable via
+  `RUNNER_DASHBOARD_REPO_ROOT` and on some deploys points at a sibling repo
+  (e.g. `Repository_Management`) that has no `VERSION` file. The reader now
+  falls back to the deployed backend's own `BACKEND_DIR.parent/VERSION` and
+  finally to `"0.0.0"` when neither file exists. A `VERSION` file that exists
+  but is malformed still raises, so a genuinely bad version is never silently
+  accepted.
+
 ## [4.9.17] - 2026-06-15
 
 ### Changed

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.162
-**Application Version:** 4.9.17 (see `VERSION`)
+**Spec Version:** 2.5.163
+**Application Version:** 4.9.18 (see `VERSION`)
 **Last Updated:** 2026-06-17T00:00:00-07:00
 **Status:** Active
 
@@ -2556,6 +2556,16 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 ---
 
 ## 7. Changelog
+
+### 2.5.163 - 2026-06-17
+
+- fix(config): `_read_repo_version()` no longer crashes the dashboard at import
+  when `REPO_ROOT/VERSION` is missing. `REPO_ROOT` is operator-overridable via
+  `RUNNER_DASHBOARD_REPO_ROOT` and on some deploys points at a sibling repo
+  (e.g. `Repository_Management`) with no `VERSION` file; the reader now falls
+  back to the deployed backend's own `BACKEND_DIR.parent/VERSION` and finally to
+  `"0.0.0"` when neither file exists. A `VERSION` file that exists but is
+  malformed still raises, so a genuinely bad version is never silently accepted.
 
 ### 2.5.26 - 2026-05-21
 

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.17
+4.9.18

--- a/backend/dashboard_config/__init__.py
+++ b/backend/dashboard_config/__init__.py
@@ -175,15 +175,34 @@ def runner_scheduler_apply_command() -> list[str]:
 
 
 def _read_repo_version(version_path: Path = REPO_ROOT / "VERSION") -> str:
-    """Return the first semver entry from the repository VERSION file."""
-    for raw_line in version_path.read_text(encoding="utf-8").splitlines():
-        candidate = raw_line.strip()
-        if not candidate or candidate.startswith("#"):
+    """Return the first semver entry from the repository VERSION file.
+
+    ``REPO_ROOT`` is operator-overridable via ``RUNNER_DASHBOARD_REPO_ROOT`` and
+    on some deploys points at a sibling repo (e.g. Repository_Management, used by
+    the agent launcher) that has no ``VERSION`` file. Rather than crash the whole
+    dashboard at import, fall back to the deployed backend's own
+    ``BACKEND_DIR.parent / "VERSION"`` and finally to ``"0.0.0"`` when neither
+    file exists. A file that *exists* but is malformed still raises, so a
+    genuinely bad version is never silently accepted.
+    """
+    candidates: list[Path] = [version_path]
+    fallback = BACKEND_DIR.parent / "VERSION"
+    if fallback != version_path:
+        candidates.append(fallback)
+    for path in candidates:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
             continue
-        if re.fullmatch(r"\d+\.\d+\.\d+", candidate):
-            return candidate
-        break
-    raise RuntimeError(f"{version_path} must contain a MAJOR.MINOR.PATCH version")
+        for raw_line in text.splitlines():
+            candidate = raw_line.strip()
+            if not candidate or candidate.startswith("#"):
+                continue
+            if re.fullmatch(r"\d+\.\d+\.\d+", candidate):
+                return candidate
+            break
+        raise RuntimeError(f"{path} must contain a MAJOR.MINOR.PATCH version")
+    return "0.0.0"
 
 
 # Deployment

--- a/frontend/src/lib/openapi.json
+++ b/frontend/src/lib/openapi.json
@@ -1147,7 +1147,7 @@
   "info": {
     "description": "Monitor and control self-hosted GitHub Actions runners",
     "title": "D-sorganization Runner Dashboard",
-    "version": "4.9.17"
+    "version": "4.9.18"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runner-dashboard",
-  "version": "4.9.17",
+  "version": "4.9.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runner-dashboard",
-      "version": "4.9.17",
+      "version": "4.9.18",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
         "@tanstack/react-query": "^5.100.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner-dashboard",
   "private": true,
-  "version": "4.9.17",
+  "version": "4.9.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runner-dashboard"
-version = "4.9.17"
+version = "4.9.18"
 description = "Runner dashboard for fleet management"
 requires-python = ">=3.11,<3.14"
 dependencies = [

--- a/tests/test_dashboard_config.py
+++ b/tests/test_dashboard_config.py
@@ -5,6 +5,7 @@ import os  # noqa: E402
 from pathlib import Path  # noqa: E402
 
 import dashboard_config  # noqa: E402
+import pytest  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -314,6 +315,34 @@ def test_version() -> None:
         if line.strip() and not line.startswith("#")
     )
     assert dashboard_config.VERSION == expected
+
+
+def test_read_repo_version_missing_primary_falls_back_to_backend(tmp_path: Path) -> None:
+    """A missing REPO_ROOT/VERSION falls back to the deployed backend's VERSION.
+
+    ``REPO_ROOT`` is operator-overridable via ``RUNNER_DASHBOARD_REPO_ROOT`` and
+    on some deploys points at a sibling repo (e.g. Repository_Management) with
+    no VERSION file. The dashboard must not crash at import in that case.
+    """
+    importlib.reload(dashboard_config)
+    missing = tmp_path / "no-such-repo" / "VERSION"
+    # backend/../VERSION exists in this checkout, so the fallback resolves it.
+    assert dashboard_config._read_repo_version(missing) == dashboard_config.VERSION
+
+
+def test_read_repo_version_all_missing_returns_safe_default(monkeypatch, tmp_path: Path) -> None:
+    """When neither the primary nor the backend fallback exists, return 0.0.0."""
+    monkeypatch.setattr(dashboard_config, "BACKEND_DIR", tmp_path / "backend")
+    missing = tmp_path / "elsewhere" / "VERSION"
+    assert dashboard_config._read_repo_version(missing) == "0.0.0"
+
+
+def test_read_repo_version_malformed_file_still_raises(tmp_path: Path) -> None:
+    """A VERSION file that exists but is malformed is a hard error, not 0.0.0."""
+    bad = tmp_path / "VERSION"
+    bad.write_text("not-a-semver\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="MAJOR.MINOR.PATCH"):
+        dashboard_config._read_repo_version(bad)
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1041,7 +1041,7 @@ wheels = [
 
 [[package]]
 name = "runner-dashboard"
-version = "4.9.17"
+version = "4.9.18"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Problem

`dashboard_config._read_repo_version()` runs at **import time** (`VERSION = _read_repo_version()`) and raised an unguarded `FileNotFoundError` when `REPO_ROOT/VERSION` was absent. `REPO_ROOT` is operator-overridable via `RUNNER_DASHBOARD_REPO_ROOT`, and on some fleet deploys it points at a sibling repo (e.g. `Repository_Management`, used by the agent launcher) that has **no `VERSION` file** — so the dashboard backend crashed on boot and the node fell out of the fleet.

This is the root cause of the DeskComputer redeploy crash:
`FileNotFoundError: /home/dieterolson/work/Repository_Management/VERSION`.

## Fix

`_read_repo_version()` now degrades gracefully instead of crashing the whole dashboard at import:

1. Try the primary `REPO_ROOT/VERSION`.
2. Fall back to the deployed backend's own `BACKEND_DIR.parent/VERSION`.
3. Finally fall back to `"0.0.0"` when neither file exists.

A `VERSION` file that **exists but is malformed** still raises `RuntimeError`, so a genuinely bad version string is never silently accepted.

## Tests (TDD)

`tests/test_dashboard_config.py` adds three cases:
- `test_read_repo_version_missing_primary_falls_back_to_backend`
- `test_read_repo_version_all_missing_returns_safe_default`
- `test_read_repo_version_malformed_file_still_raises`

## Versioning

Bumps `4.9.17 -> 4.9.18` across the single-source metadata (VERSION, pyproject.toml, package.json, package-lock.json, uv.lock, openapi.json, SPEC.md, CHANGELOG.md) to satisfy `test_version_single_source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)