### PR TITLE
feat(deploy): alarm on ControlTower host disk floors

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1570,7 +1570,14 @@ distros in one shared utility VM. Two hardening steps keep them out of the
   `MultipleInstances=IgnoreNew`), and any floor breach computed from the
   dashboard feed is re-verified against the GitHub API before warnings or
   self-heal actions (the feed can serve stale/false zeros; verification
-  unavailable → the cycle takes no action).
+  unavailable → the cycle takes no action). The same ControlTower probe
+  reports host free space and alarms below per-drive floors
+  (`$DiskFloorsGb`, default C: 25 GB / F: 40 GB): a WSL2 distro that
+  exhausts host disk mid-write corrupts itself — null-byte files and a
+  broken package database — which is the probable origin of the #1071 NVMe
+  corruption and came within minutes of repeating on the live pool on
+  2026-07-31. The floor is **alarm-only**; reclaiming space means deleting
+  large artifacts and is never automated.
 - **`deploy/run-hidden.vbs` + `deploy/install-hidden-task-launcher.ps1`** stop
   InteractiveToken scheduled tasks from popping focus-stealing console windows
   in the user's session. The installer rewrites a task's action to

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.22
+4.9.23

--- a/deploy/fleet-health-monitor.ps1
+++ b/deploy/fleet-health-monitor.ps1
@@ -39,6 +39,12 @@ param(
   # idle fleet. What the floors must catch is silent pool decay toward the
   # ~14-day registration purge, where counts sit at/near zero for days.
   [hashtable]$PoolFloors          = @{ 'Desktop' = 3; 'ControlTower-SSD' = 6; 'Oglaptop' = 2 },
+  # Host free-space floors (GB) for the ControlTower drives. A WSL2 vhdx that
+  # exhausts host disk mid-write corrupts the distro (null-byte files, corrupt
+  # package DB) — the probable origin of the #1071 NVMe corruption, which on
+  # 2026-07-31 came within minutes of repeating on the LIVE SSD pool. F: holds
+  # the 326GB live runner vhdx, so its floor is the larger one.
+  [hashtable]$DiskFloorsGb        = @{ 'C' = 25; 'F' = 40 },
   [string]$DeskWslDistro          = "Ubuntu-22.04",
   [int]   $DeskRunnerTotal        = 8,
   [string]$LocalKeepAliveTask     = "WSL-Runner-KeepAlive",
@@ -101,6 +107,20 @@ function ConvertFrom-GitHubRunnerJson {
   return @($parsed.runners | ForEach-Object {
       [pscustomobject]@{ name = [string]$_.name; status = [string]$_.status }
     })
+}
+
+function Test-DiskBelowFloor {
+  <# True when free space is known AND strictly below the floor. Unknown
+     free space returns $false so an unparsable probe never fabricates a
+     breach (the alarm must mean something when it fires). #>
+  param(
+    [AllowNull()]$FreeGb,
+    [Parameter(Mandatory)][double]$FloorGb
+  )
+  if ($null -eq $FreeGb -or $FreeGb -eq '') { return $false }
+  $value = 0.0
+  if (-not [double]::TryParse([string]$FreeGb, [ref]$value)) { return $false }
+  return ($value -lt $FloorGb)
 }
 
 function Test-PurgeSuspected {
@@ -195,6 +215,7 @@ $state = [ordered]@{
   timestamp          = (Get-Date).ToString("o")
   actions            = @()
   ct_wmi_max_handles = $null
+  ct_disk_free_gb    = $null
   pool_counts        = $null
   pools_below_floor  = @()
   purge_suspected    = $false
@@ -233,14 +254,39 @@ foreach (`$p in Get-Process WmiPrvSE -ErrorAction SilentlyContinue) {
 }
 "WMIMAX=`$max"
 "WMIKILLED=`$(`$killed -join ',')"
+foreach (`$dl in 'C', 'F') {
+  `$v = Get-Volume -DriveLetter `$dl -ErrorAction SilentlyContinue
+  # `${dl} braces are required: "`$dl:" would parse as a scope qualifier.
+  if (`$v) { "DISKFREE=`${dl}:`$([math]::Round(`$v.SizeRemaining/1GB,2))" }
+}
 "@
   $res = Invoke-CtPowerShell $guard
-  $maxLine = ($res -split "`n" | Where-Object { $_ -match "WMIMAX=" }) -replace ".*WMIMAX=", ""
-  $killLine = ($res -split "`n" | Where-Object { $_ -match "WMIKILLED=" }) -replace ".*WMIKILLED=", ""
-  $state.ct_wmi_max_handles = ($maxLine | Select-Object -First 1).Trim()
-  if ($killLine -and ($killLine.Trim())) {
-    Write-Log "ControlTower WMI guard KILLED leaking WmiPrvSE: $($killLine.Trim()) (threshold $WmiHandleKillThreshold)" "WARN"
-    $state.actions += "killed-ct-wmiprvse:$($killLine.Trim())"
+  # Null-safe: a timed-out or failed ssh returns '', and calling .Trim() on the
+  # resulting empty match set threw, aborting the whole section (incl. the disk
+  # floors below) instead of degrading to "unknown".
+  $maxLine = @($res -split "`n" | Where-Object { $_ -match "WMIMAX=" }) -replace ".*WMIMAX=", ""
+  $killLine = @($res -split "`n" | Where-Object { $_ -match "WMIKILLED=" }) -replace ".*WMIKILLED=", ""
+  $state.ct_wmi_max_handles = if ($maxLine.Count -gt 0) { ([string]$maxLine[0]).Trim() } else { $null }
+  if ($killLine.Count -gt 0 -and ([string]$killLine[0]).Trim()) {
+    $killed = ([string]$killLine[0]).Trim()
+    Write-Log "ControlTower WMI guard KILLED leaking WmiPrvSE: $killed (threshold $WmiHandleKillThreshold)" "WARN"
+    $state.actions += "killed-ct-wmiprvse:$killed"
+  }
+
+  # Host free-space floors. Deliberately alarm-only: reclaiming space means
+  # deleting large artifacts, which is never safe to automate.
+  $disk = @{}
+  foreach ($line in ($res -split "`n" | Where-Object { $_ -match 'DISKFREE=' })) {
+    if ($line -match 'DISKFREE=([A-Z]):([0-9.]+)') { $disk[$Matches[1]] = [double]$Matches[2] }
+  }
+  $state.ct_disk_free_gb = $disk
+  foreach ($dl in $DiskFloorsGb.Keys) {
+    if ($disk.ContainsKey($dl) -and (Test-DiskBelowFloor -FreeGb $disk[$dl] -FloorGb $DiskFloorsGb[$dl])) {
+      Write-Log ("ControlTower ${dl}: only $($disk[$dl])GB free (floor $($DiskFloorsGb[$dl])GB) - " +
+        "vhdx corruption risk: a WSL2 distro that exhausts host disk mid-write corrupts itself (see #1071). " +
+        "Reclaim space now; do not wait.") "ERROR"
+      $state.actions += "alarm-ct-disk-$dl"
+    }
   }
 } catch {
   Write-Log "ControlTower WMI guard failed: $($_.Exception.Message)" "ERROR"

--- a/tests/deploy/test_fleet_health_monitor.py
+++ b/tests/deploy/test_fleet_health_monitor.py
@@ -107,6 +107,19 @@ def test_ct_ssh_enforces_a_hard_timeout() -> None:
     assert "ct_ssh_timeout" in text or "timed out" in text
 
 
+def test_script_guards_controltower_host_disk_space() -> None:
+    """A WSL2 vhdx that runs out of host disk mid-write corrupts the distro
+    (null-byte files, corrupt package DB) — the probable origin of the #1071
+    NVMe corruption, which on 2026-07-31 came within minutes of repeating on
+    the LIVE ControlTower-SSD pool (F: hit 2.05 GB free and falling). The
+    monitor must alarm on host free space, not just runner counts."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert "$DiskFloorsGb" in text, "disk floors must be a declared parameter"
+    assert "Test-DiskBelowFloor" in text
+    assert "DISKFREE=" in text, "the ControlTower probe must report free space"
+    assert "vhdx corruption risk" in text.lower()
+
+
 def test_cycle_logs_a_heartbeat_line() -> None:
     """A cycle that dies before its first section must still leave a trace,
     otherwise a stall is indistinguishable from healthy silence."""
@@ -199,6 +212,26 @@ def test_github_runner_json_parses_to_pool_counts() -> None:
     assert "OG=1/1" in result.stdout
     assert "BADJSON=True" in result.stdout
     assert "EMPTY=True" in result.stdout
+
+
+@PWSH_REQUIRED
+def test_disk_floor_helper_is_pure_and_inclusive() -> None:
+    """Below-floor is strict (< floor); exactly-at-floor is still healthy.
+    Unknown/unparsable free space must NOT report a false breach."""
+    driver = _prefix() + textwrap.dedent(
+        """
+        Write-Output ("R1=" + (Test-DiskBelowFloor -FreeGb 2.05 -FloorGb 40))
+        Write-Output ("R2=" + (Test-DiskBelowFloor -FreeGb 289.2 -FloorGb 40))
+        Write-Output ("R3=" + (Test-DiskBelowFloor -FreeGb 40 -FloorGb 40))
+        Write-Output ("R4=" + (Test-DiskBelowFloor -FreeGb $null -FloorGb 40))
+        """
+    )
+    result = _run_ps(driver)
+    assert result.returncode == 0, result.stderr
+    assert "R1=True" in result.stdout
+    assert "R2=False" in result.stdout
+    assert "R3=False" in result.stdout
+    assert "R4=False" in result.stdout
 
 
 @PWSH_REQUIRED


### PR DESCRIPTION
## Problem

On 2026-07-31 ControlTower **F: fell to 2.05 GB free and was dropping ~130 MB/min** while the *live* `ControlTower-SSD` distro (326 GB vhdx, 8 busy runners) wrote to it. A WSL2 distro that exhausts host disk mid-write corrupts itself — null-byte files, broken package database — which is the probable origin of the #1071 NVMe corruption. Nothing in the fleet monitor watched host free space, so this near-miss was caught only by manual inspection.

(Resolved operationally by retiring the quarantined NVMe distro after verifying its backup: F: 2.73 GB → 289 GB free, live pool untouched.)

## Change

- The existing ControlTower probe now also reports per-drive free space — no extra SSH round-trip — and the cycle alarms below configurable floors (`$DiskFloorsGb`, default C: 25 GB / F: 40 GB), with the corruption mechanism spelled out in the log line.
- **Alarm-only by design.** Reclaiming space means deleting large artifacts; that must never be automated.
- Free space is recorded in the state JSON (`ct_disk_free_gb`) for trending.

Two defects the live deploy exposed, also fixed:
- the remote probe interpolated `"$dl:"`, which PowerShell parses as a scope qualifier — it broke the entire guard script (now `"${dl}:"`);
- `WMIMAX`/`WMIKILLED` parsing called `.Trim()` on an empty match set, so a timed-out SSH aborted the whole section (including the new disk check) instead of degrading to "unknown".

## Testing (TDD)

Static contract plus `Test-DiskBelowFloor` behavioural checks — including exactly-at-floor (healthy, not a breach) and unknown free space (must not fabricate a breach, so the alarm means something when it fires). 14/14 pass. Deployed live on DeskComputer and verified a cycle reporting `C:=30.95GB F:=289.49GB`. SPEC updated, VERSION 4.9.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
