### PR TITLE
feat(deploy): fleet pool-floor monitoring + registration-purge alarm

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1554,6 +1554,17 @@ distros in one shared utility VM. Two hardening steps keep them out of the
   and an `AtStartup` trigger. This keeps the host-side handle that holds the WSL
   VM resident across logoff, preventing the teardown that otherwise forces both
   distros to cold-boot together and race the 10s window.
+- **`deploy/fleet-health-monitor.ps1`** is the canonical DeskComputer fleet
+  monitor (5-minute scheduled task, launched via `run-hidden.vbs`). Beyond the
+  original DeskComputer-keepalive check and ControlTower WMI-handle guard, it
+  enforces **per-pool online floors** (Desktop / ControlTower-SSD / Oglaptop)
+  from the dashboard's `/api/runners` feed, self-heals a below-floor Desktop
+  pool with in-place `systemctl start` of the local runner units (never a WSL
+  reset), and raises an explicit **registration-purge alarm** (zero pool
+  members online on GitHub while local units run — the signature of GitHub's
+  ~14-day offline auto-delete, which silently destroyed the DeskComputer
+  pool's registrations in July 2026). Recovery procedure:
+  `docs/runbooks/runner-registration-purge-recovery.md`.
 - **`deploy/run-hidden.vbs` + `deploy/install-hidden-task-launcher.ps1`** stop
   InteractiveToken scheduled tasks from popping focus-stealing console windows
   in the user's session. The installer rewrites a task's action to

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.20
+4.9.21

--- a/backend/machine_registry.yml
+++ b/backend/machine_registry.yml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-06-09
+updated_at: 2026-07-31
 machines:
   - name: ControlTower
     aliases:
@@ -31,23 +31,26 @@ machines:
         dashboard_url: http://controltower.tail2bbcc7.ts.net:8321
         storage_tier: nvme
         runner_base_dir: /home/dieterolson/actions-runners-nvme
+        # QUARANTINED 2026-07 (Runner_Dashboard issue #1071): the distro
+        # exposed broad filesystem corruption (null-byte binaries, corrupt
+        # dpkg/node/uv). Registered runners 6-8 carry only the
+        # d-sorg-quarantine label; 1-5 were auto-purged by GitHub. The
+        # ControlTower-NVMe distro must stay STOPPED and the legacy
+        # C:\WSL\ext4.vhdx (0x80070570, hosted the :8321 hub) must not be
+        # deleted or mutated until the documented backup/reprovision.
         runner_labels:
           - self-hosted
           - Linux
           - X64
-          - d-sorg-fleet
-          - d-sorg-fleet-nvme
-          - d-sorg-fleet-fast-io
-          - d-sorg-fleet-docker
-          - d-sorg-fleet-4core
+          - d-sorg-quarantine
         runners:
-          min: 4
-          default: 8
+          min: 0
+          default: 0
           max: 8
         storage:
           host_drive: "C:"
           windows_host_path: "C:\\WSL"
-          wsl_distro: WSL
+          wsl_distro: ControlTower-NVMe
           vhdx_path: "C:\\WSL\\ext4.vhdx"
           disk_bus: NVMe
           disk_media_type: SSD
@@ -70,9 +73,9 @@ machines:
           - d-sorg-fleet-docker
           - d-sorg-fleet-4core
         runners:
-          min: 4
-          default: 8
-          max: 8
+          min: 12
+          default: 17
+          max: 17
         storage:
           host_drive: "F:"
           windows_host_path: "F:\\WSL\\ControlTower-SSD"
@@ -99,9 +102,12 @@ machines:
       allow_auto_stop: false
       preferred_window: Saturdays 10:00-12:00 UTC
       notes: >
-        Keep the hub online. The retired D: HDD pool has been removed from
-        the active registry; ControlTower now runs eight NVMe-backed runners
-        in the WSL distro and eight SSD-backed runners in ControlTower-SSD.
+        ControlTower-SSD (17 runners) is the only active ControlTower pool
+        as of 2026-07-31; the NVMe pool is quarantined per issue #1071 and
+        the legacy WSL-distro hub dashboard on :8321 is down with it (the
+        SSD distro serves :8322). The Windows-side matlab-1 runner is
+        separate and active. The retired D: HDD pool has been removed from
+        the active registry.
   - name: OGLaptop
     aliases:
       - og-laptop
@@ -119,7 +125,7 @@ machines:
       - Linux
       - X64
       - d-sorg-fleet
-      - d-sorg-fleet-4core
+      - d-sorg-fleet-docker
     runners:
       default: 4
       max: 8
@@ -162,8 +168,11 @@ machines:
       - Linux
       - X64
       - d-sorg-fleet
-      - d-sorg-fleet-4core
-      - d-sorg-fleet-6core
+      - d-sorg-fleet-docker
+    runners:
+      min: 6
+      default: 8
+      max: 8
     hardware:
       cpu_model: null
       cpu_physical_cores: null

--- a/backend/machine_registry.yml
+++ b/backend/machine_registry.yml
@@ -60,7 +60,12 @@ machines:
           - controltower-ssd
           - control-tower-ssd
           - controltower-bulk
-        dashboard_url: http://controltower.tail2bbcc7.ts.net:8322
+        # 2026-07-31: this instance IS the fleet hub (MACHINE_ROLE=hub) and
+        # moved to the canonical hub port 8321 after the legacy WSL-distro
+        # hub died with its corrupt vhdx (issue #1071). Windows
+        # tailscale-serve maps the old :8322 URL to the same backend for
+        # backward compatibility.
+        dashboard_url: http://controltower.tail2bbcc7.ts.net:8321
         storage_tier: ssd
         runner_base_dir: /home/dieterolson/actions-runners
         runner_labels:
@@ -103,11 +108,13 @@ machines:
       preferred_window: Saturdays 10:00-12:00 UTC
       notes: >
         ControlTower-SSD (17 runners) is the only active ControlTower pool
-        as of 2026-07-31; the NVMe pool is quarantined per issue #1071 and
-        the legacy WSL-distro hub dashboard on :8321 is down with it (the
-        SSD distro serves :8322). The Windows-side matlab-1 runner is
-        separate and active. The retired D: HDD pool has been removed from
-        the active registry.
+        as of 2026-07-31; the NVMe pool is quarantined per issue #1071. The
+        hub dashboard now runs INSIDE the ControlTower-SSD distro on the
+        canonical port 8321 (drop-in hub-port-8321.conf; the legacy
+        WSL-distro hub died with its corrupt vhdx), with the old :8322 URL
+        tailscale-served to the same backend. The Windows-side matlab-1
+        runner is separate and active. The retired D: HDD pool has been
+        removed from the active registry.
   - name: OGLaptop
     aliases:
       - og-laptop

--- a/deploy/fleet-health-monitor.ps1
+++ b/deploy/fleet-health-monitor.ps1
@@ -1,0 +1,255 @@
+<#
+.SYNOPSIS
+  Central runner-fleet health monitor. Runs on DeskComputer (interactive
+  session, launched hidden via run-hidden.vbs), manages DeskComputer and
+  ControlTower over Tailscale. One cycle per invocation; cadence comes from
+  the scheduled-task repetition trigger (every 5 min).
+
+  What it does each cycle:
+    1. Ensure DeskComputer's own WSL-Runner-KeepAlive task is Running.
+    2. ControlTower WMI-handle guard: kill any WmiPrvSE leaking > threshold
+       handles (root cause of the 2026-06-11 ControlTower outage).
+    3. Query the dashboard /api/runners (GitHub App auth, authoritative):
+       a. per-pool online floors for Desktop / ControlTower-SSD / Oglaptop —
+          the 2026-07-30 outage went unseen for weeks because only the
+          CT-SSD count was watched, and GitHub auto-purged the silent pools'
+          registrations after ~14 days offline;
+       b. Desktop self-heal: below-floor Desktop pool -> start the local
+          systemd runner units (in-place; never a WSL reset);
+       c. purge alarm: zero Desktop runners online while local units run is
+          the registration-purge signature -> ERROR pointing at
+          docs/runbooks/runner-registration-purge-recovery.md;
+       d. restart the ControlTower SSD keepalive task when its pool is low.
+    4. Log + write state JSON.
+
+  ControlTower remote ops go over SSH (key auth, host alias 'controltower').
+  Never invokes wsl.exe over SSH (it hangs in the network-logon session and
+  exhausts the desktop heap) -- all CT WSL work stays inside CT's own
+  keepalive tasks.
+#>
+param(
+  [string]$DashboardUrl          = "http://127.0.0.1:8321",
+  [string]$CtSsh                 = "controltower",
+  [int]   $WmiHandleKillThreshold = 120000,
+  [int]   $CtRunnerMinOnline      = 6,
+  [int]   $CtRunnerTotal          = 17,
+  # Floors are REAL-OUTAGE thresholds, deliberately below nominal capacity:
+  # GitHub's "online" flag flaps for idle runners (broker session cycling,
+  # see 2026-05-29 postmortem), so a tight floor would false-alarm on any
+  # idle fleet. What the floors must catch is silent pool decay toward the
+  # ~14-day registration purge, where counts sit at/near zero for days.
+  [hashtable]$PoolFloors          = @{ 'Desktop' = 3; 'ControlTower-SSD' = 6; 'Oglaptop' = 2 },
+  [string]$DeskWslDistro          = "Ubuntu-22.04",
+  [int]   $DeskRunnerTotal        = 8,
+  [string]$LocalKeepAliveTask     = "WSL-Runner-KeepAlive",
+  [string]$LogDir                 = "C:\Users\diete\runner_fleet_monitor",
+  # Dot-source with -FunctionsOnly to expose the pure helpers for tests.
+  [switch]$FunctionsOnly
+)
+
+# ---------------------------------------------------------------------------
+# Pure helpers (covered by tests/deploy/test_fleet_health_monitor.py)
+# ---------------------------------------------------------------------------
+
+$script:PoolPrefixes = @{
+  'Desktop'          = 'd-sorg-local-Desktop-'
+  'ControlTower-SSD' = 'd-sorg-local-ControlTower-SSD-'
+  'Oglaptop'         = 'd-sorg-local-Oglaptop-'
+}
+
+function Get-RunnerPoolCounts {
+  <# Classify runners into pools by name prefix.
+     Postcondition: every configured pool key is present with online/total. #>
+  param(
+    [array]$Runners = @(),
+    [hashtable]$PoolPrefixes = $script:PoolPrefixes
+  )
+  $counts = @{}
+  foreach ($pool in $PoolPrefixes.Keys) {
+    $members = @($Runners | Where-Object { $_.name -like ($PoolPrefixes[$pool] + '*') })
+    $counts[$pool] = @{
+      online = @($members | Where-Object { $_.status -eq 'online' }).Count
+      total  = $members.Count
+    }
+  }
+  return $counts
+}
+
+function Get-PoolsBelowFloor {
+  <# Names of pools whose online count is below the configured floor. #>
+  param(
+    [Parameter(Mandatory)][hashtable]$Counts,
+    [Parameter(Mandatory)][hashtable]$Floors
+  )
+  $below = @()
+  foreach ($pool in $Floors.Keys) {
+    if ($Counts.ContainsKey($pool) -and [int]$Counts[$pool].online -lt [int]$Floors[$pool]) {
+      $below += $pool
+    }
+  }
+  return $below
+}
+
+function Test-PurgeSuspected {
+  <# GitHub deletes registrations for runners offline ~14 days. Zero pool
+     members online while local units are actively running is that
+     signature: listeners are up but the server no longer knows them. #>
+  param(
+    [Parameter(Mandatory)][int]$PoolOnline,
+    [Parameter(Mandatory)][int]$LocalUnitsActive
+  )
+  return ($PoolOnline -eq 0 -and $LocalUnitsActive -ge 1)
+}
+
+if ($FunctionsOnly) { return }
+
+# ---------------------------------------------------------------------------
+# Cycle
+# ---------------------------------------------------------------------------
+
+$ErrorActionPreference = "Continue"
+if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
+$LogFile   = Join-Path $LogDir "monitor.log"
+$StateFile = Join-Path $LogDir "state.json"
+
+function Write-Log([string]$msg, [string]$level = "INFO") {
+  $ts = (Get-Date).ToString("o")
+  Add-Content -Path $LogFile -Value "$ts [$level] $msg"
+  if ((Test-Path $LogFile) -and ((Get-Item $LogFile).Length -gt 2MB)) {
+    Move-Item $LogFile "$LogFile.1" -Force
+  }
+}
+
+function Invoke-CtPowerShell([string]$Script, [int]$TimeoutSec = 30) {
+  $bytes = [System.Text.Encoding]::Unicode.GetBytes($Script)
+  $enc   = [Convert]::ToBase64String($bytes)
+  $out = & ssh -o ConnectTimeout=10 -o BatchMode=yes $CtSsh "powershell -NoProfile -EncodedCommand $enc" 2>&1
+  # Drop ssh/CLIXML stderr noise so keepalive-restart results stay readable
+  # in monitor.log (remote powershell emits progress records as CLIXML).
+  $clean = $out | ForEach-Object { [string]$_ } | Where-Object {
+    $_ -notmatch '^#< CLIXML' -and
+    $_ -notmatch '<Objs .*</Objs>' -and
+    $_ -notmatch 'Warning: Permanently added' -and
+    $_ -notmatch 'NativeCommandError|CategoryInfo|FullyQualifiedErrorId|^\s*\+\s'
+  }
+  return ($clean | Out-String)
+}
+
+function Get-DeskActiveUnitCount {
+  <# Count active local Desktop runner units inside the WSL distro. #>
+  $out = & wsl -d $DeskWslDistro -u dieterolson -e bash -c 'systemctl list-units --state=active --no-legend "actions.runner.*Desktop*" | wc -l' 2>$null
+  $n = 0
+  [void][int]::TryParse(([string]$out).Trim(), [ref]$n)
+  return $n
+}
+
+function Start-DeskRunnerUnits {
+  <# In-place unit starts only; never resets or restarts WSL itself. #>
+  for ($n = 1; $n -le $DeskRunnerTotal; $n++) {
+    & wsl -d $DeskWslDistro -u root -e systemctl start "actions.runner.D-sorganization.d-sorg-local-Desktop-$n.service" 2>$null
+  }
+}
+
+$state = [ordered]@{
+  timestamp          = (Get-Date).ToString("o")
+  actions            = @()
+  ct_wmi_max_handles = $null
+  pool_counts        = $null
+  pools_below_floor  = @()
+  purge_suspected    = $false
+  desk_keepalive     = $null
+  errors             = @()
+}
+
+# -- 1. DeskComputer local keepalive -----------------------------------------
+try {
+  $t = Get-ScheduledTask -TaskName $LocalKeepAliveTask -ErrorAction Stop
+  $state.desk_keepalive = "$($t.State)"
+  if ($t.State -ne "Running") {
+    Start-ScheduledTask -TaskName $LocalKeepAliveTask
+    Write-Log "DeskComputer keepalive '$LocalKeepAliveTask' was $($t.State); started it." "WARN"
+    $state.actions += "started-desk-keepalive"
+  }
+} catch {
+  Write-Log "Failed to check/start DeskComputer keepalive: $($_.Exception.Message)" "ERROR"
+  $state.errors += "desk-keepalive: $($_.Exception.Message)"
+}
+
+# -- 2. ControlTower WMI-handle guard ----------------------------------------
+try {
+  $guard = @"
+`$killed = @()
+`$max = 0
+foreach (`$p in Get-Process WmiPrvSE -ErrorAction SilentlyContinue) {
+  if (`$p.HandleCount -gt `$max) { `$max = `$p.HandleCount }
+  if (`$p.HandleCount -gt $WmiHandleKillThreshold) {
+    try { Stop-Process -Id `$p.Id -Force -ErrorAction Stop; `$killed += "`$(`$p.Id):`$(`$p.HandleCount)" } catch {}
+  }
+}
+"WMIMAX=`$max"
+"WMIKILLED=`$(`$killed -join ',')"
+"@
+  $res = Invoke-CtPowerShell $guard
+  $maxLine = ($res -split "`n" | Where-Object { $_ -match "WMIMAX=" }) -replace ".*WMIMAX=", ""
+  $killLine = ($res -split "`n" | Where-Object { $_ -match "WMIKILLED=" }) -replace ".*WMIKILLED=", ""
+  $state.ct_wmi_max_handles = ($maxLine | Select-Object -First 1).Trim()
+  if ($killLine -and ($killLine.Trim())) {
+    Write-Log "ControlTower WMI guard KILLED leaking WmiPrvSE: $($killLine.Trim()) (threshold $WmiHandleKillThreshold)" "WARN"
+    $state.actions += "killed-ct-wmiprvse:$($killLine.Trim())"
+  }
+} catch {
+  Write-Log "ControlTower WMI guard failed: $($_.Exception.Message)" "ERROR"
+  $state.errors += "ct-wmi: $($_.Exception.Message)"
+}
+
+# -- 3. Fleet pool floors + self-heal + CT keepalive restart ------------------
+try {
+  $runners = Invoke-RestMethod -Uri "$DashboardUrl/api/runners?local=true" -TimeoutSec 25
+  $poolCounts = Get-RunnerPoolCounts -Runners $runners.runners
+  $state.pool_counts = $poolCounts
+  $summary = ($poolCounts.Keys | Sort-Object | ForEach-Object { "$($_)=$($poolCounts[$_].online)/$($poolCounts[$_].total)" }) -join ' '
+  Write-Log "fleet pools online: $summary (WmiPrvSE max handles: $($state.ct_wmi_max_handles))"
+
+  $below = Get-PoolsBelowFloor -Counts $poolCounts -Floors $PoolFloors
+  $state.pools_below_floor = $below
+  foreach ($pool in $below) {
+    Write-Log "pool '$pool' online $($poolCounts[$pool].online) below floor $($PoolFloors[$pool])" "WARN"
+  }
+
+  # 3b. Desktop self-heal + registration-purge alarm (local machine only).
+  if ($below -contains 'Desktop') {
+    $localActive = Get-DeskActiveUnitCount
+    if (Test-PurgeSuspected -PoolOnline ([int]$poolCounts['Desktop'].online) -LocalUnitsActive $localActive) {
+      $state.purge_suspected = $true
+      Write-Log ("Desktop pool: 0 online on GitHub while $localActive local units run - REGISTRATION PURGE " +
+        "suspected. Re-register: see docs/runbooks/runner-registration-purge-recovery.md") "ERROR"
+    } else {
+      Start-DeskRunnerUnits
+      Write-Log "Desktop pool below floor; started local runner units in-place." "WARN"
+      $state.actions += "started-desk-runner-units"
+    }
+  }
+
+  # 3c. ControlTower SSD keepalive restart when its pool is low.
+  $ctOnline = [int]$poolCounts['ControlTower-SSD'].online
+  if ($ctOnline -lt $CtRunnerMinOnline) {
+    Write-Log "ControlTower SSD online ($ctOnline/$CtRunnerTotal) below min ($CtRunnerMinOnline); restarting SSD keepalive task." "WARN"
+    $restart = @'
+foreach ($tn in @("ControlTower-SSD-KeepAlive")) {
+  $t = Get-ScheduledTask -TaskName $tn -ErrorAction SilentlyContinue
+  if ($t -and $t.State -ne "Running") { Start-ScheduledTask -TaskName $tn; "restarted $tn" }
+  elseif ($t) { "$tn already $($t.State)" }
+  else { "missing $tn" }
+}
+'@
+    $r = Invoke-CtPowerShell $restart
+    Write-Log "Keepalive restart result: $($r.Trim() -replace '\s+',' ')"
+    $state.actions += "restarted-ct-ssd-keepalive"
+  }
+} catch {
+  Write-Log "Runner status query failed: $($_.Exception.Message)" "ERROR"
+  $state.errors += "runners-api: $($_.Exception.Message)"
+}
+
+# -- 4. Persist state ---------------------------------------------------------
+$state | ConvertTo-Json -Depth 5 | Set-Content -Path $StateFile

