### PR TITLE
docs(registry): retire the ControlTower-NVMe pool after verified backups

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
 # Dashboard version following semantic versioning (MAJOR.MINOR.PATCH)
 # Bumped on: deployment changes, new features, bug fixes
-4.9.23
+4.9.24

--- a/backend/machine_registry.yml
+++ b/backend/machine_registry.yml
@@ -31,30 +31,45 @@ machines:
         dashboard_url: http://controltower.tail2bbcc7.ts.net:8321
         storage_tier: nvme
         runner_base_dir: /home/dieterolson/actions-runners-nvme
-        # QUARANTINED 2026-07 (Runner_Dashboard issue #1071): the distro
-        # exposed broad filesystem corruption (null-byte binaries, corrupt
-        # dpkg/node/uv). Registered runners 6-8 carry only the
-        # d-sorg-quarantine label; 1-5 were auto-purged by GitHub. The
-        # ControlTower-NVMe distro must stay STOPPED and the legacy
-        # C:\WSL\ext4.vhdx (0x80070570, hosted the :8321 hub) must not be
-        # deleted or mutated until the documented backup/reprovision.
+        # RETIRED 2026-07-31 (Runner_Dashboard issue #1071). Quarantined in
+        # July after broad filesystem corruption (null-byte binaries, corrupt
+        # dpkg/node/uv); retired rather than reprovisioned because the pool
+        # was no longer NVMe-backed at all -- its vhdx sat on the same F:
+        # SATA volume as the SSD pool, so a rebuild would have added disk
+        # contention rather than an I/O tier, and ControlTower-SSD was
+        # expanded 8 -> 17 runners to replace it.
+        #
+        # Both distros were unregistered after byte-verified backups:
+        #   ControlTower-NVMe -> F:\WSL-backups\...-20260731.tar (sha256 recorded)
+        #   legacy "WSL" hub  -> DeskComputer D:\WSL-backups\controltower\
+        #                        (sha256 57B850DA...8191F3, matched both sides)
+        # Reversal for either: wsl --import from the corresponding archive.
+        #
+        # Probable root cause of the original corruption: F: reached zero free
+        # space while a distro was writing. It nearly recurred on the LIVE SSD
+        # pool on 2026-07-31 (2.05 GB free, falling); the fleet monitor now
+        # alarms on host disk floors. Do NOT co-locate large backups with a
+        # live runner vhdx.
         runner_labels:
           - self-hosted
           - Linux
           - X64
           - d-sorg-quarantine
+        retired: true
+        retired_on: 2026-07-31
         runners:
           min: 0
           default: 0
-          max: 8
+          max: 0
         storage:
-          host_drive: "C:"
-          windows_host_path: "C:\\WSL"
-          wsl_distro: ControlTower-NVMe
-          vhdx_path: "C:\\WSL\\ext4.vhdx"
-          disk_bus: NVMe
-          disk_media_type: SSD
-          cache_budget_gb: 120
+          # Distro unregistered; no vhdx remains on the host.
+          host_drive: null
+          windows_host_path: null
+          wsl_distro: null
+          vhdx_path: null
+          disk_bus: null
+          disk_media_type: null
+          cache_budget_gb: 0
       - name: ControlTower-SSD
         aliases:
           - controltower-ssd

--- a/docs/runbooks/runner-registration-purge-recovery.md
+++ b/docs/runbooks/runner-registration-purge-recovery.md
@@ -68,11 +68,13 @@ per-host scripts; the canonical per-pool label sets are in
    `run-hidden.vbs` so it stays windowless) that writes output to a file.
 5. **OGLaptop**: the console may be logged off, so `/IT` tasks won't run —
    use an S4U task (the resident keepalive proves S4U → WSL works there).
