### PR TITLE
fix(system): hide Windows powershell spec-probe console windows (#1056)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,9 +1,15 @@
 # SPEC.md — D-sorganization Runner Dashboard
 
-**Spec Version:** 2.5.165
+**Spec Version:** 2.5.166
 **Application Version:** 4.9.19 (see `VERSION`)
 **Last Updated:** 2026-06-20T00:00:00-07:00
 **Status:** Active
+
+- **2026-06-20 (2.5.166):** Host machine-spec probes now launch the Windows
+  `powershell.exe` with `-WindowStyle Hidden -NonInteractive`. When the backend
+  runs in WSL and shells out to the Windows host powershell for hardware facts,
+  Windows otherwise pops a visible console window per probe on every spec sync;
+  the flags keep the sync silent with no change to the data collected (#1056).
 
 - **2026-06-20 (2.5.165):** Exempted the read-only org runner inventory
   `GET /api/runners` from the #924 structural auth perimeter, alongside
@@ -2571,6 +2577,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 ---
 
 ## 7. Changelog
+
+### 2.5.166 - 2026-06-20
+
+- fix(system): host `powershell.exe` spec probes run with
+  `-WindowStyle Hidden -NonInteractive` so the WSL->Windows machine-spec sync no
+  longer pops visible console windows on the operator desktop (#1056).
 
 ### 2.5.163 - 2026-06-17
 

--- a/backend/system_utils.py
+++ b/backend/system_utils.py
@@ -155,7 +155,19 @@ def _run_windows_powershell(command: str, *, deadline: float | None = None) -> s
             timeout = 5.0
         try:
             result = subprocess.run(
-                [powershell, "-NoProfile", "-Command", command],
+                # -WindowStyle Hidden / -NonInteractive: when the dashboard runs
+                # inside WSL and shells out to the Windows host powershell.exe,
+                # Windows would otherwise pop a visible console window for every
+                # hardware-spec probe. These flags keep the spec sync silent.
+                [
+                    powershell,
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-WindowStyle",
+                    "Hidden",
+                    "-Command",
+                    command,
+                ],
                 capture_output=True,
                 text=True,
                 timeout=timeout,

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -394,6 +394,33 @@ def test_run_windows_powershell_respects_deadline(monkeypatch) -> None:
     assert all(t is not None and t <= 5.0 for t in seen_timeouts)
 
 
+def test_run_windows_powershell_launches_hidden(monkeypatch) -> None:
+    """Host powershell.exe probes must run with a hidden window so the WSL->Windows
+    spec sync does not pop visible console windows on the operator's desktop."""
+    monkeypatch.setattr(
+        system_utils.platform,
+        "uname",
+        lambda: type("Uname", (), {"release": "6.6-microsoft-standard-WSL2"})(),
+    )
+    monkeypatch.setattr(system_utils, "get_powershell_candidates", lambda: ["ps.exe"])
+    seen_args: list[list[str]] = []
+
+    def fake_run(args, **kwargs):  # noqa: ARG001
+        seen_args.append(list(args))
+        return _cp(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(system_utils.subprocess, "run", fake_run)
+    assert system_utils._run_windows_powershell("Get-Thing") == "ok"
+    assert seen_args, "powershell candidate should have been invoked"
+    args = seen_args[0]
+    # The window must be suppressed; -NonInteractive avoids any prompt hang.
+    assert "-WindowStyle" in args
+    assert args[args.index("-WindowStyle") + 1] == "Hidden"
+    assert "-NonInteractive" in args
+    # The actual command must still be passed through.
+    assert "-Command" in args and args[args.index("-Command") + 1] == "Get-Thing"
+
+
 def test_host_snapshot_caches_within_ttl(monkeypatch) -> None:
     """Rapid successive calls must reuse one PowerShell fork within the TTL."""
     monkeypatch.setattr(system_utils, "_host_snapshot_cache", None)


### PR DESCRIPTION
Closes #1056

## Problem
Every time the dashboard syncs Windows host machine specs, a burst of visible PowerShell console windows pops up on the operator's desktop.

## Cause
The backend runs in WSL and shells out to the Windows host \powershell.exe\ for hardware facts (CPU/disk/memory/hardware-facts probes, all via \_run_windows_powershell\). Launching a Windows console exe from WSL makes Windows allocate a visible console window.

## Fix
Launch with \-WindowStyle Hidden -NonInteractive\. One change covers all probes. No change to collected data. Adds a regression test asserting the hidden-window flags are passed.