--- a/docs/runbooks/runner-registration-purge-recovery.md
+++ b/docs/runbooks/runner-registration-purge-recovery.md
@@ -1,0 +1,93 @@
+# Runner registration purge — detection and recovery
+
+## What happens
+
+GitHub automatically **deletes** the server-side registration of any
+self-hosted runner that has not connected for ~14 days. The local install
+is untouched, so the failure mode is quiet and confusing:
+
+- the runner disappears from `gh api orgs/D-sorganization/actions/runners`
+  entirely (not "offline" — gone);
+- the local systemd unit / listener starts fine, then exits with
+  `Failed to create a session. The runner registration has been deleted
+from the server, please re-configure.` (journal / `_diag/Runner_*.log`);
+- units flip to `inactive`/`failed` ("no retry needed") and stay down.
+
+This hit the whole DeskComputer pool (8 runners) and ControlTower's
+`matlab-1` on 2026-07-30, after their hosts/distros had been down since
+mid-July. The fleet ran on ~8 saturated CT-SSD runners and CI queued for
+hours. `deploy/fleet-health-monitor.ps1` now alarms on the purge signature
+(zero pool members online while local units run) and enforces per-pool
+online floors so silent decay is caught in minutes, not weeks.
+
+## Recovery (per runner)
+
+Mint one org registration token (valid ~1 h, reusable across runners):
+
+```bash
+gh api -X POST orgs/D-sorganization/actions/runners/registration-token --jq .token
+```
+
+Then, in each runner directory (Linux example; same flow with `config.cmd`
+on Windows):
+
+```bash
+sudo systemctl stop <unit>
+mv .service .service.keep 2>/dev/null          # see gotcha 1
+mv .runner_migrated .runner_migrated.bak 2>/dev/null   # see gotcha 2
+rm -f .runner .credentials .credentials_rsaparams
+./config.sh --unattended --replace \
+    --url https://github.com/D-sorganization \
+    --token <TOKEN> \
+    --name <original-runner-name> \
+    --labels d-sorg-fleet,d-sorg-fleet-docker \
+    --work _work            # use the pool's label set (see machine_registry.yml)
+mv .service.keep .service 2>/dev/null
+sudo systemctl restart <unit>
+```
+
+`scratch` automation used on 2026-07-30 lives in this repo's history as the
+per-host scripts; the canonical per-pool label sets are in
+`backend/machine_registry.yml`.
+
+### Gotchas (all hit live on 2026-07-30)
+
+1. **`.service` marker**: `config.sh` refuses to configure (and `remove`
+   demands a service uninstall) while the `svc.sh` marker exists — but
+   `svc.sh uninstall`/`install` would regenerate the systemd unit and lose
+   fleet hardening (Restart=always, KillMode=mixed, hook envs). Move the
+   marker aside and restore it instead.
+2. **`.runner_migrated`**: the broker-flow copy of `.runner` also trips the
+   "already configured" check. Move it aside; a fresh one is written on the
+   next session.
+3. **Same names + `--replace`**: re-registering under the original names
+   keeps unit files, hooks, and dashboards consistent. Never copy `.runner`
+   identity files between machines or pools.
+4. **ControlTower**: never run `wsl.exe` over SSH (hangs the network-logon
+   session). Drive WSL via an interactive scheduled task (wrap it in
+   `run-hidden.vbs` so it stays windowless) that writes output to a file.
+5. **OGLaptop**: the console may be logged off, so `/IT` tasks won't run —
+   use an S4U task (the resident keepalive proves S4U → WSL works there).
+6. **Quarantine**: check runner labels before re-registering. A pool
+   labelled `d-sorg-quarantine` (ControlTower-NVMe as of 2026-07-30, see
+   Runner_Dashboard issue #1071) is out of service **on purpose** — its
+   distro must stay stopped and its purged runners must NOT be re-registered
+   until the documented reprovision completes.
+
+## Verify
+
+```bash
+gh api orgs/D-sorganization/actions/runners --paginate \
+  --jq '.runners[] | .name + " " + .status'
+```
+
+All expected names present and `online`; `systemctl is-active` on each unit;
+the fleet-health-monitor log shows pool counts at/above floors.
+
+## Prevention
+
+- `deploy/fleet-health-monitor.ps1` (DeskComputer, every 5 min): per-pool
+  floors, Desktop in-place unit self-heal, purge alarm.
+- Keepalives hold distros resident: `RunnerDashboard-WSL-Resident-KeepAlive`
+  (S4U) per host / `ControlTower-SSD-KeepAlive`. A distro with runners but
+  no keepalive is how the 14-day clock starts.

--- a/tests/deploy/test_fleet_health_monitor.py
+++ b/tests/deploy/test_fleet_health_monitor.py
@@ -1,0 +1,159 @@
+"""Contracts for ``deploy/fleet-health-monitor.ps1``.
+
+The 2026-07-30 fleet outage went unnoticed for weeks because the deployed
+DeskComputer health monitor only watched the ControlTower-SSD pool: the
+DeskComputer runners sat offline until GitHub's 14-day auto-purge deleted
+their registrations, and nothing alarmed. This canonical monitor closes the
+blind spot with per-pool online floors, a DeskComputer unit self-heal, and
+an explicit registration-purge alarm.
+
+Static checks run everywhere; behavioural checks drive the pure helpers via
+``-FunctionsOnly`` dot-sourcing (the live cycle needs SSH/WSL/dashboard and
+is exercised operationally, not here).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "deploy" / "fleet-health-monitor.ps1"
+
+
+def _find_pwsh() -> str | None:
+    for candidate in ("pwsh", "powershell"):
+        if shutil.which(candidate):
+            return candidate
+    return None
+
+
+PWSH = _find_pwsh()
+PWSH_REQUIRED = pytest.mark.skipif(PWSH is None, reason="PowerShell not available on this runner")
+
+
+def _run_ps(script_body: str) -> subprocess.CompletedProcess[str]:
+    assert PWSH is not None
+    return subprocess.run(
+        [PWSH, "-NoProfile", "-NonInteractive", "-Command", script_body],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _prefix() -> str:
+    return f". '{SCRIPT.as_posix()}' -FunctionsOnly; "
+
+
+# ---------------------------------------------------------------------------
+# Static checks
+# ---------------------------------------------------------------------------
+
+
+def test_script_exists() -> None:
+    assert SCRIPT.is_file(), f"missing: {SCRIPT}"
+
+
+def test_script_declares_contract_parameters() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    for param in (
+        "DashboardUrl",
+        "CtSsh",
+        "WmiHandleKillThreshold",
+        "PoolFloors",
+        "DeskWslDistro",
+        "FunctionsOnly",
+    ):
+        assert f"${param}" in text, f"parameter ${param} not declared"
+
+
+def test_script_watches_all_pools_not_just_ct_ssd() -> None:
+    """Regression guard for the 2026-07-30 blind spot."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "d-sorg-local-Desktop-" in text
+    assert "d-sorg-local-ControlTower-SSD-" in text
+    assert "d-sorg-local-Oglaptop-" in text
+
+
+def test_script_alarms_on_suspected_registration_purge() -> None:
+    """Zero pool members online while local units run = the purge signature
+    (GitHub deletes registrations after ~14 days offline). The monitor must
+    say so loudly and point at the recovery runbook."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "Test-PurgeSuspected" in text
+    assert "runner-registration-purge-recovery" in text, "must point at the recovery runbook"
+
+
+def test_script_self_heals_desk_units_without_wsl_reset() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "systemctl" in text and "start" in text
+    assert "wsl --shutdown" not in text, "monitor must never tear down WSL"
+
+
+# ---------------------------------------------------------------------------
+# Behavioural checks — pure helpers
+# ---------------------------------------------------------------------------
+
+
+@PWSH_REQUIRED
+def test_pool_counts_classify_by_prefix() -> None:
+    driver = _prefix() + textwrap.dedent(
+        """
+        $runners = @(
+            @{ name = 'd-sorg-local-Desktop-1'; status = 'online' },
+            @{ name = 'd-sorg-local-Desktop-2'; status = 'offline' },
+            @{ name = 'd-sorg-local-ControlTower-SSD-1'; status = 'online' },
+            @{ name = 'd-sorg-local-ControlTower-nvme-6'; status = 'offline' },
+            @{ name = 'd-sorg-local-Oglaptop-8'; status = 'online' }
+        ) | ForEach-Object { [pscustomobject]$_ }
+        $c = Get-RunnerPoolCounts -Runners $runners
+        Write-Output ("DESK=" + $c['Desktop'].online + "/" + $c['Desktop'].total)
+        Write-Output ("SSD=" + $c['ControlTower-SSD'].online + "/" + $c['ControlTower-SSD'].total)
+        Write-Output ("OG=" + $c['Oglaptop'].online + "/" + $c['Oglaptop'].total)
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "DESK=1/2" in result.stdout
+    assert "SSD=1/1" in result.stdout
+    assert "OG=1/1" in result.stdout
+
+
+@PWSH_REQUIRED
+def test_pools_below_floor_detected() -> None:
+    driver = _prefix() + textwrap.dedent(
+        """
+        $counts = @{
+            'Desktop' = @{ online = 2; total = 8 }
+            'ControlTower-SSD' = @{ online = 15; total = 17 }
+            'Oglaptop' = @{ online = 8; total = 8 }
+        }
+        $floors = @{ 'Desktop' = 6; 'ControlTower-SSD' = 12; 'Oglaptop' = 4 }
+        $below = Get-PoolsBelowFloor -Counts $counts -Floors $floors
+        Write-Output ("BELOW=" + ($below -join ','))
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "BELOW=Desktop" in result.stdout
+
+
+@PWSH_REQUIRED
+def test_purge_signature_requires_zero_online_and_local_activity() -> None:
+    driver = _prefix() + textwrap.dedent(
+        """
+        Write-Output ("R1=" + (Test-PurgeSuspected -PoolOnline 0 -LocalUnitsActive 8))
+        Write-Output ("R2=" + (Test-PurgeSuspected -PoolOnline 3 -LocalUnitsActive 8))
+        Write-Output ("R3=" + (Test-PurgeSuspected -PoolOnline 0 -LocalUnitsActive 0))
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "R1=True" in result.stdout
+    assert "R2=False" in result.stdout
+    assert "R3=False" in result.stdout


### PR DESCRIPTION
## Problem

The 2026-07-30 fleet outage went unseen for weeks: the deployed DeskComputer health monitor only watched the ControlTower-SSD pool, so the DeskComputer runners sat offline until GitHub's ~14-day auto-purge **deleted their registrations**, the org ran on ~8 saturated runners, and CI queued for 7+ hours.

## Change

- Canonicalize the DeskComputer monitor as `deploy/fleet-health-monitor.ps1` (previously an untracked host file) and extend it:
  - **per-pool online floors** (Desktop, ControlTower-SSD, Oglaptop) from the dashboard runners feed — deliberate real-outage thresholds below nominal capacity, because GitHub "online" flaps for idle runners (broker session cycling);
  - **Desktop self-heal**: below-floor pool triggers in-place `systemctl start` of local units, never a WSL reset;
  - **registration-purge alarm**: zero pool members online while local units run raises an ERROR pointing at the new runbook;
  - ControlTower SSH output is CLIXML/noise-filtered for readable logs.
- `docs/runbooks/runner-registration-purge-recovery.md` — recovery procedure with the live-hit gotchas (`.service` and `.runner_migrated` configure-refusal, no wsl-over-SSH on ControlTower, S4U on OGLaptop, issue #1071 quarantine guardrails).
- `backend/machine_registry.yml` refreshed to verified topology: SSD pool 17, NVMe pool quarantined per #1071, real Desktop and Oglaptop label sets, hub-down note.
- SPEC 2.3.1 entry, VERSION 4.9.21.

## Testing (TDD)

`tests/deploy/test_fleet_health_monitor.py` written first: static contracts (all pools watched, purge alarm + runbook pointer, no `wsl --shutdown`) and pwsh-driven pure-helper checks (pool classification, floor detection, purge-signature truth table). 77 deploy+registry tests pass locally. Deployed live on DeskComputer: clean cycle logged `ControlTower-SSD=17/17 Desktop=6/8 Oglaptop=8/8`.

## Context

Shipped alongside the 2026-07-30/31 fleet restoration: 8 Desk runners plus the ControlTower matlab runner re-registered post-purge, SSD-9..17 and Oglaptop-1..7 restarted (24+ online, queue draining), ControlTower-NVMe quarantine per #1071 respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