-6. **Quarantine**: check runner labels before re-registering. A pool
-   labelled `d-sorg-quarantine` (ControlTower-NVMe as of 2026-07-30, see
-   Runner_Dashboard issue #1071) is out of service **on purpose** — its
-   distro must stay stopped and its purged runners must NOT be re-registered
-   until the documented reprovision completes.
+6. **Quarantine / retirement**: check runner labels before re-registering. A
+   pool labelled `d-sorg-quarantine` is out of service **on purpose** — never
+   re-register its runners to "fix" the count. ControlTower-NVMe carried that
+   label from 2026-07-30 and was **retired** on 2026-07-31 (issue #1071);
+   `machine_registry.yml` marks it `retired: true`, so its absence from the
+   fleet is expected, not decay. Any `d-sorg-local-ControlTower-nvme-*`
+   registrations still listed are orphans of that retirement.
 
 ## Verify
 
@@ -83,6 +85,36 @@ gh api orgs/D-sorganization/actions/runners --paginate \
 
 All expected names present and `online`; `systemctl is-active` on each unit;
 the fleet-health-monitor log shows pool counts at/above floors.
+
+## Host disk space is a first-class runner-health signal
+
+A WSL2 distro whose host volume reaches zero free space **corrupts itself**
+mid-write: files that are allocated but never flushed come back as null
+bytes, taking out binaries and the dpkg database. That is the probable
+origin of the ControlTower-NVMe corruption (issue #1071), and on 2026-07-31
+it came within minutes of repeating on the _live_ ControlTower-SSD pool
+(F: at 2.05 GB free and falling ~130 MB/min under 8 busy runners).
+
+Rules that follow from it:
+
+- **Never co-locate a large backup with a live runner vhdx.** The 190 GB
+  NVMe export was written to F:, the same 931 GB volume as the 326 GB live
+  SSD vhdx and 170 GB of ollama models — that is what consumed the headroom.
+- `deploy/fleet-health-monitor.ps1` alarms below per-drive floors
+  (`$DiskFloorsGb`, default C: 25 GB / F: 40 GB). It is **alarm-only** —
+  reclaiming space means deleting large artifacts and must not be automated.
+- A vhdx handle stays held by the WSL service even when the distro reads
+  `Stopped`, so the file cannot simply be deleted. Use
+  `wsl --unregister <distro>` — it releases the handle, removes the vhdx,
+  and avoids leaving a registration pointing at a missing file. Reverse with
+  `wsl --import`.
+- After retiring a distro, check whether it was the host's **default**
+  (`wsl --list --verbose` marks it `*`). A default pointing at a
+  missing/corrupt distro makes every bare `wsl` call fail and can wedge the
+  WSL service. Repoint with `wsl --set-default <live-distro>`.
+- Verify a `wsl --export` tar before trusting it: a complete POSIX archive
+  ends in ≥1024 zero bytes. Reading the last 1024 bytes distinguishes a
+  finished export from a truncated one in seconds, without rehashing.
 
 ## Prevention
 


### PR DESCRIPTION
Closes #1071.

## What happened

Both corrupt ControlTower distros are gone, each after a byte-verified backup:

| Distro | Backup | Verification |
| --- | --- | --- |
| `ControlTower-NVMe` (quarantined pool) | `F:\WSL-backups\...-20260731.tar`, 190.28 GB | complete POSIX end-of-archive trailer + recorded sha256 |
| legacy `WSL` (dead :8321 hub) | DeskComputer `D:\WSL-backups\controltower\`, 376 GB | byte-exact size, sha256 `57B850DA…8191F3` computed independently on **both** machines and compared before deletion |

Reclaimed **286 GB on F:** and **330 GB on C:** (29.7 → 360 GB free). The legacy distro was also ControlTower's *default*, so every bare `wsl` call was targeting a distro that could not attach — the default now points at the live `ControlTower-SSD`. Fleet was undisturbed throughout (25 online / 24 busy; hub healthy on :8321).

Reversal for either pool: `wsl --import` from the corresponding archive.

## Why retired instead of reprovisioned

#1071's acceptance criteria assumed a rebuild. The evidence pointed the other way:

- the pool was **no longer NVMe-backed** — its vhdx sat on the same F: SATA volume as the SSD pool, so rebuilding would have added disk contention rather than an I/O tier;
- `ControlTower-SSD` was expanded 8 → 17 runners to replace it;
- the fleet is healthy without it, and public repos are moving to GitHub-hosted runners, further reducing self-hosted demand.

## Root cause of the original corruption

Almost certainly **host disk exhaustion**: a WSL2 distro whose volume hits zero free space corrupts itself mid-write — allocated-but-never-flushed blocks come back as null bytes, which matches #1071's symptoms exactly (null-byte binaries, corrupt dpkg/node/uv).

It nearly happened again on 2026-07-31, to the **live** SSD pool: F: fell to 2.05 GB free and was dropping ~130 MB/min under 8 busy runners, because a 190 GB backup tar had been written to the same volume as the 326 GB live vhdx and 170 GB of ollama models. Retiring the NVMe distro is what recovered the headroom.

## This PR

- `machine_registry.yml`: the NVMe pool is `retired: true` with `max: 0` and null storage (no vhdx remains); rationale and both backup locations recorded inline.
- Runbook: new *"Host disk space is a first-class runner-health signal"* section — the corruption mechanism, the never-co-locate-backups rule, why `wsl --unregister` is required (the service holds the vhdx handle even when the distro reads `Stopped`), the default-distro trap, and the cheap tar-trailer completeness check. The quarantine gotcha is updated to describe retirement.
- Host disk floors are already enforced by the monitor (#1079, C: 25 GB / F: 40 GB, alarm-only).

Registry tests pass (47). VERSION 4.9.24.

**Remaining tidy-up (deliberately not done here):** the `d-sorg-local-ControlTower-nvme-6/7/8` registrations are orphans of this retirement — harmless and auto-purged by GitHub in ~14 days, but they can be deleted for a clean inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
