### PR TITLE
fix(deploy): zero-window launcher for interactive scheduled tasks

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1554,6 +1554,20 @@ distros in one shared utility VM. Two hardening steps keep them out of the
   and an `AtStartup` trigger. This keeps the host-side handle that holds the WSL
   VM resident across logoff, preventing the teardown that otherwise forces both
   distros to cold-boot together and race the 10s window.
+- **`deploy/run-hidden.vbs` + `deploy/install-hidden-task-launcher.ps1`** stop
+  InteractiveToken scheduled tasks from popping focus-stealing console windows
+  in the user's session. The installer rewrites a task's action to
+  `wscript.exe //B //Nologo "run-hidden.vbs" <exe> <args>`; the GUI-subsystem
+  host launches the child with `SW_HIDE` (no console window is ever created —
+  unlike `-WindowStyle Hidden`, which still flashes the console host), waits,
+  and propagates the child's exit code so `LastTaskResult` stays accurate.
+  Contracts: idempotent (wrapping a wrapped task is a no-op), reversible
+  (`-Revert` restores the original action verbatim), postcondition-verified
+  (re-reads the task after writing), foldered tasks addressed by discovered
+  `TaskPath`, and arguments with literal double quotes refused (WScript strips
+  quoting; they cannot be rebuilt losslessly). For tasks that do not need the
+  interactive session, an S4U principal remains the preferred fix. Runbook:
+  `docs/runbooks/interactive-task-console-popups.md`.
 
 #### 2.3.2 Disk-pressure controls (`runner-cleanup.sh`)
 

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.19
+4.9.20

