### PR TITLE
fix: pin Runner Dashboard Docker image to Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # of slow CPython 3.14 source builds.
 # To regenerate requirements.lock.txt:  uv export --no-dev -o requirements.lock.txt
 
-FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f
 
 WORKDIR /app
 


### PR DESCRIPTION
Fix the Docker runtime mismatch exposed by Runner_Dashboard#1080.

The Dockerfile documentation and cleanup paths target Python 3.13 (`requires-python >=3.11,<3.14`), but the base image was pinned to Python 3.14. The 3.14 image has no compatible locked wheels for several Rust-backed dependencies, so the Docker build fell back to source builds and failed with `linker cc not found`.

This one-line change restores the previously approved Python 3.13 slim digest from repository history. It keeps the documented runtime contract and lets locked native wheels be selected without adding a compiler toolchain to the production image.

Validation:
- Compared main to this branch: exactly one Dockerfile line changed.
- Confirmed the new base digest is the prior repository-approved Python 3.13 pin.
- GitHub Actions Docker build should be rerun by this PR.