--- a/deploy/install-hidden-task-launcher.ps1
+++ b/deploy/install-hidden-task-launcher.ps1
@@ -1,0 +1,261 @@
+<#
+.SYNOPSIS
+    Rewrite a scheduled task's action to launch through run-hidden.vbs so it
+    never opens a console window in the interactive session.
+
+.DESCRIPTION
+    Interactive-token scheduled tasks whose action is a console executable
+    (powershell.exe, cmd.exe, bash.exe) pop a visible console window each time
+    they fire and steal foreground focus. "-WindowStyle Hidden" is not enough:
+    the console host window is created before the argument is parsed, so a
+    focus-stealing flash remains. This installer rewrites the task action from
+
+        <exe> <args>
+    to
+        wscript.exe //B //Nologo "<run-hidden.vbs>" <exe> <args>
+
+    which never creates a console window. Triggers, settings, and principal
+    are untouched. The rewrite is idempotent (wrapping a wrapped task is a
+    no-op) and reversible (-Revert restores the original action verbatim).
+
+    S4U / SYSTEM tasks do not need this (they run in a non-interactive
+    session with no desktop); it exists for tasks that must stay
+    InteractiveToken, e.g. anything that has to reach the user's WSL session.
+
+.EXAMPLE
+    .\install-hidden-task-launcher.ps1 -TaskName 'RunnerFleet-Health-Monitor'
+
+.EXAMPLE
+    .\install-hidden-task-launcher.ps1 -TaskName 'RunnerFleet-Health-Monitor' -Revert
+#>
+
+[CmdletBinding()]
+param(
+    [string]$TaskName = '',
+    # Defaults resolved in the body: $PSScriptRoot is empty during param
+    # binding when the script is dot-sourced under Windows PowerShell 5.1.
+    [string]$VbsPath = '',
+    [string]$WScriptPath = '',
+    [switch]$Revert,
+    [switch]$DryRun,
+    # Dot-source with -FunctionsOnly to expose the pure helpers for tests
+    # without touching the Task Scheduler.
+    [switch]$FunctionsOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($WScriptPath)) {
+    $WScriptPath = Join-Path $env:SystemRoot 'System32\wscript.exe'
+}
+if ([string]::IsNullOrWhiteSpace($VbsPath) -and -not $FunctionsOnly) {
+    $VbsPath = Join-Path $PSScriptRoot 'run-hidden.vbs'
+}
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no Task Scheduler access; covered by tests/deploy/)
+# ---------------------------------------------------------------------------
+
+function Format-CommandToken {
+    <# Quote a single command-line token if it needs it. Embedded double
+       quotes cannot be re-quoted losslessly once WScript strips them, so
+       they violate the launcher's argument contract. #>
+    param([Parameter(Mandatory)][string]$Token)
+    if ($Token.Contains('"')) {
+        throw "token contains an embedded double quote and cannot be wrapped losslessly: $Token"
+    }
+    if ($Token.Contains(' ')) { return '"' + $Token + '"' }
+    return $Token
+}
+
+function Get-WrappedArgumentPrefix {
+    param([Parameter(Mandatory)][string]$VbsPath)
+    # //B suppresses script-host error dialogs; //Nologo keeps stdout clean.
+    return '//B //Nologo "' + $VbsPath + '" '
+}
+
+function Test-WrappedAction {
+    <# True when the action already launches through this VbsPath. #>
+    param(
+        [Parameter(Mandatory)][string]$Execute,
+        [AllowEmptyString()][string]$Arguments = '',
+        [Parameter(Mandatory)][string]$VbsPath
+    )
+    $leaf = Split-Path -Leaf ($Execute.Trim('"'))
+    if ($leaf -ine 'wscript.exe') { return $false }
+    $prefix = Get-WrappedArgumentPrefix -VbsPath $VbsPath
+    return ([string]$Arguments).StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function ConvertTo-WrappedAction {
+    <# Build the wscript-wrapped equivalent of an action.
+       Preconditions: Execute non-empty, not already wrapped.
+       Postcondition: result launches wscript.exe with the original command
+       appended verbatim after the VBS path, so ConvertFrom-WrappedAction can
+       restore it exactly. #>
+    param(
+        [Parameter(Mandatory)][string]$Execute,
+        [AllowEmptyString()][string]$Arguments = '',
+        [Parameter(Mandatory)][string]$VbsPath,
+        [string]$WScriptPath = (Join-Path $env:SystemRoot 'System32\wscript.exe')
+    )
+    if ([string]::IsNullOrWhiteSpace($Execute)) {
+        throw 'Execute must be a non-empty string'
+    }
+    if (Test-WrappedAction -Execute $Execute -Arguments $Arguments -VbsPath $VbsPath) {
+        throw "action is already wrapped by $VbsPath; refusing to double-wrap"
+    }
+    $command = Format-CommandToken -Token ($Execute.Trim('"'))
+    if (-not [string]::IsNullOrEmpty($Arguments)) {
+        $command = $command + ' ' + $Arguments
+    }
+    return [pscustomobject]@{
+        Execute   = $WScriptPath
+        Arguments = (Get-WrappedArgumentPrefix -VbsPath $VbsPath) + $command
+    }
+}
+
+function ConvertFrom-WrappedAction {
+    <# Restore the original action from a wrapped one (the -Revert path).
+       Precondition: the action was wrapped with this VbsPath.
+       Postcondition: returns the original Execute/Arguments verbatim. #>
+    param(
+        [Parameter(Mandatory)][string]$Execute,
+        [AllowEmptyString()][string]$Arguments = '',
+        [Parameter(Mandatory)][string]$VbsPath
+    )
+    if (-not (Test-WrappedAction -Execute $Execute -Arguments $Arguments -VbsPath $VbsPath)) {
+        throw "action is not wrapped by $VbsPath; nothing to revert"
+    }
+    $prefix = Get-WrappedArgumentPrefix -VbsPath $VbsPath
+    $remainder = ([string]$Arguments).Substring($prefix.Length)
+    if ($remainder.StartsWith('"')) {
+        $closing = $remainder.IndexOf('"', 1)
+        if ($closing -lt 0) { throw "malformed wrapped action (unterminated quote): $remainder" }
+        $originalExecute = $remainder.Substring(1, $closing - 1)
+        $originalArguments = $remainder.Substring($closing + 1).TrimStart(' ')
+    }
+    else {
+        $space = $remainder.IndexOf(' ')
+        if ($space -lt 0) {
+            $originalExecute = $remainder
+            $originalArguments = ''
+        }
+        else {
+            $originalExecute = $remainder.Substring(0, $space)
+            $originalArguments = $remainder.Substring($space + 1)
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($originalExecute)) {
+        throw "malformed wrapped action (empty original executable): $remainder"
+    }
+    return [pscustomobject]@{
+        Execute   = $originalExecute
+        Arguments = $originalArguments
+    }
+}
+
+if ($FunctionsOnly) { return }
+
+# ---------------------------------------------------------------------------
+# Main flow (Task Scheduler access lives only below this line)
+# ---------------------------------------------------------------------------
+
+if ([string]::IsNullOrWhiteSpace($TaskName)) {
+    throw 'TaskName must be a non-empty string'
+}
+if (-not (Test-Path -LiteralPath $VbsPath -PathType Leaf)) {
+    throw "launcher script not found: $VbsPath (deploy run-hidden.vbs first)"
+}
+if (-not (Test-Path -LiteralPath $WScriptPath -PathType Leaf)) {
+    throw "wscript.exe not found at $WScriptPath"
+}
+
+# Get-ScheduledTask -TaskName searches every folder; Set-ScheduledTask
+# without -TaskPath looks only at the root (0x80070002 for foldered tasks),
+# so pin the discovered path for the write, the re-read, and the fallback.
+$task = Get-ScheduledTask -TaskName $TaskName
+if (@($task).Count -gt 1) {
+    $paths = (@($task) | ForEach-Object { $_.TaskPath }) -join ', '
+    throw "'$TaskName' matches multiple tasks ($paths); disambiguation is not supported"
+}
+$taskPath = [string]$task.TaskPath
+if (@($task.Actions).Count -ne 1) {
+    throw "task '$TaskName' has $(@($task.Actions).Count) actions; only single-action tasks are supported"
+}
+$currentExecute = [string]$task.Actions[0].Execute
+$currentArguments = [string]$task.Actions[0].Arguments
+if ([string]::IsNullOrWhiteSpace($currentExecute)) {
+    throw "task '$TaskName' has an empty action executable"
+}
+
+$alreadyWrapped = Test-WrappedAction -Execute $currentExecute -Arguments $currentArguments -VbsPath $VbsPath
+if ($Revert) {
+    $target = ConvertFrom-WrappedAction -Execute $currentExecute -Arguments $currentArguments -VbsPath $VbsPath
+    $mode = 'revert'
+}
+elseif ($alreadyWrapped) {
+    $target = $null
+    $mode = 'noop-already-wrapped'
+}
+else {
+    $target = ConvertTo-WrappedAction -Execute $currentExecute -Arguments $currentArguments `
+        -VbsPath $VbsPath -WScriptPath $WScriptPath
+    $mode = 'wrap'
+}
+
+$result = [ordered]@{
+    task_name      = $TaskName
+    mode           = $mode
+    from_execute   = $currentExecute
+    from_arguments = $currentArguments
+    to_execute     = if ($target) { $target.Execute } else { $currentExecute }
+    to_arguments   = if ($target) { $target.Arguments } else { $currentArguments }
+    write_path     = $null
+    verified       = $null
+}
+
+if ($DryRun -or $mode -eq 'noop-already-wrapped') {
+    [pscustomobject]$result | ConvertTo-Json -Depth 3
+    exit 0
+}
+
+try {
+    $newAction = New-ScheduledTaskAction -Execute $target.Execute -Argument $target.Arguments
+    Set-ScheduledTask -TaskName $TaskName -TaskPath $taskPath -Action $newAction | Out-Null
+    $result.write_path = 'Set-ScheduledTask'
+}
+catch {
+    # Non-elevated sessions can lack CIM write access to their own tasks;
+    # schtasks /Change works there but its /TR value is silently truncated
+    # beyond 261 characters -- refuse rather than corrupt the task.
+    $tr = (Format-CommandToken -Token $target.Execute) + ' ' + $target.Arguments
+    $trEscaped = $tr.Replace('"', '\"')
+    if ($tr.Length -gt 261) {
+        throw ("Set-ScheduledTask failed ($($_.Exception.Message)) and the schtasks fallback " +
+            "cannot carry $($tr.Length) chars (limit 261). Re-run elevated.")
+    }
+    $p = Start-Process -FilePath 'schtasks.exe' `
+        -ArgumentList ('/Change /TN "' + ($taskPath + $TaskName) + '" /TR "' + $trEscaped + '"') `
+        -NoNewWindow -Wait -PassThru
+    if ($p.ExitCode -ne 0) {
+        throw "schtasks /Change fallback failed with exit code $($p.ExitCode)"
+    }
+    $result.write_path = 'schtasks /Change'
+}
+
+# Postcondition: what we wrote is what the task now runs. schtasks /TR folds
+# executable and arguments into one command line, so compare that form.
+$reread = Get-ScheduledTask -TaskName $TaskName -TaskPath $taskPath
+$rereadExecute = ([string]$reread.Actions[0].Execute).Trim('"')
+$rereadArguments = [string]$reread.Actions[0].Arguments
+$expectedCommand = (Format-CommandToken -Token $target.Execute) + ' ' + $target.Arguments
+$actualCommand = (Format-CommandToken -Token $rereadExecute) + ' ' + $rereadArguments
+$result.verified = ($actualCommand -eq $expectedCommand)
+if (-not $result.verified) {
+    throw ("postcondition failed for '$TaskName': task action is '$actualCommand', " +
+        "expected '$expectedCommand'")
+}
+
+[pscustomobject]$result | ConvertTo-Json -Depth 3

--- a/deploy/run-hidden.vbs
+++ b/deploy/run-hidden.vbs
@@ -1,0 +1,49 @@
+' run-hidden.vbs -- zero-window launcher for console commands.
+'
+' Scheduled tasks registered with an InteractiveToken principal and a console
+' executable (powershell.exe, cmd.exe, bash.exe) open a visible, focus-stealing
+' console window in the user's session every time they fire. Launching the same
+' command through wscript.exe (a GUI-subsystem host) with window style 0 never
+' creates a console window at all -- unlike "powershell -WindowStyle Hidden",
+' which still flashes the console host before the argument is parsed.
+'
+' Contract
+'   Arguments : <command> [args...]
+'               Preconditions: at least one argument; no argument may contain a
+'               literal double quote (WScript strips quoting while parsing, so
+'               such an argument cannot be rebuilt losslessly -- refuse rather
+'               than silently corrupt the command line).
+'   Behaviour : runs the command hidden (SW_HIDE) and waits for it to finish,
+'               so the host process lives as long as the child. The scheduled
+'               task's MultipleInstancesPolicy and Running state stay accurate.
+'   Exit code : the child's exit code; 87 (ERROR_INVALID_PARAMETER) on a
+'               violated argument contract.
+'
+' Installed onto fleet hosts by install-hidden-task-launcher.ps1.
+Option Explicit
+
+Dim shell, command, arg, i, exitCode
+
+If WScript.Arguments.Count = 0 Then
+  WScript.Quit(87)
+End If
+
+command = ""
+For i = 0 To WScript.Arguments.Count - 1
+  arg = WScript.Arguments(i)
+  If InStr(arg, Chr(34)) > 0 Then
+    WScript.Quit(87)
+  End If
+  If InStr(arg, " ") > 0 Then
+    arg = Chr(34) & arg & Chr(34)
+  End If
+  If i = 0 Then
+    command = arg
+  Else
+    command = command & " " & arg
+  End If
+Next
+
+Set shell = CreateObject("WScript.Shell")
+exitCode = shell.Run(command, 0, True)
+WScript.Quit(exitCode)

--- a/docs/runbooks/interactive-task-console-popups.md
+++ b/docs/runbooks/interactive-task-console-popups.md
@@ -1,0 +1,116 @@
+# Interactive scheduled tasks popping console windows (focus steal)
+
+## Symptom
+
+Console (PowerShell/cmd/Git Bash) windows appear on the desktop "out of
+nowhere" every few minutes, stealing keyboard/mouse focus mid-typing. On
+DeskComputer this was a visible window every 5 minutes that stayed open for
+the duration of two SSH round-trips; on ControlTower, every 30 minutes.
+
+## Root cause
+
+Any scheduled task registered with an **InteractiveToken** principal ("run
+only when user is logged on") whose action is a **console-subsystem
+executable** (`powershell.exe`, `pwsh.exe`, `cmd.exe`, `bash.exe`) creates a
+visible console window in the user's session each time it fires. The window
+takes foreground focus.
+
+`-WindowStyle Hidden` is **not sufficient**: the console host window is
+created by the loader before PowerShell ever parses its arguments, so a
+focus-stealing flash remains on every start.
+
+Tasks running as **S4U** ("run whether user is logged on or not") or
+**SYSTEM** are immune — they execute in a non-interactive session with no
+desktop. Prefer S4U for new tasks that don't need the interactive session
+(see `install-wsl-keepalive-task.ps1` for the pattern). The launcher below
+exists for tasks that **must** stay InteractiveToken — anything that has to
+reach the logged-on user's WSL instance or desktop apps.
+
+## Fix
+
+`deploy/run-hidden.vbs` + `deploy/install-hidden-task-launcher.ps1`.
+
+The installer rewrites the task action from
+
+```
+<exe> <args>
+```
+
+to
+
+```
+wscript.exe //B //Nologo "<path>\run-hidden.vbs" <exe> <args>
+```
+
+`wscript.exe` is a GUI-subsystem host, and `WshShell.Run(cmd, 0, True)`
+launches the child with `SW_HIDE`: **no console window is ever created** —
+no flash, no focus steal. The VBS waits for the child and propagates its
+exit code, so task history / `LastTaskResult` stay accurate. Triggers,
+settings, and principal are untouched.
+
+Contracts (enforced, tested in `tests/deploy/test_hidden_task_launcher.py`):
+
+- idempotent — wrapping a wrapped task is a no-op;
+- reversible — `-Revert` restores the original action verbatim;
+- postcondition-verified — the installer re-reads the task after writing and
+  fails loudly on any mismatch;
+- foldered tasks are addressed by their discovered `TaskPath`
+  (`Get-ScheduledTask` finds them anywhere but `Set-ScheduledTask` without
+  `-TaskPath` fails with 0x80070002 — found live on ControlTower's
+  `\D-sorganization\matlab-runner`);
+- arguments containing literal double quotes are refused (WScript strips
+  quoting during argument parsing, so they cannot be rebuilt losslessly);
+- the non-elevated `schtasks /Change` fallback refuses command lines over
+  261 chars (silent truncation limit).
+
+## Install on a host
+
+```powershell
+# 1. Stage both files together (they must sit in the same directory):
+Copy-Item deploy\run-hidden.vbs, deploy\install-hidden-task-launcher.ps1 `
+    -Destination C:\Users\<user>\runner_fleet_monitor\
+
+# 2. Wrap each offending task (repeat per task; -DryRun to preview):
+powershell -NoProfile -File C:\Users\<user>\runner_fleet_monitor\install-hidden-task-launcher.ps1 `
+    -TaskName 'RunnerFleet-Health-Monitor'
+
+# Revert if ever needed:
+powershell -NoProfile -File ...\install-hidden-task-launcher.ps1 -TaskName '<name>' -Revert
+```
+
+Find candidates on a host:
+
+```powershell
+Get-ScheduledTask | Where-Object { $_.State -ne 'Disabled' -and
+    [string]$_.Principal.LogonType -eq 'Interactive' } |
+  ForEach-Object { $t = $_; $t.Actions |
+    Where-Object { $_.Execute -match 'powershell|pwsh|cmd\.exe|bash' } |
+    ForEach-Object { "$($t.TaskPath)$($t.TaskName)  ->  $($_.Execute)" } }
+```
+
+Verify a wrapped task runs windowless: fire it, then confirm the child's
+`MainWindowHandle` is `0` while it runs and `LastTaskResult` is `0` after.
+
+## Fleet state (rollout 2026-07-30)
+
+| Host         | Task                                                    | Action                                                                                           |
+| ------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| DeskComputer | `RunnerFleet-Health-Monitor` (5 min)                    | wrapped                                                                                          |
+| DeskComputer | `Forgejo-Backup-Sync` (daily 03:00)                     | wrapped                                                                                          |
+| DeskComputer | Startup `start_docker.bat`                              | replaced by `start_docker_hidden.lnk` → launcher; bat moved to `C:\Users\diete\start_docker.bat` |
+| ControlTower | `Conductor-RealWork-RM-30min` (30 min)                  | wrapped                                                                                          |
+| ControlTower | `D-sorg GitHub Forgejo Posture Backup`                  | wrapped                                                                                          |
+| ControlTower | `WSL-VHDX-Compact-Overnight`                            | wrapped                                                                                          |
+| ControlTower | `\D-sorganization\matlab-runner`                        | wrapped                                                                                          |
+| OGLaptop     | — (keepalive already S4U; no interactive console tasks) | launcher staged only                                                                             |
+
+Not wrapped on purpose: S4U/SYSTEM tasks (no UI by construction), Microsoft
+system tasks (`\Microsoft\...`), and OGLaptop's `RebootToUbuntu`
+(user-invoked deliberate reboot; a flash there is moot).
+
+## Related
+
+- `docs/runbooks/wsl-keepalive-probe-fix.md` — the keepalive watchdog this
+  monitor babysits.
+- `deploy/install-wsl-keepalive-task.ps1` — S4U registration pattern for
+  tasks that don't need the interactive session.

--- a/docs/runbooks/interactive-task-console-popups.md
+++ b/docs/runbooks/interactive-task-console-popups.md
@@ -108,6 +108,19 @@ Not wrapped on purpose: S4U/SYSTEM tasks (no UI by construction), Microsoft
 system tasks (`\Microsoft\...`), and OGLaptop's `RebootToUbuntu`
 (user-invoked deliberate reboot; a flash there is moot).
 
+Known remainder: DeskComputer's `WSL-Runner-KeepAlive` was registered from an
+elevated context, so rewriting its action needs an elevated session (both
+`Set-ScheduledTask` and the `schtasks` fallback are denied non-elevated, and
+elevating non-interactively would itself pop UAC). Low impact — the task is
+resident, so its `-WindowStyle Hidden` flash occurs only at logon or when the
+health monitor restarts a dead instance. To finish it, run once from an
+elevated PowerShell:
+
+```powershell
+powershell -NoProfile -File C:\Users\diete\runner_fleet_monitor\install-hidden-task-launcher.ps1 `
+    -TaskName 'WSL-Runner-KeepAlive'
+```
+
 ## Related
 
 - `docs/runbooks/wsl-keepalive-probe-fix.md` — the keepalive watchdog this

--- a/tests/deploy/test_hidden_task_launcher.py
+++ b/tests/deploy/test_hidden_task_launcher.py
@@ -1,0 +1,353 @@
+"""Cross-platform tests for the zero-window scheduled-task launcher.
+
+``deploy/run-hidden.vbs`` + ``deploy/install-hidden-task-launcher.ps1`` fix
+the fleet-host console-popup nuisance: any scheduled task registered with an
+InteractiveToken principal and a console executable (powershell.exe,
+bash.exe, cmd.exe) opens a visible console window in the user's session each
+time it fires and steals foreground focus. ``-WindowStyle Hidden`` is not
+sufficient — the console host window is created before PowerShell parses its
+arguments, so a focus-stealing flash remains. Launching through
+``wscript.exe`` (a GUI-subsystem host) with ``WshShell.Run(cmd, 0, True)``
+never creates a console window at all.
+
+Test layout mirrors ``test_wsl_keepalive_script.py``:
+
+1. **Static checks** (run everywhere): both artifacts exist and contain the
+   load-bearing contract markers.
+2. **Behavioural checks** (require ``pwsh``): drive the installer's pure
+   helpers (``ConvertTo-WrappedAction`` / ``ConvertFrom-WrappedAction`` /
+   ``Test-WrappedAction``) via ``-FunctionsOnly`` dot-sourcing.
+3. **Windows-only behavioural checks**: execute the VBS via ``cscript`` and
+   assert exit-code propagation and precondition rejections. (Window
+   invisibility itself is verified operationally on the live task — it is
+   not automatable from a headless test.)
+
+The scheduled-task read/write path (Get-/Set-ScheduledTask) is deliberately
+NOT exercised here: CI runners are Linux and have no Task Scheduler. The
+installer isolates it behind its pure helpers plus a postcondition re-read.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VBS = REPO_ROOT / "deploy" / "run-hidden.vbs"
+INSTALLER = REPO_ROOT / "deploy" / "install-hidden-task-launcher.ps1"
+
+IS_WINDOWS = sys.platform == "win32"
+WINDOWS_REQUIRED = pytest.mark.skipif(not IS_WINDOWS, reason="cscript.exe only exists on Windows")
+
+
+def _find_pwsh() -> str | None:
+    for candidate in ("pwsh", "powershell"):
+        if shutil.which(candidate):
+            return candidate
+    return None
+
+
+PWSH = _find_pwsh()
+PWSH_REQUIRED = pytest.mark.skipif(PWSH is None, reason="PowerShell (pwsh/powershell) not available on this runner")
+
+
+def _run_ps(script_body: str) -> subprocess.CompletedProcess[str]:
+    assert PWSH is not None
+    return subprocess.run(
+        [PWSH, "-NoProfile", "-NonInteractive", "-Command", script_body],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _run_vbs(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the launcher under cscript (same engine as wscript, console host)."""
+    return subprocess.run(
+        ["cscript.exe", "//B", "//Nologo", str(VBS), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _dot_source_prefix() -> str:
+    """Dot-source the installer exposing only its pure helpers."""
+    return f". '{INSTALLER.as_posix()}' -FunctionsOnly; "
+
+
+# ---------------------------------------------------------------------------
+# Static checks — run-hidden.vbs
+# ---------------------------------------------------------------------------
+
+
+def test_vbs_exists() -> None:
+    assert VBS.is_file(), f"launcher missing: {VBS}"
+
+
+def test_vbs_runs_hidden_and_waits() -> None:
+    """The whole point: SW_HIDE (0) and synchronous wait (True).
+
+    Waiting matters for two reasons: the task's MultipleInstancesPolicy
+    (IgnoreNew) only debounces overlapping cycles if the wscript process
+    lives as long as the child, and the child's exit code can only be
+    propagated after it exits.
+    """
+    text = VBS.read_text(encoding="utf-8")
+    assert ".Run(command, 0, True)" in text, "must run with window style 0 (hidden) and wait"
+
+
+def test_vbs_propagates_child_exit_code() -> None:
+    text = VBS.read_text(encoding="utf-8")
+    assert "WScript.Quit(exitCode)" in text, "child exit code must become the launcher exit code"
+
+
+def test_vbs_rejects_missing_command() -> None:
+    """Precondition: at least one argument (the command)."""
+    text = VBS.read_text(encoding="utf-8")
+    assert "WScript.Quit(87)" in text, "argument-contract violations must exit 87 (ERROR_INVALID_PARAMETER)"
+
+
+def test_vbs_rejects_embedded_double_quotes() -> None:
+    """Precondition: embedded double quotes are not re-quotable losslessly.
+
+    WScript strips quoting during argument parsing; an argument that still
+    contains a literal double quote cannot be rebuilt unambiguously, so the
+    launcher must refuse rather than silently corrupt the command line.
+    """
+    text = VBS.read_text(encoding="utf-8")
+    assert "InStr(arg, Chr(34))" in text, "must detect embedded double quotes and refuse"
+
+
+# ---------------------------------------------------------------------------
+# Static checks — install-hidden-task-launcher.ps1
+# ---------------------------------------------------------------------------
+
+
+def test_installer_exists() -> None:
+    assert INSTALLER.is_file(), f"installer missing: {INSTALLER}"
+
+
+def test_installer_declares_contract_parameters() -> None:
+    text = INSTALLER.read_text(encoding="utf-8")
+    for param in ("TaskName", "VbsPath", "Revert", "DryRun", "FunctionsOnly"):
+        assert f"${param}" in text, f"parameter ${param} not declared"
+
+
+def test_installer_uses_strict_mode() -> None:
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert "Set-StrictMode -Version Latest" in text
+    assert "$ErrorActionPreference = 'Stop'" in text
+
+
+def test_installer_launches_via_wscript_batch_mode() -> None:
+    """//B suppresses script-host error dialogs; //Nologo keeps stdout clean."""
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert "wscript.exe" in text
+    assert "//B" in text
+    assert "//Nologo" in text
+
+
+def test_installer_verifies_postcondition_after_write() -> None:
+    """DbC: after Set-ScheduledTask the installer must re-read the task and
+    verify the action actually matches what it intended to write."""
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert "postcondition" in text.lower()
+
+
+def test_installer_guards_schtasks_fallback_length() -> None:
+    """The non-elevated fallback path (schtasks /Change /TR) silently
+    truncates beyond 261 characters; the installer must refuse instead."""
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert "261" in text, "schtasks /TR 261-char limit must be guarded"
+
+
+def test_installer_threads_task_path_through_write_and_reread() -> None:
+    """Regression guard (found live on ControlTower's ``matlab-runner``):
+    ``Get-ScheduledTask -TaskName`` finds a task in any folder, but
+    ``Set-ScheduledTask`` without ``-TaskPath`` looks only at the root and
+    fails with 0x80070002. The discovered TaskPath must be passed to the
+    write, the postcondition re-read, and the schtasks fallback (as the
+    ``\\folder\\name`` form), and a name matching multiple tasks must be
+    rejected up front."""
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert text.count("-TaskPath $taskPath") >= 2, "write and re-read must both pin the discovered TaskPath"
+    assert "$taskPath + $TaskName" in text, "schtasks fallback must address the task by full path"
+    assert "matches multiple tasks" in text, "ambiguous task names must be rejected"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural checks — pure helpers (require pwsh)
+# ---------------------------------------------------------------------------
+
+
+@PWSH_REQUIRED
+def test_helpers_wrap_simple_powershell_action(tmp_path: Path) -> None:
+    vbs = tmp_path / "run-hidden.vbs"
+    vbs.write_text("' stub", encoding="utf-8")
+    driver = _dot_source_prefix() + textwrap.dedent(
+        f"""
+        $w = ConvertTo-WrappedAction -Execute 'powershell.exe' `
+            -Arguments '-NoProfile -File "C:\\ops\\monitor.ps1"' `
+            -VbsPath '{vbs}'
+        Write-Output ("EXEC=" + $w.Execute)
+        Write-Output ("ARGS=" + $w.Arguments)
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "EXEC=" in result.stdout
+    exec_line = next(line for line in result.stdout.splitlines() if line.startswith("EXEC="))
+    args_line = next(line for line in result.stdout.splitlines() if line.startswith("ARGS="))
+    assert exec_line.removeprefix("EXEC=").lower().endswith("wscript.exe")
+    assert args_line.removeprefix("ARGS=").startswith('//B //Nologo "')
+    assert 'powershell.exe -NoProfile -File "C:\\ops\\monitor.ps1"' in args_line
+
+
+@PWSH_REQUIRED
+def test_helpers_quote_executable_containing_spaces(tmp_path: Path) -> None:
+    vbs = tmp_path / "run-hidden.vbs"
+    vbs.write_text("' stub", encoding="utf-8")
+    driver = _dot_source_prefix() + textwrap.dedent(
+        f"""
+        $w = ConvertTo-WrappedAction -Execute 'C:\\Program Files\\Git\\bin\\bash.exe' `
+            -Arguments '-lc "/c/ops/backup.sh"' `
+            -VbsPath '{vbs}'
+        Write-Output ("ARGS=" + $w.Arguments)
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert '"C:\\Program Files\\Git\\bin\\bash.exe"' in result.stdout
+
+
+@PWSH_REQUIRED
+def test_helpers_round_trip_wrap_then_revert(tmp_path: Path) -> None:
+    """ConvertFrom(ConvertTo(x)) must reproduce x verbatim — the revert path
+    depends on it."""
+    vbs = tmp_path / "run-hidden.vbs"
+    vbs.write_text("' stub", encoding="utf-8")
+    cases = [
+        ("powershell.exe", '-NoProfile -ExecutionPolicy Bypass -File "C:\\ops\\fleet-health-monitor.ps1"'),
+        ("C:\\Program Files\\Git\\bin\\bash.exe", '-lc "/c/ops/run-forgejo-backup.sh"'),
+        ("cmd.exe", "/c echo done"),
+    ]
+    for execute, arguments in cases:
+        driver = _dot_source_prefix() + textwrap.dedent(
+            f"""
+            $w = ConvertTo-WrappedAction -Execute '{execute}' -Arguments '{arguments}' -VbsPath '{vbs}'
+            $r = ConvertFrom-WrappedAction -Execute $w.Execute -Arguments $w.Arguments -VbsPath '{vbs}'
+            Write-Output ("EXEC=" + $r.Execute)
+            Write-Output ("ARGS=" + $r.Arguments)
+            """
+        )
+        result = _run_ps(driver)
+        assert result.returncode == 0, f"{execute}: {result.stderr}"
+        assert f"EXEC={execute}" in result.stdout, result.stdout
+        assert f"ARGS={arguments}" in result.stdout, result.stdout
+
+
+@PWSH_REQUIRED
+def test_helpers_detect_wrapped_action(tmp_path: Path) -> None:
+    vbs = tmp_path / "run-hidden.vbs"
+    vbs.write_text("' stub", encoding="utf-8")
+    driver = _dot_source_prefix() + textwrap.dedent(
+        f"""
+        $w = ConvertTo-WrappedAction -Execute 'powershell.exe' -Arguments '-File x.ps1' -VbsPath '{vbs}'
+        $before = Test-WrappedAction -Execute 'powershell.exe' -Arguments '-File x.ps1' -VbsPath '{vbs}'
+        Write-Output ("BEFORE=" + $before)
+        Write-Output ("AFTER=" + (Test-WrappedAction -Execute $w.Execute -Arguments $w.Arguments -VbsPath '{vbs}'))
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "BEFORE=False" in result.stdout
+    assert "AFTER=True" in result.stdout
+
+
+@PWSH_REQUIRED
+def test_helpers_refuse_double_wrap(tmp_path: Path) -> None:
+    """Precondition: wrapping an already-wrapped action must throw, not nest."""
+    vbs = tmp_path / "run-hidden.vbs"
+    vbs.write_text("' stub", encoding="utf-8")
+    driver = _dot_source_prefix() + textwrap.dedent(
+        f"""
+        $w = ConvertTo-WrappedAction -Execute 'powershell.exe' -Arguments '-File x.ps1' -VbsPath '{vbs}'
+        try {{
+            ConvertTo-WrappedAction -Execute $w.Execute -Arguments $w.Arguments -VbsPath '{vbs}' | Out-Null
+            Write-Output 'NOTHROW'
+        }} catch {{
+            Write-Output 'THREW'
+        }}
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "THREW" in result.stdout
+
+
+@PWSH_REQUIRED
+def test_helpers_refuse_revert_of_unwrapped_action(tmp_path: Path) -> None:
+    vbs = tmp_path / "run-hidden.vbs"
+    vbs.write_text("' stub", encoding="utf-8")
+    driver = _dot_source_prefix() + textwrap.dedent(
+        f"""
+        try {{
+            ConvertFrom-WrappedAction -Execute 'powershell.exe' -Arguments '-File x.ps1' -VbsPath '{vbs}' | Out-Null
+            Write-Output 'NOTHROW'
+        }} catch {{
+            Write-Output 'THREW'
+        }}
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "THREW" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Behavioural checks — the VBS itself (Windows only)
+# ---------------------------------------------------------------------------
+
+
+@WINDOWS_REQUIRED
+def test_vbs_propagates_exit_code_live() -> None:
+    result = _run_vbs("cmd.exe", "/c", "exit 3")
+    assert result.returncode == 3, f"expected 3, got {result.returncode}: {result.stderr}"
+
+
+@WINDOWS_REQUIRED
+def test_vbs_zero_exit_code_live() -> None:
+    result = _run_vbs("cmd.exe", "/c", "exit 0")
+    assert result.returncode == 0
+
+
+@WINDOWS_REQUIRED
+def test_vbs_no_arguments_rejected_live() -> None:
+    result = _run_vbs()
+    assert result.returncode == 87
+
+
+@WINDOWS_REQUIRED
+def test_vbs_requotes_spaced_argument_live(tmp_path: Path) -> None:
+    """An argument containing spaces must survive WScript's quote-stripping
+    via the launcher's re-quoting: a batch file in a spaced directory only
+    runs (and its exit code only propagates) if the rebuilt command line
+    quoted the path again.
+
+    Note there is deliberately no live embedded-double-quote test: WScript's
+    parser strips all quoting before the script sees its arguments, so a
+    literal ``"`` cannot be injected at runtime. The ``InStr(arg, Chr(34))``
+    guard is defense-in-depth and is asserted statically above.
+    """
+    spaced_dir = tmp_path / "a b"
+    spaced_dir.mkdir()
+    script = spaced_dir / "probe.cmd"
+    script.write_text("@exit 11\r\n", encoding="ascii")
+    result = _run_vbs(str(script))
+    assert result.returncode == 11, f"expected 11, got {result.returncode}: {result.stderr}"


### PR DESCRIPTION
## Problem

Interactive-token scheduled tasks whose action is a console executable pop a visible console window in the logged-on user's session every time they fire, stealing foreground focus. On DeskComputer this was `RunnerFleet-Health-Monitor` every 5 minutes (window held open across two SSH round-trips); on ControlTower, `Conductor-RealWork-RM-30min` every 30 minutes. `-WindowStyle Hidden` is insufficient — the console host window is created before PowerShell parses its arguments, so a focus-stealing flash remains.

## Fix

- `deploy/run-hidden.vbs` — GUI-subsystem `wscript` launcher: runs the child with `SW_HIDE` (no console window is ever created), waits, propagates the exit code. Refuses violated argument contracts with exit 87.
- `deploy/install-hidden-task-launcher.ps1` — rewrites a task action to `wscript.exe //B //Nologo "run-hidden.vbs" <exe> <args>`. Idempotent, reversible (`-Revert` restores the original verbatim), postcondition-verified (re-reads the task after writing), TaskPath-aware (foldered tasks: `Set-ScheduledTask` without `-TaskPath` fails 0x80070002 — hit live on ControlTower's `\D-sorganization\matlab-runner`), and 261-char guard on the non-elevated `schtasks /Change` fallback.
- Runbook: `docs/runbooks/interactive-task-console-popups.md` (includes fleet rollout state).
- SPEC 2.3.1 entry + VERSION 4.9.20.

## Testing (TDD)

`tests/deploy/test_hidden_task_launcher.py` written first (red), then implementation (green): static contract checks, pwsh-driven pure-helper behavioural checks (wrap/revert round-trip, double-wrap refusal, spaced-executable quoting), and Windows-only live VBS checks (exit-code propagation, spaced-argument re-quoting). 22/22 pass locally; Linux CI runs the static + pwsh subsets.

## Rollout (already applied 2026-07-30)

DeskComputer: health monitor, Forgejo backup, docker startup shim. ControlTower: conductor real-work, Forgejo posture backup, VHDX compaction, matlab-runner (starting the wrapped task also brought the offline MATLAB runner back online). OGLaptop: launcher staged; its keepalive is already S4U (no interactive console tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)